### PR TITLE
set up travis for mac + linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
-language: cpp
+language: objective-c # force travis to run on mac
+os:
+    - linux
+    - osx
 compiler: 
     - gcc
 notifications:
@@ -8,10 +11,21 @@ env:
     - JULIAVERSION="juliareleases"
     - JULIAVERSION="julianightlies"
 before_install:
-    - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-    - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-    - sudo apt-get update -qq -y
-    - sudo apt-get install libpcre3-dev julia -y
+    - if [ `uname` = "Linux" ]; then
+        sudo add-apt-repository ppa:staticfloat/julia-deps -y;
+        sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y;
+        sudo apt-get update -qq -y;
+        sudo apt-get install libpcre3-dev julia -y;
+      elif [ `uname` = "Darwin" ]; then
+        if [ "$JULIAVERSION" = "julianightlies" ]; then
+          wget -O julia.dmg "http://status.julialang.org/download/osx10.7+";
+        else
+          wget -O julia.dmg "http://status.julialang.org/stable/osx10.7+";
+        fi;
+        hdiutil mount julia.dmg;
+        cp -Ra /Volumes/Julia/*.app/Contents/Resources/julia ~;
+        export PATH="$PATH:$(echo ~)/julia/bin";
+      fi
     - git config --global user.name "Travis User"
     - git config --global user.email "travis@example.net"
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi


### PR DESCRIPTION
See http://docs.travis-ci.com/user/multi-os/ - you need to send an email to support@travis-ci.com asking them to enable multi-OS support for this repo. They were short on capacity for a while, but looks like they're accepting new repos again now.

The `language: objective-c` line is temporary just to see what a test build looks like on mac only, we'll change that back for the real thing.
