### PR TITLE
Minor tweaks and clean up

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,4 @@
-using BinDeps, Compat
+using BinDeps
 
 @BinDeps.setup
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -33,9 +33,7 @@ function h5_get_libversion()
     minnum = Ref{Cuint}()
     relnum = Ref{Cuint}()
     status = ccall((:H5get_libversion, libhdf5),
-                   Cint,
-                   (Ptr{Cuint}, Ptr{Cuint}, Ptr{Cuint}),
-                   _majnum, _minnum, _relnum)
+                   Cint, (Ptr{Cuint}, Ptr{Cuint}, Ptr{Cuint}), majnum, minnum, relnum)
     status < 0 && error("Error getting HDF5 library version")
     VersionNumber(convert(Int, majnum[]), convert(Int, minnum[]), convert(Int, relnum[]))
 end

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -28,25 +28,25 @@ end
 
 init_libhdf5()
 
-const _majnum = Ref{Cuint}()
-const _minnum = Ref{Cuint}()
-const _relnum = Ref{Cuint}()
 function h5_get_libversion()
+    majnum = Ref{Cuint}()
+    minnum = Ref{Cuint}()
+    relnum = Ref{Cuint}()
     status = ccall((:H5get_libversion, libhdf5),
                    Cint,
                    (Ptr{Cuint}, Ptr{Cuint}, Ptr{Cuint}),
                    _majnum, _minnum, _relnum)
     status < 0 && error("Error getting HDF5 library version")
-    convert(Int, _majnum[]), convert(Int, _minnum[]), convert(Int, _relnum[])
+    VersionNumber(convert(Int, majnum[]), convert(Int, minnum[]), convert(Int, relnum[]))
 end
 
-const _libversion = h5_get_libversion()
+const libversion = h5_get_libversion()
 
 ## C types
 const C_time_t = Int
 
 ## HDF5 types and constants
-if _libversion >= (1, 10, 0)
+if libversion >= v"1.10.0"
     const Hid     = Int64
 else
     const Hid     = Cint
@@ -118,22 +118,22 @@ const H5O_TYPE_DATASET = 1
 const H5O_TYPE_NAMED_DATATYPE = 2
 # Property constants
 const H5P_DEFAULT          = 0
