### PR TITLE
"Could not load module libhdf5" when installed by Homebrew.jl on OS X

### DIFF
--- a/src/plain.jl
+++ b/src/plain.jl
@@ -22,10 +22,7 @@ typealias Haddr       Uint64
 
 ### Load and initialize the HDF library ###
 libname = "libhdf5"
-@osx_only begin
-import Homebrew
-push!(DL_LOAD_PATH, joinpath(Homebrew.brew_prefix,"lib"))
-end
+@osx_only import Homebrew # Add Homebrew/lib to the DL_LOAD_PATH
 @unix_only const libhdf5 = dlopen(libname)
 @windows_only begin
 function findlibhdf5()


### PR DESCRIPTION
You use BinDeps to install libhdf5.  On OS X, this uses Homebrew.jl.  Unfortunately, Homebrew's lib path isn't automatically added to the DL_LOAD_PATH.

This simple patch adds Homebrew's lib to DL_LOAD_PATH on OS X before the `dlopen`.  Not sure if there's a better way here, but this works.
