### PR TITLE
h5rewrite: h5open a temporary file and rename to filename if succesful

### DIFF
--- a/src/plain.jl
+++ b/src/plain.jl
@@ -612,12 +612,7 @@ if VERSION >= v"0.4"
         close(tmpio)
 
         try
-            fid = h5open(tmppath, "w", args...)
-            val = try
-                ret = f(fid)
-            finally
-                close(fid)
-            end
+            val = h5open(f, tmppath, "w", args...)
             Base.FS.rename(tmppath, filename)
             return val
         catch

--- a/src/plain.jl
+++ b/src/plain.jl
@@ -606,6 +606,27 @@ function h5open(f::Function, args...)
     end
 end
 
+function h5rewrite(f::Function, filename::AbstractString, args...)
+    tmppath = string(filename, "tmpXXXXXX")
+    p = ccall(:mkstemp, Int32, (Cstring,), tmppath) # modifies tmppath
+    systemerror(:h5rewrite, p == -1)
+    close(fdio(p))
+
+    try
+        fid = h5open(tmppath, "w", args...)
+        val = try
+            ret = f(fid)
+        finally
+            close(fid)
+        end
+        Base.FS.rename(tmppath, filename)
+        return val
+    catch
+        Base.FS.unlink(tmppath)
+        rethrow()
+    end
+end
+
 function h5write(filename, name::String, data)
     fid = h5open(filename, true, true, true, false, true)
     try
@@ -2324,6 +2345,7 @@ export
     getindex,
     h5open,
     h5read,
+    h5rewrite,
     h5writeattr,
     h5readattr,
     h5write,

--- a/src/plain.jl
+++ b/src/plain.jl
@@ -606,22 +606,24 @@ function h5open(f::Function, args...)
     end
 end
 
-function h5rewrite(f::Function, filename::AbstractString, args...)
-    tmppath,tmpio = mktemp(dirname(filename))
-    close(tmpio)
+if VERSION >= v"0.4"
+    function h5rewrite(f::Function, filename::AbstractString, args...)
+        tmppath,tmpio = mktemp(dirname(filename))
+        close(tmpio)
 
-    try
-        fid = h5open(tmppath, "w", args...)
-        val = try
-            ret = f(fid)
-        finally
-            close(fid)
+        try
+            fid = h5open(tmppath, "w", args...)
+            val = try
+                ret = f(fid)
+            finally
+                close(fid)
+            end
+            Base.FS.rename(tmppath, filename)
+            return val
+        catch
+            Base.FS.unlink(tmppath)
+            rethrow()
         end
-        Base.FS.rename(tmppath, filename)
-        return val
-    catch
-        Base.FS.unlink(tmppath)
-        rethrow()
     end
 end
 

--- a/src/plain.jl
+++ b/src/plain.jl
@@ -607,10 +607,8 @@ function h5open(f::Function, args...)
 end
 
 function h5rewrite(f::Function, filename::AbstractString, args...)
-    tmppath = string(filename, "tmpXXXXXX")
-    p = ccall(:mkstemp, Int32, (Cstring,), tmppath) # modifies tmppath
-    systemerror(:h5rewrite, p == -1)
-    close(fdio(p))
+    tmppath,tmpio = mktemp(dirname(filename))
+    close(tmpio)
 
     try
         fid = h5open(tmppath, "w", args...)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -251,17 +251,19 @@ close(g)
 close(fid)
 
 # more do syntax: atomic rename version
-h5rewrite(fn) do fid
-    g_create(fid, "mygroup") do g
-        write(g, "y", 3.3)
+if VERSION >= v"0.4"
+    h5rewrite(fn) do fid
+        g_create(fid, "mygroup") do g
+            write(g, "y", 3.3)
+        end
     end
+    fid = h5open(fn, "r")
+    @assert names(fid) == Compat.ASCIIString["mygroup"]
+    g = fid["mygroup"]
+    @assert names(g) == Compat.ASCIIString["y"]
+    close(g)
+    close(fid)
 end