-const H5P_OBJECT_CREATE    = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_OBJECT_CREATE_ID_g    : :H5P_CLS_OBJECT_CREATE_g)
-const H5P_FILE_CREATE      = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_FILE_CREATE_ID_g      : :H5P_CLS_FILE_CREATE_g)
-const H5P_FILE_ACCESS      = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_FILE_ACCESS_ID_g      : :H5P_CLS_FILE_ACCESS_g)
-const H5P_DATASET_CREATE   = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_DATASET_CREATE_ID_g   : :H5P_CLS_DATASET_CREATE_g)
-const H5P_DATASET_ACCESS   = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_DATASET_ACCESS_ID_g   : :H5P_CLS_DATASET_ACCESS_g)
-const H5P_DATASET_XFER     = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_DATASET_XFER_ID_g     : :H5P_CLS_DATASET_XFER_g)
-const H5P_FILE_MOUNT       = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_FILE_MOUNT_ID_g       : :H5P_CLS_FILE_MOUNT_g)
-const H5P_GROUP_CREATE     = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_GROUP_CREATE_ID_g     : :H5P_CLS_GROUP_CREATE_g)
-const H5P_GROUP_ACCESS     = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_GROUP_ACCESS_ID_g     : :H5P_CLS_GROUP_ACCESS_g)
-const H5P_DATATYPE_CREATE  = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_DATATYPE_CREATE_ID_g  : :H5P_CLS_DATATYPE_CREATE_g)
-const H5P_DATATYPE_ACCESS  = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_DATATYPE_ACCESS_ID_g  : :H5P_CLS_DATATYPE_ACCESS_g)
-const H5P_STRING_CREATE    = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_STRING_CREATE_ID_g    : :H5P_CLS_STRING_CREATE_g)
-const H5P_ATTRIBUTE_CREATE = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_ATTRIBUTE_CREATE_ID_g : :H5P_CLS_ATTRIBUTE_CREATE_g)
-const H5P_OBJECT_COPY      = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_OBJECT_COPY_ID_g      : :H5P_CLS_OBJECT_COPY_g)
-const H5P_LINK_CREATE      = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_LINK_CREATE_ID_g      : :H5P_CLS_LINK_CREATE_g)
-const H5P_LINK_ACCESS      = read_const(_libversion >= (1, 8, 14) ? :H5P_CLS_LINK_ACCESS_ID_g      : :H5P_CLS_LINK_ACCESS_g)
+const H5P_OBJECT_CREATE    = read_const(libversion >= v"1.8.14" ? :H5P_CLS_OBJECT_CREATE_ID_g    : :H5P_CLS_OBJECT_CREATE_g)
+const H5P_FILE_CREATE      = read_const(libversion >= v"1.8.14" ? :H5P_CLS_FILE_CREATE_ID_g      : :H5P_CLS_FILE_CREATE_g)
+const H5P_FILE_ACCESS      = read_const(libversion >= v"1.8.14" ? :H5P_CLS_FILE_ACCESS_ID_g      : :H5P_CLS_FILE_ACCESS_g)
+const H5P_DATASET_CREATE   = read_const(libversion >= v"1.8.14" ? :H5P_CLS_DATASET_CREATE_ID_g   : :H5P_CLS_DATASET_CREATE_g)
+const H5P_DATASET_ACCESS   = read_const(libversion >= v"1.8.14" ? :H5P_CLS_DATASET_ACCESS_ID_g   : :H5P_CLS_DATASET_ACCESS_g)
+const H5P_DATASET_XFER     = read_const(libversion >= v"1.8.14" ? :H5P_CLS_DATASET_XFER_ID_g     : :H5P_CLS_DATASET_XFER_g)
+const H5P_FILE_MOUNT       = read_const(libversion >= v"1.8.14" ? :H5P_CLS_FILE_MOUNT_ID_g       : :H5P_CLS_FILE_MOUNT_g)
+const H5P_GROUP_CREATE     = read_const(libversion >= v"1.8.14" ? :H5P_CLS_GROUP_CREATE_ID_g     : :H5P_CLS_GROUP_CREATE_g)
+const H5P_GROUP_ACCESS     = read_const(libversion >= v"1.8.14" ? :H5P_CLS_GROUP_ACCESS_ID_g     : :H5P_CLS_GROUP_ACCESS_g)
+const H5P_DATATYPE_CREATE  = read_const(libversion >= v"1.8.14" ? :H5P_CLS_DATATYPE_CREATE_ID_g  : :H5P_CLS_DATATYPE_CREATE_g)
+const H5P_DATATYPE_ACCESS  = read_const(libversion >= v"1.8.14" ? :H5P_CLS_DATATYPE_ACCESS_ID_g  : :H5P_CLS_DATATYPE_ACCESS_g)
+const H5P_STRING_CREATE    = read_const(libversion >= v"1.8.14" ? :H5P_CLS_STRING_CREATE_ID_g    : :H5P_CLS_STRING_CREATE_g)
+const H5P_ATTRIBUTE_CREATE = read_const(libversion >= v"1.8.14" ? :H5P_CLS_ATTRIBUTE_CREATE_ID_g : :H5P_CLS_ATTRIBUTE_CREATE_g)
+const H5P_OBJECT_COPY      = read_const(libversion >= v"1.8.14" ? :H5P_CLS_OBJECT_COPY_ID_g      : :H5P_CLS_OBJECT_COPY_g)
+const H5P_LINK_CREATE      = read_const(libversion >= v"1.8.14" ? :H5P_CLS_LINK_CREATE_ID_g      : :H5P_CLS_LINK_CREATE_g)
+const H5P_LINK_ACCESS      = read_const(libversion >= v"1.8.14" ? :H5P_CLS_LINK_ACCESS_ID_g      : :H5P_CLS_LINK_ACCESS_g)
 # Reference constants
 const H5R_OBJECT         = 0
 const H5R_DATASET_REGION = 1
