### PR TITLE
Fix loading of custom types defined in external modules.

### DIFF
--- a/src/jld.jl
+++ b/src/jld.jl
@@ -392,7 +392,7 @@ function read(obj::JldDataset, T::DataType)
         params = a_read(obj.plain, "TypeParameters")
         p = Array(Any, length(params))
         for i = 1:length(params)
-            p[i] = eval(parse(params[i]))
+            p[i] = eval(current_module(), parse(params[i]))
         end
         T = T{p...}
     end


### PR DESCRIPTION
One eval() was missing a module context, causing all of my read()s to fail.
