### PR TITLE
update to new StrPack and Expr()

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 StrPack
+julia 0.2-


### PR DESCRIPTION
Now using the new StrPack package. Also updated plain.jl to match the new `Expr()` interface.

There is more work to do on jld.jl to get things working on julia 0.2-dev. Mainly, there are references to `CompositeKind` all over the place that need to go. However, if you are not using the JLD file format, you can just comment out that source line in HDF5.jl and this pull request will get you to a working state.
