### PR TITLE
Use built-in C type names and replace StrPack usage with immutables

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-StrPack
 julia 0.2-


### PR DESCRIPTION
Removing StrPack should improve performance, both for loading the module and for reading data.  This passes all included tests and the tests for MAT.jl, but I don't think test coverage is complete, so please test on your data sets before merging.
