### PR TITLE
WIP: attempt to replicate virtual dataset example

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1196,7 +1196,11 @@ dataspace(n::Void) = HDF5Dataspace(h5s_create(H5S_NULL))
 dataspace(sz::Dims; max_dims::Union{Dims, Tuple{}}=()) = _dataspace(sz, max_dims)
 dataspace(sz1::Int, sz2::Int, sz3::Int...; max_dims::Union{Dims, Tuple{}}=()) = _dataspace(tuple(sz1, sz2, sz3...), max_dims)
 
+"""
+    get_dims(dset::HDF5Dataspace)
 
+Get the dataspace dimensions from a dataset and return a tuple of dims and maxdims.
+"""
 get_dims(dspace::HDF5Dataspace) = h5s_get_simple_extent_dims(dspace.id)
 
 """
@@ -2038,6 +2042,7 @@ for (jlname, h5name, outtype, argtypes, argsyms, msg) in
      (:h5p_set_local_heap_size_hint, :H5Pset_local_heap_size_hint, Herr, (Hid, Cuint), (:fapl_id, :size_hint), "Error setting local heap size hint"),
      (:h5p_set_shuffle, :H5Pset_shuffle, Herr, (Hid,), (:plist_id,), "Error enabling shuffle filter"),
      (:h5p_set_userblock, :H5Pset_userblock, Herr, (Hid, Hsize), (:plist_id, :len), "Error setting userblock"),
+     (:h5p_set_virtual, :H5Pset_virtual, Herr, (Hid, Hid, Ptr{UInt8}, Ptr{UInt8}, Hid), (:dcpl_id, :vspace_id, :src_file_name, :src_dset_name, :src_space_id), "Error setting mapping between virtual and source datasets"),
      (:h5s_close, :H5Sclose, Herr, (Hid,), (:space_id,), "Error closing dataspace"),
      (:h5s_select_hyperslab, :H5Sselect_hyperslab, Herr, (Hid, Cint, Ptr{Hsize}, Ptr{Hsize}, Ptr{Hsize}, Ptr{Hsize}), (:dspace_id, :seloper, :start, :stride, :count, :block), "Error selecting hyperslab"),
      (:h5t_commit, :H5Tcommit2, Herr, (Hid, Ptr{UInt8}, Hid, Hid, Hid, Hid), (:loc_id, :name, :dtype_id, :lcpl_id, :tcpl_id, :tapl_id), "Error committing type"),

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -679,7 +679,7 @@ function h5rewrite(f::Function, filename::AbstractString, args...)
 end
 
 function h5write(filename, name::String, data)
-    fid = h5open(filename, "r+")
+    fid = h5open(filename, true, true, true, false, true)
     try
         write(fid, name, data)
     finally

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -345,4 +345,12 @@ f = h5open(fn, "w")
 close(f)
 rm(fn)
 
+# Test the h5read/write interface with a filename as a first argument, when
+# the file does not exist
+h5write(fn, "newgroup/W", W)
+Wr = h5read(fn, "newgroup/W")
+@test Wr == W
+close(f)
+rm(fn)
+
 end # testset plain

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,10 @@
 using HDF5
 using Base.Test
 
-include("plain.jl")
-include("readremote.jl")
-include("extend_test.jl")
-include("gc.jl")
-include("external.jl")
-include("swmr.jl")
+# include("plain.jl")
+# include("readremote.jl")
+# include("extend_test.jl")
+# include("gc.jl")
+# include("external.jl")
+# include("swmr.jl")
+include("virtual.jl")

--- a/test/virtual.jl
+++ b/test/virtual.jl
@@ -1,0 +1,46 @@
+# roughly following https://support.hdfgroup.org/ftp/HDF5/examples/110/h5_vds.c
+using HDF5
+
+basedir = mktempdir()
+FILE = "vds.h5"
+DATASET = "VDS"
+VDSDIM0 = 4
+VDSDIM1 = 6
+DIM0 = 6
+SRC_FILE = ["a.h5","b.h5","c.h5"]
+SRC_DATASET = ["A","B","C"]
+vdsdims = [VDSDIM0, VDSDIM1]
+dims = [DIM0]
+
+for i=1:3
+    src_file = h5open(SRC_FILE[i],"w")
+    src_file[SRC_DATASET[i]] = collect((i-1)*6+(1:6))
+    close(src_file)
+end
+
+vfile = h5open(FILE,"w")
+
+space = dataspace(VDSDIM0, VDSDIM1)
+dcpl = HDF5.h5p_create(HDF5.H5P_DATASET_CREATE)
+start = [0, 0]
+count = [1, 1]
+block = [1, VDSDIM1]
+
+# watch out!! dataspace(5) creates a scalar dataspace, not a length 5 one dimensional dataspace
+src_space = dataspace((DIM0,))
+for i=1:3
+    start[1]=i-1
+    HDF5.h5s_select_hyperslab(space, HDF5.H5S_SELECT_SET, start, C_NULL, count, block)
+    HDF5.h5p_set_virtual(dcpl, space, SRC_FILE[i], SRC_DATASET[i], src_space)
+end
+
+space = dataspace(VDSDIM1, VDSDIM0) # this seems backwards, but the next line fails without it?
+dset = HDF5.h5d_create(vfile.id, DATASET, HDF5.H5T_NATIVE_INT64, space, HDF5.H5P_DEFAULT, dcpl, HDF5.H5P_DEFAULT)
+close(space)
+close(src_space)
+HDF5.h5d_close(dset)
+close(vfile)
+HDF5.h5p_close(dcpl)
+
+file2 = h5open(FILE,"r")
+@show read(file2[DATASET])


### PR DESCRIPTION
Don't merge this.

I was hoping someone could take a look at this and figure out what I'm doing wrong. 

I added `h5p_set_virtual` then I tried to replicate the example [h5_vds.c](https://support.hdfgroup.org/ftp/HDF5/examples/110/h5_vds.c). But I've failed. I get an error on the last line of `virtual.jl` stating "objects still in open object info set". Additionally, I seem to need a `dataspace` in which the dimensions are reversed from the example in line 38.

If I can help me figure it out, I'll try to create a slightly easier to use API for creating virtual datasets, at least in some easy cases.