### PR TITLE
Use the BinDeps BSDPkg provider for building on FreeBSD

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
-BinDeps
+BinDeps 0.6.0
 Blosc
 Compat 0.17.0
 @osx Homebrew 0.3.1

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -34,6 +34,10 @@ if is_apple()
     provides(Homebrew.HB, "homebrew/science/hdf5", hdf5, os=:Darwin)
 end
 
+if Sys.KERNEL === :FreeBSD
+    provides(BSDPkg, "hdf5", hdf5, os=:FreeBSD)
+end
+
 provides(Sources, URI("https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0-patch1/src/hdf5-1.10.0-patch1.tar.gz"), hdf5)
 provides(BuildProcess, Autotools(libtarget=joinpath("src", "libhdf5.la")), hdf5)
 


### PR DESCRIPTION
The provider uses the FreeBSD Ports Collection to install the HDF5 library system-wide, as is done with Apt et al. on Linux. The Autotools-based `BuildProcess` fails on FreeBSD.