### PR TITLE
Fix load macro when no vars are passed

### DIFF
--- a/src/jld.jl
+++ b/src/jld.jl
@@ -871,7 +871,7 @@ macro load(filename, vars...)
         nms = names(f)
         for n in nms
             obj = f[n]
-            if isa(obj, HDF5Dataset)
+            if isa(obj, JldDataset)
                 sym = symbol(n)
                 push!(readexprs, :($(esc(sym)) = read($f, $n)))
             end


### PR DESCRIPTION
Not sure if this is the proper fix, however it works on my machine now (while previously `@load "file.jld"` would silently fail to read anything).
