### PR TITLE
Remove isassigned for writing string arrays

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1922,7 +1922,7 @@ function h5d_write(dataset_id::Hid, memtype_id::Hid, x::T) where {T<:HDF5Scalar}
     h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, tmp)
 end
 function h5d_write(dataset_id::Hid, memtype_id::Hid, strs::Array{S}) where {S<:String}
-    p = Ref{Cstring}(nonnull_str)
+    p = Ref{Cstring}(strs)
     h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, p)
 end
 function h5d_write(dataset_id::Hid, memtype_id::Hid, v::HDF5Vlen{T}) where {T<:Union{HDF5Scalar,CharType}}

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1933,11 +1933,7 @@ function h5d_write{T<:HDF5Scalar}(dataset_id::Hid, memtype_id::Hid, x::T)
     h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, tmp)
 end
 function h5d_write{S<:String}(dataset_id::Hid, memtype_id::Hid, strs::Array{S})
-    nonnull_str = copy(strs)
-    for i = 1:length(nonnull_str)
-        isassigned(nonnull_str, i) || (nonnull_str[i] = "")
-    end
-    p = Ref{Cstring}(nonnull_str)
+    p = Ref{Cstring}(strs)
     h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, p)
 end
 function h5d_write{T<:Union{HDF5Scalar,CharType}}(dataset_id::Hid, memtype_id::Hid, v::HDF5Vlen{T})

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -341,6 +341,16 @@ end
 
 @test HDF5.unpad(UInt8[0x43, 0x43, 0x41], 1) == "CCA"
 
+# Test the h5read/write interface with a filename as a first argument, when
+# the file does not exist
+h5write(fn, "newgroup/W", W)
+Wr = h5read(fn, "newgroup/W")
+@test Wr == W
+close(f)
+rm(fn)
+
+end # testset plain
+
 # test strings with null and undefined references
 @testset "undefined and null" begin
 fn = tempname()
@@ -357,14 +367,4 @@ undefstrarr = similar(Vector(1:3), String) # strs = String[#undef, #undef, #unde
 
 close(f)
 rm(fn)
-end
-	
-# Test the h5read/write interface with a filename as a first argument, when
-# the file does not exist
-h5write(fn, "newgroup/W", W)
-Wr = h5read(fn, "newgroup/W")
-@test Wr == W
-close(f)
-rm(fn)
-
-end # testset plain
+end # testset null and undefined

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -341,15 +341,24 @@ end
 
 @test HDF5.unpad(UInt8[0x43, 0x43, 0x41], 1) == "CCA"
 
-# don't silently truncate data
+# test strings with null and undefined references
+@testset "undefined and null" begin
 fn = tempname()
 f = h5open(fn, "w")
+
+# don't silently truncate data
 @test_throws ArgumentError write(f, "test", ["hello","there","\0"])
 @test_throws ArgumentError write(f, "trunc1", "\0")
 @test_throws ArgumentError write(f, "trunc2", "trunc\0ateme")
+
+# test writing uninitialized string arrays
+undefstrarr = similar(Vector(1:3), String) # strs = String[#undef, #undef, #undef]
+@test_throws UndefRefError h5write(f, "undef", undefstrarr)
+
 close(f)
 rm(fn)
-
+end
+	
 # Test the h5read/write interface with a filename as a first argument, when
 # the file does not exist
 h5write(fn, "newgroup/W", W)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -353,7 +353,7 @@ f = h5open(fn, "w")
 
 # test writing uninitialized string arrays
 undefstrarr = similar(Vector(1:3), String) # strs = String[#undef, #undef, #undef]
-@test_throws UndefRefError h5write(f, "undef", undefstrarr)
+@test_throws UndefRefError write(f, "undef", undefstrarr)
 
 close(f)
 rm(fn)


### PR DESCRIPTION
Right now saving an uninitialized string array, initializes the values to be `""` . I can't think of a good reason to allow this or why anyone would have to save an uninitialized string array. I think this could hide a potential issue/bug, when a user attempts to save a string array (that is believed to have proper references) and HDF5 silently initializes the array to `""`. 


Example (current behavior)
```julia
strs = similar(rand(3),String) # strs = String[#undef, #undef, #undef]
julia> h5write(f,"d",strs)
julia> h5read(f,"d")
3-element Array{String,1}:
 ""
 ""
 ""
```


**vs this pr which instead throws**
```
strs = similar(rand(3),String) # strs = String[#undef, #undef, #undef]
julia> h5write(f,"d",strs)
ERROR: UndefRefError: access to undefined reference
```