-fid = h5open(fn, "r")
-@assert names(fid) == Compat.ASCIIString["mygroup"]
-g = fid["mygroup"]
-@assert names(g) == Compat.ASCIIString["y"]
-close(g)
-close(fid)
 
 d = h5read(joinpath(test_path, "compound.h5"), "/data")
 @assert typeof(d) == HDF5.HDF5Compound

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -250,6 +250,19 @@ g = fid["mygroup"]
 close(g)
 close(fid)
 
+# more do syntax: atomic rename version
+h5rewrite(fn) do fid
+    g_create(fid, "mygroup") do g
+        write(g, "y", 3.3)
+    end
+end
+fid = h5open(fn, "r")
+@assert names(fid) == Compat.ASCIIString["mygroup"]
+g = fid["mygroup"]
+@assert names(g) == Compat.ASCIIString["y"]
+close(g)
+close(fid)
+
 d = h5read(joinpath(test_path, "compound.h5"), "/data")
 @assert typeof(d) == HDF5.HDF5Compound
 @assert typeof(d.data) == Array{UInt8,1}

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -252,17 +252,47 @@ close(fid)
 
 # more do syntax: atomic rename version
 if VERSION >= v"0.4"
-    h5rewrite(fn) do fid
+    tmpdir = mktempdir()
+    outfile = joinpath(tmpdir, "test.h5")
+
+    # create a new file
+    h5rewrite(outfile) do fid
+        g_create(fid, "mygroup") do g
+            write(g, "x", 3.3)
+        end
+    end
+    @test length(readdir(tmpdir)) == 1
+    h5open(outfile, "r") do fid
+        @test names(fid) == Compat.ASCIIString["mygroup"]
+        @test names(fid["mygroup"]) == Compat.ASCIIString["x"]
+    end
+
+    # fail to overwrite
+    @test_throws ErrorException h5rewrite(outfile) do fid
+        g_create(fid, "mygroup") do g
+            write(g, "oops", 3.3)
+        end
+        error("failed")
+    end
+    @test length(readdir(tmpdir)) == 1
+    h5open(outfile, "r") do fid
+        @test names(fid) == Compat.ASCIIString["mygroup"]
+        @test names(fid["mygroup"]) == Compat.ASCIIString["x"]
+    end
+
+    # overwrite
+    h5rewrite(outfile) do fid
         g_create(fid, "mygroup") do g
             write(g, "y", 3.3)
         end
     end
-    fid = h5open(fn, "r")
-    @assert names(fid) == Compat.ASCIIString["mygroup"]
-    g = fid["mygroup"]
-    @assert names(g) == Compat.ASCIIString["y"]
-    close(g)
-    close(fid)
+    @test length(readdir(tmpdir)) == 1
+    h5open(outfile, "r") do fid
+        @test names(fid) == Compat.ASCIIString["mygroup"]
+        @test names(fid["mygroup"]) == Compat.ASCIIString["y"]
+    end
+
+    rm(tmpdir, recursive=true)
 end
 
 d = h5read(joinpath(test_path, "compound.h5"), "/data")


### PR DESCRIPTION
I've been cut-and-pasting a function like this into many programs that use HDF5.jl.  It creates a temporary file, h5opens it, and calls a function.  If the h5open and user function call are successful, then the temporary file is renamed (atomically) to replace an existing file.  If the call fails, then the original file is untouched,  the temporary file is deleted, and the exception propagates.

For me it's just a hacky way to decouple producers and consumers of data.  Surely there  are better ways, but this works across multiple machines, doesn't require any setup except a network mounted scratch directory, and lets me poke around in the files when things go wrong.

It took me a few tries to get it right (mv != rename, rm != unlink), and it's been useful in a few different programs, so I'll offer it here in case you want to include it in the library.

The patch also included a simple test of the new function.