### PR TITLE
replace unsafe pointer operations with their gc-safe Ref equivalents

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.5
 BinDeps 0.6.0
 Blosc
-Compat 0.17.0
+Compat 0.24.0
 @osx Homebrew 0.3.1
 @windows WinRPM

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -5,13 +5,12 @@ module HDF5
 using Compat
 
 using Base: unsafe_convert
+using Compat: StringVector
 
 import Base:
     close, convert, done, eltype, endof, flush, getindex, ==,
     isempty, isvalid, length, names, ndims, next, parent, read,
     setindex!, show, size, sizeof, start, write, isopen
-
-import Compat: StringVector
 
 export
     # types

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -6,10 +6,12 @@ using Compat
 
 using Base: unsafe_convert
 
-import Base: 
+import Base:
     close, convert, done, eltype, endof, flush, getindex, ==,
     isempty, isvalid, length, names, ndims, next, parent, read,
     setindex!, show, size, sizeof, start, write, isopen
+
+import Compat: StringVector
 
 export
     # types
@@ -1330,7 +1332,7 @@ function read{S<:String}(obj::DatasetOrAttribute, ::Type{S})
     objtype = datatype(obj)
     try
         if h5t_is_variable_str(objtype.id)
-            buf = Ptr{UInt8}[C_NULL]
+            buf = Cstring[C_NULL]
             memtype_id = h5t_copy(H5T_C_S1)
             h5t_set_size(memtype_id, H5T_VARIABLE)
             h5t_set_cset(memtype_id, h5t_get_cset(datatype(obj)))
@@ -1371,10 +1373,10 @@ function read{S<:String}(obj::DatasetOrAttribute, ::Type{Array{S}})
         ret = Array{S}(sz)
         if isvar
             # Variable-length
-            buf = Vector{Ptr{UInt8}}(len)
+            buf = Vector{Cstring}(len)
             h5t_set_size(memtype_id, H5T_VARIABLE)
             readarray(obj, memtype_id, buf)
-            # FIXME? Who owns the memory for each string? Will Julia free it?
+            # FIXME? Who owns the memory for each string? Julia v0.6+ won't free it.
             for i = 1:len
                 ret[i] = unsafe_string(buf[i])
             end
@@ -1384,10 +1386,13 @@ function read{S<:String}(obj::DatasetOrAttribute, ::Type{Array{S}})
             buf = Vector{UInt8}(len*ilen)
             h5t_set_size(memtype_id, ilen)
             readarray(obj, memtype_id, buf)
-            p = pointer(buf)
+            src = 1
             for i = 1:len
-                ret[i] = unsafe_string(p)
-                p += ilen
+                slen = findnext(buf, 0x00, src) - src # find null terminator
+                sv = StringVector(slen)
+                copy!(sv, 1, buf, src, slen)
+                ret[i] = String(sv)
+                src += ilen
             end
         end
     end
@@ -1902,11 +1907,7 @@ function h5a_write{T<:HDF5Scalar}(attr_id::Hid, mem_type_id::Hid, x::T)
     h5a_write(attr_id, mem_type_id, tmp)
 end
 function h5a_write{S<:String}(attr_id::Hid, memtype_id::Hid, strs::Array{S})
-    len = length(strs)
-    p = Array{Ptr{UInt8}}(size(strs))
-    for i = 1:len
-        p[i] = pointer(strs[i])
-    end
+    p = Ref{Cstring}(strs)
     h5a_write(attr_id, memtype_id, p)
 end
 function h5a_write{T<:Union{HDF5Scalar,CharType}}(attr_id::Hid, memtype_id::Hid, v::HDF5Vlen{T})
@@ -1926,11 +1927,11 @@ function h5d_write{T<:HDF5Scalar}(dataset_id::Hid, memtype_id::Hid, x::T)
     h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, tmp)
 end
 function h5d_write{S<:String}(dataset_id::Hid, memtype_id::Hid, strs::Array{S})
-    len = length(strs)
-    p = Array{Ptr{UInt8}}(size(strs))
-    for i = 1:len
-        p[i] = !isassigned(strs, i) || isempty(strs[i]) ? pointer(EMPTY_STRING) : pointer(strs[i])
+    nonnull_str = copy(strs)
+    for i = 1:length(nonnull_str)
+        isassigned(nonnull_str, i) || (nonnull_str[i] = "")
     end
+    p = Ref{Cstring}(nonnull_str)
     h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, p)
 end
 function h5d_write{T<:Union{HDF5Scalar,CharType}}(dataset_id::Hid, memtype_id::Hid, v::HDF5Vlen{T})

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -27,6 +27,8 @@ write(f, "Auint8", convert(Matrix{UInt8}, Ai))
 write(f, "Auint16", convert(Matrix{UInt16}, Ai))
 write(f, "Auint32", convert(Matrix{UInt32}, Ai))
 write(f, "Auint64", convert(Matrix{UInt64}, Ai))
+@test_throws ArgumentError write(f, "truncarr", ["hello","there","\0"]) # don't silently truncate data
+# @test_throws ArgumentError  write(f, "trunc", "\0")
 
 salut = "Hi there"
 ucode = "uniçº∂e"

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -27,8 +27,6 @@ write(f, "Auint8", convert(Matrix{UInt8}, Ai))
 write(f, "Auint16", convert(Matrix{UInt16}, Ai))
 write(f, "Auint32", convert(Matrix{UInt32}, Ai))
 write(f, "Auint64", convert(Matrix{UInt64}, Ai))
-@test_throws ArgumentError write(f, "truncarr", ["hello","there","\0"]) # don't silently truncate data
-# @test_throws ArgumentError  write(f, "trunc", "\0")
 
 salut = "Hi there"
 ucode = "uniçº∂e"
@@ -338,5 +336,13 @@ h5open(joinpath(test_files, "nullterm_ascii.h5"), "r") do fid
 end
 
 @test HDF5.unpad(UInt8[0x43, 0x43, 0x41], 1) == "CCA"
+
+# don't silently truncate data
+fn = tempname()
+f = h5open(fn, "w")
+@test_throws ArgumentError write(f, "test", ["hello","there","\0"])
+# @test_throws ArgumentError  write(f, "trunc", "\0")
+close(f)
+rm(fn)
 
 end # testset plain


### PR DESCRIPTION
Avoids using `pointer` so that Julia can natively track the usage of the objects and ensure it is gc-rooted.