### PR TITLE
Revert "Add aliases on Windows"

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,7 +11,7 @@ end
 
 if is_windows()
     using WinRPM
-    hdf5 = library_dependency("libhdf5", aliases = ["hdf5_w64", "hdf5"])
+    hdf5 = library_dependency("libhdf5")
     provides(WinRPM.RPM, "hdf5", hdf5, os = :Windows )
 end
 


### PR DESCRIPTION
Reverts JuliaIO/HDF5.jl#288, we don't want to use an msvc-compiled hdf5 dll. Ref https://github.com/JuliaIO/HDF5.jl/issues/323