### PR TITLE
Update example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ end
 Convenience functions for attributes attached to datasets are also provided:
 
 ```julia
-  A=[1:10]
+  A=Array{Int64}(1:10)
   h5write("bar.h5", "foo", A)
   h5writeattr("bar.h5", "foo", Dict("c"=>"value for metadata parameter c","d"=>"metadata d"))
   h5readattr("bar.h5", "foo")


### PR DESCRIPTION
Without an explicit `Array{Int64}` instantiation the following error is produced (in julia 0.5.0): `ERROR: MethodError: no method matching write(::HDF5.HDF5File, ::String, ::Array{UnitRange{Int64},1})`
