### PR TITLE
add support for CartesianRange indexing 

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -710,6 +710,12 @@ function h5read(filename, name::String, indices::Tuple{Vararg{Union{Range{Int},I
     dat
 end
 
+function h5read{N}(filename, name::String, cr::CartesianRange{CartesianIndex{N}})
+    # transfer to unit range
+    ur = ( map((x,y)->x:y, cr.start, cr.stop)...)
+    h5read(filename, name, ur)
+end 
+
 function h5writeattr(filename, name::String, data::Dict)
     fid = h5open(filename, "r+")
     try
@@ -958,6 +964,14 @@ function setindex!(p::HDF5Properties, val, name::String)
     funcset(p, val...)
     return p
 end
+
+# cartesian range indexing 
+function setindex!{N}(dset::HDF5Dataset, val, cr::CartesianRange{CartesianIndex{N}})
+    # transfer to unit range 
+    ur = ( map((x,y)->x:y, cr.start, cr.stop)...)
+    setindex!(dset, val, ur)
+end 
+
 # Create a dataset with properties: obj[path, prop1, set1, ...] = val
 function setindex!(parent::Union{HDF5File, HDF5Group}, val, path::String, prop1::String, val1, pv...)
     if !iseven(length(pv))

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -712,7 +712,7 @@ end
 
 function h5read{N}(filename, name::String, cr::CartesianRange{CartesianIndex{N}})
     # transfer to unit range
-    ur = ( map((x,y)->x:y, cr.start, cr.stop)...)
+    ur = map((x,y)->x:y, cr.start.I, cr.stop.I)
     h5read(filename, name, ur)
 end 
 
@@ -851,6 +851,12 @@ root(obj::Union{HDF5Group, HDF5Dataset}) = g_open(file(obj), "/")
 getindex(parent::Union{HDF5File, HDF5Group}, path::String) = o_open(parent, path)
 getindex(dset::HDF5Dataset, name::String) = a_open(dset, name)
 getindex(x::HDF5Attributes, name::String) = a_open(x.parent, name)
+# getindex for cartesian range
+function getindex{N}(dset::HDF5Dataset, cr::CartesianRange{CartesianIndex{N}})
+    # transfer to unit range
+    ur = map((x,y)->x:y, cr.start.I, cr.stop.I) 
+    dset[ur...]
+end 
 
 # Path manipulation
 function joinpathh5(a::String, b::String)
@@ -967,9 +973,10 @@ end
 
 # cartesian range indexing 
 function setindex!{N}(dset::HDF5Dataset, val, cr::CartesianRange{CartesianIndex{N}})
-    # transfer to unit range 
-    ur = ( map((x,y)->x:y, cr.start, cr.stop)...)
-    setindex!(dset, val, ur)
+    # transfer to unit range
+    ur = map((x,y)->x:y, cr.start.I, cr.stop.I)
+    @show ur
+    dset[ur...] = val
 end 
 
 # Create a dataset with properties: obj[path, prop1, set1, ...] = val

--- a/test/cartesian_range.jl
+++ b/test/cartesian_range.jl
@@ -1,0 +1,20 @@
+using HDF5
+using Base.Test
+using Compat
+
+@testset "cartesian_range" begin 
+
+filename = "$(tempname()).h5"
+
+h5write(filename, "main", Array(1:10))
+@test h5read(filename, "main", CartesianRange((3:5,))) == [3:5;]
+f = h5open(filename,"r+")
+dset = f["main"]
+# setindex of cartesian range
+dset[CartesianRange((3:5,))] = [3:5;]
+@test dset[CartesianRange((3:5,))] == [3:5;]
+
+close(f)
+rm(filename)
+
+end # end of testset

--- a/test/cartesian_range.jl
+++ b/test/cartesian_range.jl
@@ -11,8 +11,8 @@ h5write(filename, "main", Array(1:10))
 f = h5open(filename,"r+")
 dset = f["main"]
 # setindex of cartesian range
-dset[CartesianRange((3:5,))] = [3:5;]
-@test dset[CartesianRange((3:5,))] == [3:5;]
+dset[CartesianRange((3:5,))] = [4:6;]
+@test dset[CartesianRange((3:5,))] == [4:6;]
 
 close(f)
 rm(filename)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -102,7 +102,6 @@ d[1,1] = 4
 d = d_create(f, "slab3", datatype(Int), ((10,), (-1,)), "chunk", (5,))
 @test d[:] == zeros(Int, 10)
 d[3:5] = 3:5
-d[CartesianRange((3:5,))] = 3:5
 # Create a dataset designed to be deleted
 f["deleteme"] = 17.2
 close(f)
@@ -192,6 +191,9 @@ target[1] = 4
 @test Xslab2r == target
 dset = fr["slab3"]
 @test dset[3:5] == [3:5;]
+# setindex and getindex of cartesian range
+dset[CartesianRange((3:5,))] = [4:6;]
+@test dset[CartesianRange((3:5,))] == [4:6;]
 emptyr = read(fr, "empty")
 @test isempty(emptyr)
 empty_stringr = read(fr, "empty_string")
@@ -247,6 +249,10 @@ Wr = h5read(fn, "newgroup/W")
 rng = (2:3:15, 3:5)
 Wr = h5read(fn, "newgroup/W", rng)
 @test Wr == W[rng...]
+# test cartesian range
+range = (1:2,1:8)
+Wr = h5read(fn, "newgroup/W", CartesianRange(range))
+@test Wr == W[range...]
 War = h5readattr(fn, "newgroup/W")
 @test War == Wa
 

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -102,6 +102,7 @@ d[1,1] = 4
 d = d_create(f, "slab3", datatype(Int), ((10,), (-1,)), "chunk", (5,))
 @test d[:] == zeros(Int, 10)
 d[3:5] = 3:5
+d[CartesianRange((3:5,))] = 3:5
 # Create a dataset designed to be deleted
 f["deleteme"] = 17.2
 close(f)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -191,9 +191,6 @@ target[1] = 4
 @test Xslab2r == target
 dset = fr["slab3"]
 @test dset[3:5] == [3:5;]
-# setindex and getindex of cartesian range
-dset[CartesianRange((3:5,))] = [4:6;]
-@test dset[CartesianRange((3:5,))] == [4:6;]
 emptyr = read(fr, "empty")
 @test isempty(emptyr)
 empty_stringr = read(fr, "empty_string")
@@ -249,10 +246,6 @@ Wr = h5read(fn, "newgroup/W")
 rng = (2:3:15, 3:5)
 Wr = h5read(fn, "newgroup/W", rng)
 @test Wr == W[rng...]
-# test cartesian range
-range = (1:2,1:8)
-Wr = h5read(fn, "newgroup/W", CartesianRange(range))
-@test Wr == W[range...]
 War = h5readattr(fn, "newgroup/W")
 @test War == Wa
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using HDF5
 using Base.Test
 
 include("plain.jl")
+include("cartesian_range.jl")
 include("readremote.jl")
 include("extend_test.jl")
 include("gc.jl")


### PR DESCRIPTION
CartesianRange is widely used to handle ranges, adding support of CartesianRange to index the arrays inside dataset could make some implementation easier.

These functions were moved from BigArrays.jl
https://github.com/seung-lab/BigArrays.jl/issues/21