### PR TITLE
Add scalar reference reading for attributes

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1258,6 +1258,13 @@ function read{A<:FixedArray}(obj::DatasetOrAttribute, ::Type{Array{A}})
     ret
 end
 
+# Read a scalar reference objected from an attribute
+function read{T<:HDF5ReferenceObj}(obj::HDF5Attribute, ::Type{T})
+    refs = Array{T}(1)
+    h5a_read(obj.id, H5T_STD_REF_OBJ, refs)
+    refs[1]
+end
+
 # Clean up string buffer according to padding mode
 function unpad(s::String, pad::Cint)
     if pad == H5T_STR_NULLTERM

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1634,13 +1634,8 @@ function a_write{T<:HDF5ReferenceObj}(parent::Union{HDF5File, HDF5Object, HDF5Da
     dtype = HDF5Datatype(H5T_STD_REF_OBJ, false)
     dspace = dataspace(data)
     obj = a_create(parent, name, dtype, dspace, plists...)
-    println(obj)
-    println(dspace)
     close(dspace)
-    ref = Ref{T}()
-    ref[] = data
-    writearray(obj, dtype.id, ref)
-    # HDF5Attribute(h5a_create(checkvalid(parent).id, name, dtype.id, dataspace(ref), file(parent))
+    writearray(obj, dtype.id, Ref{T}(data))
 end
 
 # Write to already-created objects

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1260,9 +1260,9 @@ end
 
 # Read a scalar reference objected from an attribute
 function read{T<:HDF5ReferenceObj}(obj::HDF5Attribute, ::Type{T})
-    refs = Array{T}(1)
-    h5a_read(obj.id, H5T_STD_REF_OBJ, refs)
-    refs[1]
+    ref = Ref{T}()
+    h5a_read(obj.id, H5T_STD_REF_OBJ, ref)
+    ref[]
 end
 
 # Clean up string buffer according to padding mode

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1630,8 +1630,9 @@ for (privatesym, fsym, ptype, crsym) in
     end
 end
 
+# Write scalar reference to an attribute
 function a_write{T<:HDF5ReferenceObj}(parent::Union{HDF5File, HDF5Object, HDF5Datatype}, name::String, data::T, plists...)
-    dtype = HDF5Datatype(H5T_STD_REF_OBJ, false)
+    dtype = datatype(data)
     dspace = dataspace(data)
     obj = a_create(parent, name, dtype, dspace, plists...)
     close(dspace)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -4,9 +4,9 @@ using Compat
 using Compat.String
 
 @testset "plain" begin
-  
+ 
     const test_path = splitdir(@__FILE__)[1]
-  
+ 
     # Create a new file
     fn = joinpath(tempdir(),"test.h5")
     f = h5open(fn, "w")

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -67,6 +67,8 @@ dset = f["salut"]
 label = "This is a string"
 attrs(dset)["typeinfo"] = label
 close(dset)
+# Scalar reference values in attributes
+attrs(f)["ref_test"] = HDF5.HDF5ReferenceObj(f, "empty_array_of_strings")
 # Group
 g = g_create(f, "mygroup")
 # Test dataset with compression

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -69,6 +69,7 @@ attrs(dset)["typeinfo"] = label
 close(dset)
 # Scalar reference values in attributes
 attrs(f)["ref_test"] = HDF5.HDF5ReferenceObj(f, "empty_array_of_strings")
+@assert read(attrs(f)["ref_test"]) === HDF5.HDF5ReferenceObj(f, "empty_array_of_strings")
 # Group
 g = g_create(f, "mygroup")
 # Test dataset with compression

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -4,9 +4,9 @@ using Compat
 using Compat.String
 
 @testset "plain" begin
- 
+
     const test_path = splitdir(@__FILE__)[1]
- 
+
     # Create a new file
     fn = joinpath(tempdir(),"test.h5")
     f = h5open(fn, "w")


### PR DESCRIPTION
Wasn't able to read a single reference object from an attribute (only arrays) — quick fix.