### PR TITLE
Clean up code, put exports at the top and do not reexport already exp…

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -22,6 +22,6 @@ if is_apple()
 end
 
 provides(Sources, URI("https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz"), hdf5)
-provides(BuildProcess, Autotools(libtarget = "libhdf5.la"), hdf5)
+provides(BuildProcess, Autotools(libtarget = joinpath("src", "libhdf5.la")), hdf5)
 
 @BinDeps.install Dict(:libhdf5 => :libhdf5)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -2269,12 +2269,12 @@ const hdf5_prop_get_set = Dict(
 const chunked_props = Set(["compress", "deflate", "blosc", "shuffle"])
 
 # external link
-"
+"""
     create_external(source::Union{HDF5File, HDF5Group}, source_relpath, target_filename, target_path; lcpl_id=HDF5.H5P_DEFAULT, lapl_id=HDF5.H5P.DEFAULT)
 
 Create an external link such that `source[source_relpath]` points to `target_path` within the file with path `target_filename`;
 Calls `[H5Lcreate_external](https://www.hdfgroup.org/HDF5/doc/RM/RM_H5L.html#Link-CreateExternal)`.
-"
+"""
 function create_external(source::Union{HDF5File, HDF5Group}, source_relpath, target_filename, target_path; lcpl_id=H5P_DEFAULT, lapl_id=H5P_DEFAULT)
     h5l_create_external(target_filename, target_path, source.id, source_relpath, lcpl_id, lapl_id)
 end

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1698,7 +1698,7 @@ function hyperslab(dset::HDF5Dataset, indices::Union{Range{Int},Int}...)
         dims, maxdims = get_dims(dspace)
         n_dims = length(dims)
         if length(indices) != n_dims
-            error("Wrong number of indices supplied; supplied indicies of length $(length(indices)) but expected $(n_dims).")
+            error("Wrong number of indices supplied, supplied length $(length(indices)) but expected $(n_dims).")
         end
         dsel_id = h5s_copy(dspace.id)
         dsel_start  = Vector{Hsize}(n_dims)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -2269,11 +2269,14 @@ const hdf5_prop_get_set = Dict(
 const chunked_props = Set(["compress", "deflate", "blosc", "shuffle"])
 
 # external link
-"create_external(source::Union{HDF5File, HDF5Group}, source_relpath, target_filename, target_path; lcpl_id=HDF5.H5P_DEFAULT, lapl_id=HDF5.H5P.DEFAULT)
-Create an external link such that `source[source_relpath]` points to `target_path` within the file with path `target_filename`. Calls `[H5Lcreate_external](https://www.hdfgroup.org/HDF5/doc/RM/RM_H5L.html#Link-CreateExternal)`
+"
+    create_external(source::Union{HDF5File, HDF5Group}, source_relpath, target_filename, target_path; lcpl_id=HDF5.H5P_DEFAULT, lapl_id=HDF5.H5P.DEFAULT)
+
+Create an external link such that `source[source_relpath]` points to `target_path` within the file with path `target_filename`;
+Calls `[H5Lcreate_external](https://www.hdfgroup.org/HDF5/doc/RM/RM_H5L.html#Link-CreateExternal)`.
 "
 function create_external(source::Union{HDF5File, HDF5Group}, source_relpath, target_filename, target_path; lcpl_id=H5P_DEFAULT, lapl_id=H5P_DEFAULT)
-  h5l_create_external(target_filename, target_path, source.id, source_relpath, lcpl_id, lapl_id)
+    h5l_create_external(target_filename, target_path, source.id, source_relpath, lcpl_id, lapl_id)
 end
 
 # error handling
@@ -2306,15 +2309,11 @@ const ASCII_ATTRIBUTE_PROPERTIES = Ref{HDF5Properties}()
 
 const DEFAULT_PROPERTIES = HDF5Properties(H5P_DEFAULT, false)
 
-const DEBUG = haskey(ENV, "DEBUG")
-
 function __init__()
     init_libhdf5()
     register_blosc()
     # Turn off automatic error printing unless DEBUG env variable set
-    if !DEBUG
-        h5e_set_auto(H5E_DEFAULT, C_NULL, C_NULL)
-    end
+    # h5e_set_auto(H5E_DEFAULT, C_NULL, C_NULL)
 
     ASCII_LINK_PROPERTIES[] = p_create(H5P_LINK_CREATE)
     h5p_set_char_encoding(ASCII_LINK_PROPERTIES[].id, H5T_CSET_ASCII)


### PR DESCRIPTION
…orted Base function and also only call `init_libhdf5()` once (inside `__init__`). In addition *turn off automatic error printing* unless in DEBUG mode (it's quite verbose and very unjulian)

In summary
- Move exports to the top
- Do not reexport already exported Base functions that are imported
- Remove extraneous call of `init_libhdf5()`
- Turn off automatic error printing unless DEBUG env variable set
- Do not use `@show` before an error branch