### PR TITLE
Remove plain from export

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -2344,7 +2344,6 @@ export
     o_open,
     p_create,
     parent,
-    plain,
     read,
     readmmap,
     @read,


### PR DESCRIPTION
There is no `plain` function anywhere, is there a reason this is exported, cc @simonster ?