### PR TITLE
Add alias for support of IBM Power architecture

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,7 +3,7 @@ using BinDeps, Compat
 @BinDeps.setup
 
 if is_linux()
-    hdf5 = library_dependency("libhdf5", aliases = ["libhdf5", "libhdf5_serial", "libhdf5_openmpi", "libhdf5_mpich"])
+    hdf5 = library_dependency("libhdf5", aliases = ["libhdf5", "libhdf5_serial", "libhdf5_serial.so.10", "libhdf5_openmpi", "libhdf5_mpich"])
     provides(AptGet, "hdf5-tools", hdf5)
     provides(Pacman, "hdf5", hdf5)
     provides(Yum, "hdf5", hdf5)


### PR DESCRIPTION
Execution of `apt-get install hdf5-tools` on a Power system running Ubuntu 16.04 does not seem to install un-versioned .so files.  The edit in this commit allows for `Pkg.build("HDF5")` to be executed successfully, and for HDF5.jl to work subsequently.