### PR TITLE
Add a note that extra privileges are required

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Within Julia, use the package manager:
 Pkg.add("HDF5")
 ```
 
+Installation requires sudo rights on Unix-family systems and admin rights under recent versions of Windows.
+These rights are only used to install required HDF5 software, not the Julia HDF5 code.
+
 You also need to have the HDF5 library installed on your
 system (version 1.8 or higher is required), but **for most users
 no additional steps should be required; the HDF5 library should be


### PR DESCRIPTION
I'm not at all sure I have characterized these properly.
The exact security requirements vary by Windows version, with Vista and later being stricter.  This is partly because under W2K people tended to run under administrative accounts routinely.

I'm also not sure that the situation on OSX is the same as other *nix's.

Although I'm assuming your installation scripts are managing the sudo, this seems like something that the julia package management software should provide as a service.
