### PR TITLE
Read HDF5 enumeration datatype as integer

### DIFF
--- a/src/plain.jl
+++ b/src/plain.jl
@@ -1646,6 +1646,11 @@ function hdf5_to_julia_eltype(objtype)
             is_signed = nothing
         end
         T = hdf5_type_map[(class_id, is_signed, native_size)]
+    elseif class_id == H5T_ENUM
+        native_type = h5t_get_native_type(h5t_get_super(objtype.id))
+        native_size = h5t_get_size(native_type)
+        is_signed = h5t_get_sign(native_type)
+        T = hdf5_type_map[(H5T_INTEGER, is_signed, native_size)]
     elseif class_id == H5T_REFERENCE
         # How to test whether it's a region reference or an object reference??
         T = HDF5ReferenceObj

--- a/test/readremote.jl
+++ b/test/readremote.jl
@@ -11,6 +11,11 @@ icmp = [0 -1 -2 -3 -4 -5 -6;
     0 0 0 0 0 0 0;
     0 1 2 3 4 5 6;
     0 2 4 6 8 10 12]'
+const SOLID, LIQUID, GAS, PLASMA = 0, 1, 2, 3
+ecmp = [SOLID SOLID SOLID SOLID SOLID SOLID SOLID;
+        SOLID LIQUID GAS PLASMA SOLID LIQUID GAS;
+        SOLID GAS SOLID GAS SOLID GAS SOLID;
+        SOLID PLASMA GAS LIQUID SOLID PLASMA GAS]'
 scmp = ["Parting", "is such", "sweet", "sorrow."]
 vicmp = Array{Int32}[[3,2,1],[1,1,2,3,5,8,13,21,34,55,89,144]]
 opq = Array{Uint8}[[0x4f, 0x50, 0x41, 0x51, 0x55, 0x45, 0x30],
@@ -78,6 +83,21 @@ fid = h5open(file, "r")
 d = read(fid, "DS1")
 @assert d == icmp
 close(fid)
+
+if HDF5.h5_get_libversion() >= (1, 8, 11)
+  file = getfile("h5ex_t_enumatt.h5")
+  fid = h5open(file, "r")
+  dset = fid["DS1"]
+  a = a_read(dset, "A1")
+  @assert a == ecmp
+  close(fid)
+
+  file = getfile("h5ex_t_enum.h5")
+  fid = h5open(file, "r")
+  d = read(fid, "DS1")
+  @assert d == ecmp
+  close(fid)
+end
 
 file = getfile("h5ex_t_objrefatt.h5")
 fid = h5open(file, "r")


### PR DESCRIPTION
In molecular simulations I use the HDF5 enumeration datatype to store particle species in an [H5MD](http://nongnu.org/h5md/h5md.html) file. [HDF5 1.8.11](http://www.hdfgroup.org/HDF5/doc/ADGuide/Changes.html#1811) or greater supports implicit conversion from enumeration file datatypes to integer memory datatypes, which permits us to read at least the enum values.
