### PR TITLE
Update .travis.yml to test release and nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,19 @@ compiler:
     - gcc
 notifications:
     email: false
+env:
+  matrix:
+    - JULIAVERSION="juliareleases"
+    - JULIAVERSION="julianightlies"
 before_install:
     - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-    - sudo add-apt-repository ppa:staticfloat/julianightlies -y
+    - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
     - sudo apt-get update -qq -y
-    - sudo apt-get install git julia hdf5-tools -y
+    - sudo apt-get install libpcre3-dev julia hdf5-tools -y
     - git config --global user.name "Travis User"
     - git config --global user.email "travis@example.net"
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:
     - julia -e 'versioninfo(); Pkg.init(); Pkg.add("DataFrames"); Pkg.clone(pwd())'
     - julia ./test/runtests.jl
-    - julia -e 'Pkg.add("JLDArchives"); Pkg.test("JLDArchives")'
+    - if [ $JULIAVERSION = "julianightlies" ]; then julia -e 'Pkg.add("JLDArchives"); cd(Pkg.dir("JLDArchives", "test")); include("runtests.jl")'; fi


### PR DESCRIPTION
Looks like we weren't testing juliarelease on Travis. Ah, the hazards of packages established at the dawn of time before we had all this lovely technology :smile:.

This should help things going forward. It took me about 6 attempts to get this simple change to the `.travis.yml` file right. One issue that cropped up towards the end is that the new JLDArchives tests won't work on julia 0.2, because UnitRange (one of the types saved) didn't exist then. So it may be that changes in julia itself are the biggest threat to the long-term stability of *.jld files. (One can use `readsafely`, of course.)
