### PR TITLE
Add binary install method for Windows

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.2-
+BinDeps

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!deps.jl
+!build.jl

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,19 @@
+using BinDeps 
+
+@BinDeps.setup
+
+@windows_only begin
+    hdf5 = library_dependency("hdf5")
+
+    const OS_ARCH = WORD_SIZE == 64 ? "x86_64" : "x86"
+
+    if WORD_SIZE == 32
+            provides(Binaries,URI("https://ia601003.us.archive.org/29/items/julialang/windows/hdf5-1.8-win32.7z"),hdf5,os = :Windows)
+    else
+            provides(Binaries,URI("https://ia601003.us.archive.org/29/items/julialang/windows/hdf5-1.8-win64.7z"),hdf5,os = :Windows)
+    end
+    push!(DL_LOAD_PATH, joinpath(Pkg.dir("HDF5/deps/usr/lib/"), OS_ARCH))
+end
+
+@BinDeps.install
+

--- a/src/plain.jl
+++ b/src/plain.jl
@@ -24,17 +24,12 @@ typealias Haddr       Uint64
 libname = "libhdf5"
 @unix_only const libhdf5 = dlopen(libname)
 @windows_only begin
-function findlibhdf5()    
-    spaths = split(ENV["SYS_PATH"], ";")
-    libfile = ""
-    for p in spaths
-        if !isempty(search(p, "HDF5"))
-            dl = dlopen_e(joinpath(p,"hdf5.dll"))
-            if dl != C_NULL
-                ccall(:add_library_mapping,Cint,(Ptr{Cchar},Ptr{Void}),libname,dl)
-                return dl
-            end
-        end
+function findlibhdf5()
+    const OS_ARCH = WORD_SIZE == 64 ? "x86_64" : "x86"
+    push!(DL_LOAD_PATH, joinpath(Pkg.dir("HDF5/deps/usr/lib/"), OS_ARCH))
+    dl = dlopen_e("hdf5")
+    if dl != C_NULL
+        return dl
     end
     error("Library not found. See the README for installation instructions.")
 end


### PR DESCRIPTION
Uses BinDeps for download/install and updates
findlibhdf5 to search appropriately.

Removes deprecation warning from add_library_mapping
Note that SYS_PATH will be searched automatically by
dlopen on Windows.
