### PR TITLE
Changes needed to precompile

### DIFF
--- a/src/plain.jl
+++ b/src/plain.jl
@@ -41,10 +41,19 @@ let
 end
 end
 
-status = ccall((:H5open, libname), Herr, ())
-if status < 0
-    error("Can't initialize the HDF5 library")
+function _init()
+    status = ccall((:H5open, libname), Herr, ())
+    if status < 0
+        error("Can't initialize the HDF5 library")
+    end
 end
+function init()
+    _init()
+    Base.rehash(hdf5_type_map, length(hdf5_type_map.keys))
+    nothing
+end
+
+_init()
 
 # Function to extract exported library constants
 # Kudos to the library developers for making these available this way!

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,6 @@
+using HDF5
+HDF5.init()
+
 include("plain.jl")
 include("jld.jl")
 include("readremote.jl")


### PR DESCRIPTION
The changes needed to get this to work with package precompilation were impressively minor. The only surprise was the need to call `rehash`, and I'm not sure why that's necessary. (I also don't understand why the other dictionary, `hdf5_prop_get_set`, does not seem to need rehashing.) CC @JeffBezanson, @vtjnash.

Currently, the user needs to call HDF5.init() in their .juliarc.jl script or before using HDF5 functions.