@@ -1888,7 +1888,7 @@ h5l_exists(loc_id::Hid, name::String) = h5l_exists(loc_id, name, H5P_DEFAULT)
 h5o_open(obj_id::Hid, name::String) = h5o_open(obj_id, name, H5P_DEFAULT)
 #h5s_get_simple_extent_ndims(space_id::Hid) = h5s_get_simple_extent_ndims(space_id, C_NULL, C_NULL)
 h5t_get_native_type(type_id::Hid) = h5t_get_native_type(type_id, H5T_DIR_ASCEND)
-if _libversion >= (1, 10, 0)
+if libversion >= v"1.10.0"
     const H5RDEREFERENCE = :H5Rdereference1
 else
     const H5RDEREFERENCE = :H5Rdereference

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -14,7 +14,6 @@ include("datafile.jl")
 
 ### Load and initialize the HDF library ###
 const depsfile = joinpath(dirname(dirname(@__FILE__)), "deps", "deps.jl")
-
 if isfile(depsfile)
     include(depsfile)
 else
@@ -38,9 +37,7 @@ function h5_get_libversion()
                    Cint,
                    (Ptr{Cuint}, Ptr{Cuint}, Ptr{Cuint}),
                    _majnum, _minnum, _relnum)
-    if status < 0
-        error("Error getting HDF5 library version")
-    end
+    status < 0 && error("Error getting HDF5 library version")
     convert(Int, _majnum[]), convert(Int, _minnum[]), convert(Int, _relnum[])
 end
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -13,8 +13,10 @@ import Base: ==, close, convert, done, dump, eltype, endof, flush, getindex,
 include("datafile.jl")
 
 ### Load and initialize the HDF library ###
-if isfile(joinpath(dirname(dirname(@__FILE__)),"deps","deps.jl"))
-    include("../deps/deps.jl")
+const depsfile = joinpath(dirname(dirname(@__FILE__)), "deps", "deps.jl")
+
+if isfile(depsfile)
+    include(depsfile)
 else
     error("HDF5 not properly installed. Please run Pkg.build(\"HDF5\")")
 end
@@ -28,9 +30,9 @@ end
 
 init_libhdf5()
 
-_majnum = Vector{Cuint}(1)
-_minnum = Vector{Cuint}(1)
-_relnum = Vector{Cuint}(1)
+const _majnum = Ref{Cuint}()
+const _minnum = Ref{Cuint}()
+const _relnum = Ref{Cuint}()
 function h5_get_libversion()
     status = ccall((:H5get_libversion, libhdf5),
                    Cint,
@@ -39,10 +41,10 @@ function h5_get_libversion()
     if status < 0
         error("Error getting HDF5 library version")
     end
-    convert(Int,_majnum[1]), convert(Int,_minnum[1]), convert(Int,_relnum[1])
+    convert(Int, _majnum[]), convert(Int, _minnum[]), convert(Int, _relnum[])
 end
 
-_libversion = h5_get_libversion()
+const _libversion = h5_get_libversion()
 
 ## C types
 const C_time_t = Int

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -22,9 +22,8 @@ end
 
 function init_libhdf5()
     status = ccall((:H5open, libhdf5), Cint, ())
-    if status < 0
-        error("Can't initialize the HDF5 library")
-    end
+    status < 0 && error("Can't initialize the HDF5 library")
+    nothing
 end
 
 init_libhdf5()

--- a/test/readremote.jl
+++ b/test/readremote.jl
@@ -1,6 +1,5 @@
 using HDF5
 using Base.Test
-using Compat
 
 @testset "readremote" begin
 

--- a/test/readremote.jl
+++ b/test/readremote.jl
@@ -88,7 +88,7 @@ using Compat
     @test d == icmp
     close(fid)
 
-    if HDF5.h5_get_libversion() >= (1, 8, 11)
+    if HDF5.h5_get_libversion() >= v"1.8.11"
       file = getfile("h5ex_t_enumatt.h5")
       fid = h5open(file, "r")
       dset = fid["DS1"]


### PR DESCRIPTION
Also use `VersionNumber` to refer to hdf5 version. Needs to be squashed.