### PR TITLE
Update libhdf5 source URL

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -21,7 +21,7 @@ if is_apple()
     provides(Homebrew.HB, "homebrew/science/hdf5", hdf5, os = :Darwin )
 end
 
-provides(Sources, URI("http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz"), hdf5)
+provides(Sources, URI("https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz"), hdf5)
 provides(BuildProcess, Autotools(libtarget = "libhdf5.la"), hdf5)
 
 @BinDeps.install Dict(:libhdf5 => :libhdf5)


### PR DESCRIPTION
Update source url to match the download link on https://support.hdfgroup.org/HDF5/release/obtainsrc5110.html