### PR TITLE
Restore compatibility with julia 0.2 (fix #125)

### DIFF
--- a/src/jld.jl
+++ b/src/jld.jl
@@ -392,9 +392,11 @@ read{N}(obj::JldDataset, ::Type{Array{Symbol,N}}) = map(symbol, read(obj.plain, 
 # Char
 read(obj::JldDataset, ::Type{Char}) = char(read(obj.plain, Uint32))
 
-# UTF16String
-read(obj::JldDataset, ::Type{UTF16String}) = UTF16String(read(obj.plain, Array{Uint16}))
-read{N}(obj::JldDataset, ::Type{Array{UTF16String,N}}) = map(x->UTF16String(x), read(obj, Array{Vector{Uint16},N}))
+# UTF16String (not defined in julia 0.2)
+if VERSION >= v"0.3-"
+    read(obj::JldDataset, ::Type{UTF16String}) = UTF16String(read(obj.plain, Array{Uint16}))
+    read{N}(obj::JldDataset, ::Type{Array{UTF16String,N}}) = map(x->UTF16String(x), read(obj, Array{Vector{Uint16},N}))
+end
 
 # General arrays
 read{T,N}(obj::JldDataset, t::Type{Array{T,N}}) = getrefs(obj, T)
@@ -604,8 +606,10 @@ write(parent::Union(JldFile, JldGroup), name::ByteString, syms::Array{Symbol}) =
 write(parent::Union(JldFile, JldGroup), name::ByteString, char::Char) = write(parent, name, uint32(char), "Char")
 
 #UTF16String
-write(parent::Union(JldFile, JldGroup), name::ByteString, str::UTF16String) = write(parent, name, str.data, "UTF16String")
-write{N}(parent::Union(JldFile, JldGroup), name::ByteString, strs::Array{UTF16String,N}) = write(parent, name, map(x->x.data, strs), "Array{UTF16String,$N}")
+if VERSION >= v"0.3-"
+    write(parent::Union(JldFile, JldGroup), name::ByteString, str::UTF16String) = write(parent, name, str.data, "UTF16String")
+    write{N}(parent::Union(JldFile, JldGroup), name::ByteString, strs::Array{UTF16String,N}) = write(parent, name, map(x->x.data, strs), "Array{UTF16String,$N}")
+end
 
 # General array types (as arrays of references)
 function write{T}(parent::Union(JldFile, JldGroup), path::ByteString, data::Array{T}, astype::String)

--- a/test/jld.jl
+++ b/test/jld.jl
@@ -9,8 +9,10 @@ Aarray = Vector{Float64}[[1.2,1.3],[2.2,2.3,2.4]]
 str = "Hello"
 stringsA = ASCIIString["It", "was", "a", "dark", "and", "stormy", "night"]
 stringsU = UTF8String["It", "was", "a", "dark", "and", "stormy", "night"]
-strings16 = convert(Array{UTF16String}, stringsA)
-strings16_2d = reshape(strings16[1:6], (2,3))
+if VERSION >= v"0.3-"
+    strings16 = convert(Array{UTF16String}, stringsA)
+    strings16_2d = reshape(strings16[1:6], (2,3))
+end
 empty_string = ""
 empty_string_array = ASCIIString[]
 empty_array_of_strings = ASCIIString[""]
@@ -61,7 +63,7 @@ cpus = Base.Sys.cpu_info()
 # Immutable type:
 rng = 1:5
 # Type with a pointer field (#84)
-objwithpointer = r"julia"
+objwithpointer = big(10)^10000
 # Custom BitsType (#99)
 bitstype 64 MyBT
 bt = reinterpret(MyBT, 55)
@@ -148,8 +150,10 @@ fid = jldopen(fn, "w")
 @write fid str
 @write fid stringsA
 @write fid stringsU
-@write fid strings16
-@write fid strings16_2d
+if VERSION >= v"0.3-"
+    @write fid strings16
+    @write fid strings16_2d
+end
 @write fid empty_string
 @write fid empty_string_array
 @write fid empty_array_of_strings
@@ -206,8 +210,10 @@ for mmap = (true, false)
     @check fidr str
     @check fidr stringsA
     @check fidr stringsU
-    @check fidr strings16
-    @check fidr strings16_2d
+    if VERSION >= v"0.3-"
+        @check fidr strings16
+        @check fidr strings16_2d
+    end
     @check fidr empty_string
     @check fidr empty_string_array
     @check fidr empty_array_of_strings
@@ -346,7 +352,7 @@ jldopen(fn, "w") do file
     file["ms"] = β
     g = g_create(file,"g")
     file["g/ms"] = ms
-    @test_throws ErrorException delete!(file, "_refs/g/ms")
+    @test_throws_02 ErrorException delete!(file, "_refs/g/ms")
     delete!(file, "g/ms")
     file["g/ms"] = ms
     delete!(file, "/g/ms")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,15 @@
 using HDF5
 HDF5.init()
 
+# backwards-compatible test_throws (works in julia 0.2)
+macro test_throws_02(args...)
+    if VERSION >= v"0.3-"
+        :(@test_throws($(esc(args[1])), $(esc(args[2]))))
+    else
+        :(@test_throws($(esc(args[2]))))
+    end
+end
+
 include("plain.jl")
 include("jld.jl")
 include("readremote.jl")


### PR DESCRIPTION
`UTF16String` did not exist in julia 0.2

Tests should also work now (note: in julia 0.2, regexes did not use pointers, so I changed the `objwithpointer` to a `BigInt`).
