### PR TITLE
Fix ccall warnings with static compile

### DIFF
--- a/test/jld_dataframe.jl
+++ b/test/jld_dataframe.jl
@@ -2,17 +2,17 @@ using HDF5
 using JLD
 using DataFrames
 
-filename = joinpath(tempdir(), "mydata.jld")
+fname = joinpath(tempdir(), "mydata.jld")
 
 df = DataFrame({[2:6], pi*[1:5]})
 df2 = @DataFrame(a => [1:5], b => pi * [1:5])
 
-file = jldopen(filename, "w")
+file = jldopen(fname, "w")
 write(file, "df", df)
 write(file, "df2", df2)
 close(file)
 
-file = jldopen(filename, "r")
+file = jldopen(fname, "r")
 x = read(file, "df")
 y = read(file, "df2")
 close(file)


### PR DESCRIPTION
Fixes `warning: literal address used in ccall for (null); code cannot be statically compiled` since the static compile branch was merged by removing `dlsym` calls. I just want to make sure I didn't break anything on Windows.
