### PR TITLE
read(f, :varname) + readsafely(f, :varname)

### DIFF
--- a/src/jld.jl
+++ b/src/jld.jl
@@ -221,6 +221,7 @@ function read(parent::Union(JldFile, JldGroup), name::ByteString)
     end
     val
 end
+read(parent::Union(JldFile,JldGroup), name::Symbol) = read(parent,bytestring(string(name)))
 
 # read and readsafely differ only in how they handle CompositeKind
 function read(obj::Union(JldFile, JldDataset))
@@ -305,6 +306,7 @@ function readsafely(parent::Union(JldFile, JldGroup), name::ByteString)
     end
     return ret
 end
+readsafely(parent::Union(JldFile,JldGroup), name::Symbol) = readsafely(parent, bytestring(string(symbol)))
 
 # Basic types
 typealias BitsKindOrByteString Union(HDF5BitsKind, ByteString)


### PR DESCRIPTION
I usually like to use `Symbol`s rather than `String`s when referring to things that are variable names, so I've been buggered for a while that `read` didn't take symbol arguments for the name of the thing to read. This should add that.

I haven't done any more elaborate testing of this than to just try it manually on a `jld` file I had laying around, and although I did glance at the test files I didn't really see the logical place to add tests for this. On the other hand, there is basically no logic here, so there's probably very little that can go wrong.
