### PR TITLE
Remove import of Base.has

### DIFF
--- a/src/plain.jl
+++ b/src/plain.jl
@@ -5,7 +5,7 @@
 module HDF5
 
 ## Add methods to...
-import Base: close, convert, done, dump, eltype, endof, flush, getindex, has, isempty, isvalid, length, names, ndims, next, read, setindex!, show, size, start, write
+import Base: close, convert, done, dump, eltype, endof, flush, getindex, isempty, isvalid, length, names, ndims, next, read, setindex!, show, size, start, write
 
 include("datafile.jl")
 


### PR DESCRIPTION
Yet another import of a previously deprecated function that was removed in Julia 0.3-RC1. This removes the import and thereby the warning.
