### PR TITLE
Tell Homebrew.jl to tap homebrew/science if necessary

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,5 @@ julia 0.3.4
 BinDeps
 Blosc
 Compat 0.8.0
-@osx Homebrew
+@osx Homebrew 0.3.1
 @windows WinRPM

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -18,7 +18,7 @@ end
 @osx_only begin
     using Homebrew
     hdf5 = library_dependency("libhdf5")
-    provides(Homebrew.HB, ["hdf5", "homebrew/science/hdf5"], hdf5, os = :Darwin )
+    provides(Homebrew.HB, "homebrew/science/hdf5", hdf5, os = :Darwin )
 end
 
 provides(Sources, URI("http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz"), hdf5)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -18,7 +18,7 @@ end
 @osx_only begin
     using Homebrew
     hdf5 = library_dependency("libhdf5")
-    provides(Homebrew.HB, "hdf5", hdf5, os = :Darwin )
+    provides(Homebrew.HB, ["hdf5", "homebrew/science/hdf5"], hdf5, os = :Darwin )
 end
 
 provides(Sources, URI("http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz"), hdf5)


### PR DESCRIPTION
HDF5 is no longer in `staticfloat/juliadeps`.
When Homebrew.jl installs its own brew (i.e. on CI) it won't have tapped `homebrew/science` so it won't find hdf5.
This change will let it find hdf5 in `homebrew/science`.