### PR TITLE
Fix #440. Add tests for h5write/read with filename

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -679,7 +679,7 @@ function h5rewrite(f::Function, filename::AbstractString, args...)
 end
 
 function h5write(filename, name::String, data)
-    fid = h5open(filename, "r+")
+    fid = h5open(filename, true, true, true, false, true)
     try
         write(fid, name, data)
     finally

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -111,9 +111,6 @@ W = copy(reshape(1:120, 15, 8))
 Wa = Dict("a" => 1, "b" => 2)
 h5write(fn, "newgroup/W", W)
 h5writeattr(fn, "newgroup/W", Wa)
-# Test the h5read/write interface with a filename as a first argument
-fn2 = tempname()
-h5write(fn2, "newgroup/W", W)
 
 
 # Read the file back in
@@ -253,10 +250,6 @@ Wr = h5read(fn, "newgroup/W", rng)
 War = h5readattr(fn, "newgroup/W")
 @test War == Wa
 
-# Test the h5read interface with a filename as first argument
-Wr = h5read(fn2, "newgroup/W")
-@test Wr == W
-
 # more do syntax
 h5open(fn, "w") do fid
     g_create(fid, "mygroup") do g
@@ -350,6 +343,13 @@ fn = tempname()
 f = h5open(fn, "w")
 @test_throws ArgumentError write(f, "test", ["hello","there","\0"])
 # @test_throws ArgumentError  write(f, "trunc", "\0")
+close(f)
+rm(fn)
+
+# Test the h5read/write interface with a filename as a first argument
+h5write(fn, "newgroup/W", W)
+Wr = h5read(fn, "newgroup/W")
+@test Wr == W
 close(f)
 rm(fn)
 

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -111,6 +111,10 @@ W = copy(reshape(1:120, 15, 8))
 Wa = Dict("a" => 1, "b" => 2)
 h5write(fn, "newgroup/W", W)
 h5writeattr(fn, "newgroup/W", Wa)
+# Test the h5read/write interface with a filename as a first argument
+fn2 = tempname()
+h5write(fn2, "newgroup/W", W)
+
 
 # Read the file back in
 fr = h5open(fn)
@@ -248,6 +252,10 @@ Wr = h5read(fn, "newgroup/W", rng)
 @test Wr == W[rng...]
 War = h5readattr(fn, "newgroup/W")
 @test War == Wa
+
+# Test the h5read interface with a filename as first argument
+Wr = h5read(fn2, "newgroup/W")
+@test Wr == W
 
 # more do syntax
 h5open(fn, "w") do fid

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -346,7 +346,8 @@ f = h5open(fn, "w")
 close(f)
 rm(fn)
 
-# Test the h5read/write interface with a filename as a first argument
+# Test the h5read/write interface with a filename as a first argument, when
+# the file does not exist
 h5write(fn, "newgroup/W", W)
 Wr = h5read(fn, "newgroup/W")
 @test Wr == W

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -112,7 +112,6 @@ Wa = Dict("a" => 1, "b" => 2)
 h5write(fn, "newgroup/W", W)
 h5writeattr(fn, "newgroup/W", Wa)
 
-
 # Read the file back in
 fr = h5open(fn)
 x = read(fr, "Float64")


### PR DESCRIPTION
* It seems like https://github.com/JuliaIO/HDF5.jl/pull/394/files#diff-02840edcdbd42c5b41e89b3f700b9a28L674 inadvetently changed the API of `h5write`, such that the file is expected to exist now.
* I'm adding tests to test for `h5write` and `h5read` with a filename as well.