### PR TITLE
Re-use object references

### DIFF
--- a/src/jld.jl
+++ b/src/jld.jl
@@ -433,12 +433,18 @@ function getrefs{T}(obj::JldDataset, ::Type{T})
     out = Array(T, size(refs))
     f = file(obj)
     for i = 1:length(refs)
-        if refs[i] != HDF5.HDF5ReferenceObj_NULL
-            ref = f[refs[i]]
-            try
-                out[i] = read(ref)
-            finally
-                close(ref)
+        prevobj = get(file(obj).objectrefs, refs[i], nothing)
+        if prevobj != nothing
+            out[i] = prevobj
+        else
+            if refs[i] != HDF5.HDF5ReferenceObj_NULL
+                ref = f[refs[i]]
+                try
+                    out[i] = read(ref)
+                    file(obj).objectrefs[refs[i]] = out[i]
+                finally
+                    close(ref)
+                end
             end
         end
     end

--- a/test/jld.jl
+++ b/test/jld.jl
@@ -262,6 +262,18 @@ save(fn, "x", 3.2, "β", β, "A", A)
 d3 = load(fn)
 @assert d == d3
 
+# Test reference semantics
+v = Array(Vector{Int},0)
+arr = [1,2,3]
+push!(v, arr)
+push!(v, arr)
+@assert v[1] === v[2]
+save(fn, "v", v)
+v2 = load(fn,"v")
+@assert v2[1] === v2[2]
+v2[1][1] = 2
+@assert v2[2] == [2,2,3]
+
 # #71
 jldopen(fn, "w") do file
     file["a"] = 1


### PR DESCRIPTION
Alright, this one is a bit more daring.

Use an ObjectIdDict to keep track of previously saved array objects, and reuse the references if saved again in a different place.  This can drastically reduce file size.

In my application, it reduced the size of the file from 491.1 MB to 74.4 MB.  Which is awesome (and almost exactly the size of the data once loaded into Julia).  But I'm not quite sure I'm making the references correctly.  Theoretically, I think this could allow saving arrays that have circular references to themselves, but while all tests pass, that still doesn't work.
