### PR TITLE
Fix julia-0.5 String transition

### DIFF
--- a/src/datafile.jl
+++ b/src/datafile.jl
@@ -28,13 +28,13 @@ macro write(fid, sym)
 end
 
 # Read a list of variables, read(parent, "A", "B", "x", ...)
-read(parent::DataFile, name::ByteString...) =
+read(parent::DataFile, name::String...) =
 	tuple([read(parent, x) for x in name]...)
 
 # Read one or more variables and pass them to a function. This is
 # convenient for avoiding type inference pitfalls with the usual
 # read syntax.
-read(f::Base.Callable, parent::DataFile, name::ASCIIString...) =
+read(f::Base.Callable, parent::DataFile, name::String...) =
 	f(read(parent, name...)...)
 
 # Read every variable in the file

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -1,4 +1,5 @@
 using HDF5, Compat, Base.Test
+using Compat.String
 const test_path = splitdir(@__FILE__)[1]
 
 # Create a new file
@@ -32,6 +33,7 @@ write(f, "ucode", ucode)
 let
     dtype = HDF5Datatype(HDF5.h5t_copy(HDF5.H5T_C_S1))
     HDF5.h5t_set_size(dtype.id, HDF5.H5T_VARIABLE)
+    HDF5.h5t_set_cset(dtype.id, HDF5.cset(typeof(salut)))
     dspace = HDF5.dataspace(salut)
     dset = HDF5.d_create(f, "salut-vlen", dtype, dspace)
     HDF5.h5d_write(dset, dtype, HDF5.H5S_ALL, HDF5.H5S_ALL, HDF5.H5P_DEFAULT, [pointer(salut.data)])
@@ -49,10 +51,10 @@ write(f, "empty", empty)
 empty_string = ""
 write(f, "empty_string", empty_string)
 # Empty array of strings
-empty_string_array = ASCIIString[]
+empty_string_array = Compat.ASCIIString[]
 write(f, "empty_string_array", empty_string_array)
 # Array of empty string
-empty_array_of_strings = ASCIIString[""]
+empty_array_of_strings = Compat.ASCIIString[""]
 write(f, "empty_array_of_strings", empty_array_of_strings)
 # Attributes
 species = [["N", "C"]; ["A", "B"]]
@@ -242,9 +244,9 @@ h5open(fn, "w") do fid
     end
 end
 fid = h5open(fn, "r")
-@assert names(fid) == ASCIIString["mygroup"]
+@assert names(fid) == Compat.ASCIIString["mygroup"]
 g = fid["mygroup"]
-@assert names(g) == ASCIIString["x"]
+@assert names(g) == Compat.ASCIIString["x"]
 close(g)
 close(fid)
 
@@ -253,7 +255,7 @@ d = h5read(joinpath(test_path, "compound.h5"), "/data")
 @assert typeof(d.data) == Array{UInt8,1}
 @assert length(d.data) == 128
 @test d.membertype == Type[Float64, HDF5.FixedArray{Float64,(3,)}, HDF5.FixedArray{Float64,(3,)}, Float64]
-@assert d.membername == ASCIIString["wgt", "xyz", "uvw", "E"]
+@assert d.membername == Compat.ASCIIString["wgt", "xyz", "uvw", "E"]
 @assert d.memberoffset == UInt64[0x00, 0x08, 0x20, 0x38]
 
 # File creation and access property lists


### PR DESCRIPTION
I had to make a few nontrivial changes because libhdf5 cares about the character encoding, but these were relatively localized changes. The `if !newstring` tests are simply to prevent method-overwritten warnings.