### PR TITLE
jld support for empty types

### DIFF
--- a/src/jld.jl
+++ b/src/jld.jl
@@ -641,6 +641,7 @@ function write_composite(parent::Union(JldFile, JldGroup), name::ByteString, s; 
         if T.size > 0
             return write_bitstype(parent, name, s)
         end
+        isdefined(T, :instance) || error("This is the write function for CompositeKind, but the input is of type ", T)
     end
     if has_pointer_field(s, name)
         return

--- a/test/jld.jl
+++ b/test/jld.jl
@@ -317,4 +317,3 @@ jldopen(fn, "r") do file
     @assert(file["a"][:] == [[1:50],[1:50]])
     @assert(file["b"][5,6][1]==5*6)
 end
-    


### PR DESCRIPTION
I don't understand what was this error was trying to avoid, but all the tests pass if I remove it.  Then JLD works with empty types.
