### PR TITLE
validate libhdf5 version in build.jl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,7 +4,7 @@ using BinDeps
 
 # https://support.hdfgroup.org/HDF5/ lists "Current Releases"
 # make sure we have one of those
-MINVERSION = v"1.8.0"
+const MINVERSION = v"1.8.0"
 function h5_get_libversion(n, h)
     f = Libdl.dlsym_e(h, "H5get_libversion")
     majnum, minnum, relnum = Ref{Cuint}(), Ref{Cuint}(), Ref{Cuint}()
@@ -15,8 +15,9 @@ end
 validate(n,h) = h5_get_libversion(n,h) > MINVERSION
 
 if is_linux()
-    hdf5 = library_dependency("libhdf5", aliases = ["libhdf5", "libhdf5_serial", "libhdf5_serial.so.10", "libhdf5_openmpi", "libhdf5_mpich"]
-    ,validate=validate)
+    hdf5 = library_dependency("libhdf5",
+        aliases = ["libhdf5", "libhdf5_serial", "libhdf5_serial.so.10", "libhdf5_openmpi", "libhdf5_mpich"],
+        validate = validate)
     provides(AptGet, "hdf5-tools", hdf5)
     provides(Pacman, "hdf5", hdf5)
     provides(Yum, "hdf5", hdf5)
@@ -24,13 +25,13 @@ end
 
 if is_windows()
     using WinRPM
-    hdf5 = library_dependency("libhdf5",validate=validate)
+    hdf5 = library_dependency("libhdf5", validate = validate)
     provides(WinRPM.RPM, "hdf5", hdf5, os = :Windows )
 end
 
 if is_apple()
     using Homebrew
-    hdf5 = library_dependency("libhdf5",validate=validate)
+    hdf5 = library_dependency("libhdf5", validate = validate)
     provides(Homebrew.HB, "homebrew/science/hdf5", hdf5, os = :Darwin )
 end
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,12 +12,12 @@ function h5_get_libversion(n, h)
     status < 0 && error("Error getting HDF5 library version")
     VersionNumber(majnum[], minnum[], relnum[])
 end
-validate(n,h) = h5_get_libversion(n,h) >= MINVERSION
+compatible_version(n,h) = h5_get_libversion(n,h) >= MINVERSION
 
 if is_linux()
     hdf5 = library_dependency("libhdf5",
         aliases = ["libhdf5", "libhdf5_serial", "libhdf5_serial.so.10", "libhdf5_openmpi", "libhdf5_mpich"],
-        validate = validate)
+        validate=compatible_version)
     provides(AptGet, "hdf5-tools", hdf5)
     provides(Pacman, "hdf5", hdf5)
     provides(Yum, "hdf5", hdf5)
@@ -25,14 +25,14 @@ end
 
 if is_windows()
     using WinRPM
-    hdf5 = library_dependency("libhdf5", validate = validate)
-    provides(WinRPM.RPM, "hdf5", hdf5, os = :Windows )
+    hdf5 = library_dependency("libhdf5", validate=compatible_version)
+    provides(WinRPM.RPM, "hdf5", hdf5, os=:Windows)
 end
 
 if is_apple()
     using Homebrew
-    hdf5 = library_dependency("libhdf5", validate = validate)
-    provides(Homebrew.HB, "homebrew/science/hdf5", hdf5, os = :Darwin )
+    hdf5 = library_dependency("libhdf5", validate=compatible_version)
+    provides(Homebrew.HB, "homebrew/science/hdf5", hdf5, os=:Darwin)
 end
 
 provides(Sources, URI("https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz"), hdf5)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,10 +5,10 @@ using BinDeps
 # https://support.hdfgroup.org/HDF5/ lists "Current Releases"
 # make sure we have one of those
 const MINVERSION = v"1.8.0"
