### PR TITLE
homebrew/science/hdf5 deprecated in favour of hdf5.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -31,7 +31,7 @@ end
 
 if is_apple()
     using Homebrew
-    provides(Homebrew.HB, "homebrew/science/hdf5", hdf5, os=:Darwin)
+    provides(Homebrew.HB, "hdf5", hdf5, os=:Darwin)
 end
 
 if Sys.KERNEL === :FreeBSD


### PR DESCRIPTION
Should close #429 