### PR TITLE
Do not silently truncate strings with embeded Nulls

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1935,7 +1935,7 @@ end
 function h5d_write{S<:String}(dataset_id::Hid, memtype_id::Hid, strs::Array{S})
     nonnull_str = copy(strs)
     for i = 1:length(nonnull_str)
-        isassigned(nonnull_str, i) || isempty(nonnull_str[i])
+        isassigned(nonnull_str, i) || (nonnull_str[i] = "")
     end
     p = Ref{Cstring}(nonnull_str)
     h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, p)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -345,7 +345,8 @@ end
 fn = tempname()
 f = h5open(fn, "w")
 @test_throws ArgumentError write(f, "test", ["hello","there","\0"])
-# @test_throws ArgumentError  write(f, "trunc", "\0")
+@test_throws ArgumentError write(f, "trunc1", "\0")
+@test_throws ArgumentError write(f, "trunc2", "trunc\0ateme")
 close(f)
 rm(fn)
 


### PR DESCRIPTION
close https://github.com/JuliaIO/HDF5.jl/issues/434

pinging @ggggggggg and @simonster for a review. 
The current behavior is nasty since it silently truncates, e.g,  "SDF\0nooo" to "SDF" 