-function h5_get_libversion(n, h)
-    f = Libdl.dlsym_e(h, "H5get_libversion")
+function h5_get_libversion(lib, handle)
+    sym = Libdl.dlsym_e(handle, "H5get_libversion")
     majnum, minnum, relnum = Ref{Cuint}(), Ref{Cuint}(), Ref{Cuint}()
-    status = ccall(f,Cint, (Ptr{Cuint}, Ptr{Cuint}, Ptr{Cuint}), majnum, minnum, relnum)
+    status = ccall(sym, Cint, (Ptr{Cuint}, Ptr{Cuint}, Ptr{Cuint}), majnum, minnum, relnum)
     status < 0 && error("Error getting HDF5 library version")
     VersionNumber(majnum[], minnum[], relnum[])
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,8 +2,21 @@ using BinDeps
 
 @BinDeps.setup
 
+# https://support.hdfgroup.org/HDF5/ lists "Current Releases"
+# make sure we have one of those
+MINVERSION = v"1.8.0"
+function h5_get_libversion(n, h)
+    f = Libdl.dlsym_e(h, "H5get_libversion")
+    majnum, minnum, relnum = Ref{Cuint}(), Ref{Cuint}(), Ref{Cuint}()
+    status = ccall(f,Cint, (Ptr{Cuint}, Ptr{Cuint}, Ptr{Cuint}), majnum, minnum, relnum)
+    status < 0 && error("Error getting HDF5 library version")
+    VersionNumber(majnum[], minnum[], relnum[])
+end
+validate(n,h) = h5_get_libversion(n,h) > MINVERSION
+
 if is_linux()
-    hdf5 = library_dependency("libhdf5", aliases = ["libhdf5", "libhdf5_serial", "libhdf5_serial.so.10", "libhdf5_openmpi", "libhdf5_mpich"])
+    hdf5 = library_dependency("libhdf5", aliases = ["libhdf5", "libhdf5_serial", "libhdf5_serial.so.10", "libhdf5_openmpi", "libhdf5_mpich"]
+    ,validate=validate)
     provides(AptGet, "hdf5-tools", hdf5)
     provides(Pacman, "hdf5", hdf5)
     provides(Yum, "hdf5", hdf5)
@@ -11,13 +24,13 @@ end
 
 if is_windows()
     using WinRPM
-    hdf5 = library_dependency("libhdf5")
+    hdf5 = library_dependency("libhdf5",validate=validate)
     provides(WinRPM.RPM, "hdf5", hdf5, os = :Windows )
 end
 
 if is_apple()
     using Homebrew
-    hdf5 = library_dependency("libhdf5")
+    hdf5 = library_dependency("libhdf5",validate=validate)
     provides(Homebrew.HB, "homebrew/science/hdf5", hdf5, os = :Darwin )
 end
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,7 +12,7 @@ function h5_get_libversion(lib, handle)
     status < 0 && error("Error getting HDF5 library version")
     VersionNumber(majnum[], minnum[], relnum[])
 end
-compatible_version(n,h) = h5_get_libversion(n,h) >= MINVERSION
+compatible_version(lib, handle) = h5_get_libversion(lib, handle) >= MINVERSION
 
 if is_linux()
     hdf5 = library_dependency("libhdf5",

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,7 +12,7 @@ function h5_get_libversion(n, h)
     status < 0 && error("Error getting HDF5 library version")
     VersionNumber(majnum[], minnum[], relnum[])
 end
-validate(n,h) = h5_get_libversion(n,h) > MINVERSION
+validate(n,h) = h5_get_libversion(n,h) >= MINVERSION
 
 if is_linux()
     hdf5 = library_dependency("libhdf5",


### PR DESCRIPTION
This uses the validate functionality in BinDeps to validate the libhdf5 version number in build.jl. It should rebuild if it finds and out of date library. I'm not quite sure what the correct choice of `MINVERSION` is. It seems like this could be useful if people starting having problems with the fact that HDF5-1.8 can't read all files created by HDF5-1.10. I'm not convinced it's necessary, but I figured it would be good to put it out there.