### PR TITLE
Add save and load functions that operate on dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,17 +78,19 @@ advanced features of HDF5, then a simpler syntax is:
 ```
 t = 15
 z = [1,3]
-save("/tmp/myfile.jld", ["t"=>t, "arr"=>z])
+save("/tmp/myfile.jld", "t", t, "arr", z)
 ```
-Here we're explicitly saving `t` and `z` as `"t"` and `"arr"` within myfile.jld.
-You can read these variables back in with
+Here we're explicitly saving `t` and `z` as `"t"` and `"arr"` within
+myfile.jld. You can alternatively pass `save` a dictionary; the keys must be
+strings and are saved as the variable names of their values within the JLD
+file. You can read these variables back in with
 ```
 d = load("/tmp/myfile.jld")
 ```
-which reads the entire file into a returned dictionary `d`. You can
-alternatively just list particular variables of interest, e.g.,
-`load("/tmp/myfile.jld", "arr")` will return the single-pair dictionary
-`["arr"=>[1,3]]`.
+which reads the entire file into a returned dictionary `d`. Or you can be more
+specific and just request particular variables of interest. For example, `z =
+load("/tmp/myfile.jld", "arr")` will return the value of `arr` from the file
+and assign it back to z.
 
 There are also convenience macros `@save` and `@load` that work on the
 variables themselves. `@save "/tmp/myfile.jld" t z` will create a file with

--- a/doc/jld.md
+++ b/doc/jld.md
@@ -17,7 +17,7 @@ file = jldopen("mydata.jld", "w")
 close(file)
 ```
 This creates a dataset named `"A"` containing the contents of the variable `A`.
-There are also the convenient `save("mydata.jld", ["A"=>A])` or `@save "mydata.jld" A` [syntaxes](../README.md).
+There are also the convenient `save("mydata.jld", "A", A)` or `@save "mydata.jld" A` [syntaxes](../README.md).
 
 JLD files can be opened with the `mmaparrays` option, which if true returns "qualified" array data sets as arrays using [memory-mapping](hdf5.md#memory-mapping):
 

--- a/test/jld.jl
+++ b/test/jld.jl
@@ -235,6 +235,13 @@ d = ["x"=>3.2, "β"=>β, "A"=>A]
 save(fn, d)
 d2 = load(fn)
 @assert d == d2
+β2, A2 = load(fn, "β", "A")
+@assert β == β2
+@assert A == A2
+
+save(fn, "x", 3.2, "β", β, "A", A)
+d3 = load(fn)
+@assert d == d3
 
 # #71
 jldopen(fn, "w") do file


### PR DESCRIPTION
These functions are similar to their macro counterparts, except that they operate on and return dictionaries instead of variables directly in the global namespace.

`save` takes a filename and a dictionary with bytestring keys. The dictionary key-value pairs are saved in the file, with the keys as the variable names and the values as their contents.

`load` takes a filename and (optionally) a list of variable names to read. If no variable names are given, all names in the file are read. It reads the variables into a dictionary that is returned.

Furthermore, the `@load` macro now returns a list of variables that it loaded.

Would fix #98. Still needs tests and documentation.  And perhaps a bike-shed: Should `save` and `load` be exported?

I needed this for myself; it's very simple but I figured I may as well push it upstream, too.
