### PR TITLE
Allow attribute reading/writing for HDF5File

### DIFF
--- a/src/plain.jl
+++ b/src/plain.jl
@@ -1358,7 +1358,7 @@ end
 # You can also pass in property lists
 for (privatesym, fsym, ptype) in
     ((:_d_create, :d_create, Union(HDF5File, HDF5Group)),
-     (:_a_create, :a_create, Union(HDF5Group, HDF5Dataset, HDF5Datatype)))
+     (:_a_create, :a_create, Union(HDF5File, HDF5Group, HDF5Dataset, HDF5Datatype)))
     @eval begin
         # Generic create (hidden)
         function ($privatesym)(parent::$ptype, name::ByteString, data, plists...)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -40,6 +40,8 @@ write(f, "empty_string_array", empty_string_array)
 empty_array_of_strings = ASCIIString[""]
 write(f, "empty_array_of_strings", empty_array_of_strings)
 # Attributes
+species = [["N", "C"], ["A", "B"]]
+attrs(f)["species"] = species
 dset = f["salut"]
 label = "This is a string"
 attrs(dset)["typeinfo"] = label
@@ -136,6 +138,7 @@ empty_string_arrayr = read(fr, "empty_string_array")
 @assert empty_string_arrayr == empty_string_array
 empty_array_of_stringsr = read(fr, "empty_array_of_strings")
 @assert empty_array_of_stringsr == empty_array_of_strings
+@assert a_read(fr, "species") == species
 dset = fr["salut"]
 @assert a_read(dset, "typeinfo") == label
 close(dset)


### PR DESCRIPTION
This permits direct access of file attributes, without having to open the root group first:

``` julia
attrs(file["/"])["input"] = ARGS
```

becomes

``` julia
attrs(file)["input"] = ARGS
```
