### PR TITLE
Fix #106

### DIFF
--- a/src/jld.jl
+++ b/src/jld.jl
@@ -722,7 +722,7 @@ function write_bitstype(parent::Union(JldFile, JldGroup), name::ByteString, s)
     else
         error("Unsupported bitstype $T of size $(T.size)")
     end
-    write(parent, name, [ub], "$T")
+    write(parent, name, [ub], "$(full_typename(T))")
 end
 
 function has_pointer_field(obj::Tuple, name)

--- a/test/jld.jl
+++ b/test/jld.jl
@@ -277,3 +277,13 @@ end
 jldopen(fn, "r") do file
     @assert read(file, "a") == 1
 end
+
+# Issue #106
+module Mod106
+bitstype 64 Typ{T}
+typ{T}(x::Int, ::Type{T}) = Base.box(Typ{T}, Base.unbox(Int,x))
+abstract UnexportedT
+end
+save(fn, "i106", Mod106.typ(1, Mod106.UnexportedT))
+i106 = load(fn, "i106")
+@assert i106 == Mod106.typ(1, Mod106.UnexportedT)


### PR DESCRIPTION
Save bitstypes with their fully-qualified typenames.
