### PR TITLE
Enable direct chunk writing

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -2030,7 +2030,7 @@ for (jlname, h5name, outtype, argtypes, argsyms, msg) in
      (:h5d_close, :H5Dclose, Herr, (Hid,), (:dataset_id,), "Error closing dataset"),
      (:h5d_flush, :H5Dflush, Herr, (Hid,), (:dataset_id,), "Error flushing dataset"),
      (:h5d_oappend, :H5DOappend, Herr, (Hid, Hid, Cuint, Hsize, Hid, Ptr{Void}) , (:dset_id, :dxpl_id, :index, :num_elem, :memtype, :buffer), "error appending"),
-     (:h5do_write_chunk, :H5DOwrite_chunk, Herr, (Hid, Hid, Int32, Ptr{Hsize}, Hsize, Ptr{Void}), (:dset_id, :dxpl_id, :filter_mask, :offset, :bufsize, :buf), "Error writing chunk"),
+     (:h5do_write_chunk, :H5DOwrite_chunk, Herr, (Hid, Hid, Int32, Ptr{Hsize}, Csize_t, Ptr{Void}), (:dset_id, :dxpl_id, :filter_mask, :offset, :bufsize, :buf), "Error writing chunk"),
      (:h5d_refresh, :H5Drefresh, Herr, (Hid,), (:dataset_id,), "Error refreshing dataset"),
      (:h5d_set_extent, :H5Dset_extent, Herr, (Hid, Ptr{Hsize}), (:dataset_id, :new_dims), "Error extending dataset dimensions"),
      (:h5d_vlen_get_buf_size, :H5Dvlen_get_buf_size, Herr, (Hid, Hid, Hid, Ptr{Hsize}), (:dset_id, :type_id, :space_id, :buf), "Error getting vlen buffer size"),

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1810,7 +1810,7 @@ function do_write_chunk(dataset::HDF5Dataset, offset, chunk_bytes::Vector{UInt8}
     h5do_write_chunk(dataset, H5P_DEFAULT, UInt32(filter_mask), offs, length(chunk_bytes), chunk_bytes)
 end
 
-immutable HDF5ChunkStorage
+struct HDF5ChunkStorage
     dataset::HDF5Dataset
 end
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -15,7 +15,7 @@ import Base:
 export
     # types
     HDF5Attribute, HDF5File, HDF5Group, HDF5Dataset, HDF5Datatype,
-    HDF5Dataspace, HDF5Object, HDF5Properties, HDF5Vlen,
+    HDF5Dataspace, HDF5Object, HDF5Properties, HDF5Vlen, HDF5ChunkStorage,
     # functions
     a_create, a_delete, a_open, a_read, a_write, attrs,
     d_create, d_create_external, d_open, d_read, d_write,
@@ -1798,6 +1798,20 @@ function d_create_external(parent::Union{HDF5File, HDF5Group}, name::String, fil
 end
 d_create_external(parent::Union{HDF5File, HDF5Group}, name::String, filepath::String, t::Type, sz::Dims) = d_create_external(parent, name, filepath, t, sz, 0)
 
+function do_write_chunk(dataset::HDF5Dataset, offset, chunk_bytes::Vector{UInt8}, filter_mask=0)
+    checkvalid(dataset)
+    offs = collect(Hsize, reverse(offset))-1
+    h5do_write_chunk(dataset, H5P_DEFAULT, UInt32(filter_mask), offs, length(chunk_bytes), chunk_bytes)
+end
+
+immutable HDF5ChunkStorage
+    dataset::HDF5Dataset
+end
+
+function setindex!(chunk_storage::HDF5ChunkStorage, v::Tuple{<:Integer,Vector{UInt8}}, index::Integer...)
+    do_write_chunk(chunk_storage.dataset, Hsize.(index), v[2], UInt32(v[1]))
+end
+
 # end of high-level interface
 
 
@@ -2010,6 +2024,7 @@ for (jlname, h5name, outtype, argtypes, argsyms, msg) in
      (:h5d_close, :H5Dclose, Herr, (Hid,), (:dataset_id,), "Error closing dataset"),
      (:h5d_flush, :H5Dflush, Herr, (Hid,), (:dataset_id,), "Error flushing dataset"),
      (:h5d_oappend, :H5DOappend, Herr, (Hid, Hid, Cuint, Hsize, Hid, Ptr{Void}) , (:dset_id, :dxpl_id, :index, :num_elem, :memtype, :buffer), "error appending"),
+     (:h5do_write_chunk, :H5DOwrite_chunk, Herr, (Hid, Hid, Int32, Ptr{Hsize}, Hsize, Ptr{Void}), (:dset_id, :dxpl_id, :filter_mask, :offset, :bufsize, :buf), "Error writing chunk"),
      (:h5d_refresh, :H5Drefresh, Herr, (Hid,), (:dataset_id,), "Error refreshing dataset"),
      (:h5d_set_extent, :H5Dset_extent, Herr, (Hid, Ptr{Hsize}), (:dataset_id, :new_dims), "Error extending dataset dimensions"),
      (:h5d_vlen_get_buf_size, :H5Dvlen_get_buf_size, Herr, (Hid, Hid, Hid, Ptr{Hsize}), (:dset_id, :type_id, :space_id, :buf), "Error getting vlen buffer size"),

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -353,4 +353,18 @@ Wr = h5read(fn, "newgroup/W")
 close(f)
 rm(fn)
 
+# Test direct chunk writing
+h5open(fn, "w") do f
+  d = d_create(f, "dataset", datatype(Int), dataspace(4, 4), "chunk", (2, 2))
+  raw = HDF5ChunkStorage(d)
+  raw[1,1] = 0, reinterpret(UInt8, [1,2,5,6])
+  raw[3,1] = 0, reinterpret(UInt8, [3,4,7,8])
+  raw[1,3] = 0, reinterpret(UInt8, [9,10,13,14])
+  raw[3,3] = 0, reinterpret(UInt8, [11,12,15,16])
+end
+
+@test h5open(fn, "r") do f
+  vec(f["dataset"][:,:])
+end == collect(1:16)
+
 end # testset plain

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -357,10 +357,10 @@ rm(fn)
 h5open(fn, "w") do f
   d = d_create(f, "dataset", datatype(Int), dataspace(4, 4), "chunk", (2, 2))
   raw = HDF5ChunkStorage(d)
-  raw[1,1] = 0, reinterpret(UInt8, [1,2,5,6])
-  raw[3,1] = 0, reinterpret(UInt8, [3,4,7,8])
-  raw[1,3] = 0, reinterpret(UInt8, [9,10,13,14])
-  raw[3,3] = 0, reinterpret(UInt8, [11,12,15,16])
+  raw[1,1] = 0, collect(reinterpret(UInt8, [1,2,5,6]))
+  raw[3,1] = 0, collect(reinterpret(UInt8, [3,4,7,8]))
+  raw[1,3] = 0, collect(reinterpret(UInt8, [9,10,13,14]))
+  raw[3,3] = 0, collect(reinterpret(UInt8, [11,12,15,16]))
 end
 
 @test h5open(fn, "r") do f


### PR DESCRIPTION
Direct chunk writing speeds up creation of large chunked and compressed files in parallel environments by allowing workers to compress the chunks in parallel.  It's a cumbersome interface, but can provide significant speedup in data preparation steps, for example, where other file formats are converted to HDF5.