### PR TITLE
Add support for MPIO and major rework HDF5 property handling

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -17,7 +17,7 @@ end
 compatible_version(lib, handle) = h5_get_libversion(lib, handle) >= MINVERSION
 
 hdf5 = library_dependency("libhdf5",
-    aliases = ["libhdf5", "libhdf5_serial", "libhdf5_serial.so.10", "libhdf5_openmpi", "libhdf5_mpich"],
+    aliases = ["libhdf5_openmpi", "libhdf5_mpich", "libhdf5", "libhdf5_serial", "libhdf5_serial.so.10" ],
     validate=compatible_version)
 
 provides(AptGet, "hdf5-tools", hdf5, os=:Linux)

--- a/doc/hdf5.md
+++ b/doc/hdf5.md
@@ -36,6 +36,9 @@ The mode can be any one of the following:
     <td>"r+"</td> <td>read-write, preserving any existing contents</td>
   </tr>
   <tr>
+    <td>"cw"</td> <td>read-write, create file if not existing, preserve existing contents</td>
+  </tr>
+  <tr>
     <td>"w"</td> <td>read-write, destroying any existing contents (if any)</td>
   </tr>
 </table>
@@ -95,6 +98,39 @@ Datasets can be created with either
 g["mydataset"] = rand(3,5)
 write(g, "mydataset", rand(3,5))
 ```
+
+Passing parameters
+------------------------
+
+It is often required to pass parameters to specific routines, which are collected 
+in so-called property lists in HDF5. There are different property lists for
+different tasks, e.g. for the access/creation of files, datasets, groups.
+In this high level framework multiple parameters can be simply applied by
+appending them at the end of function calls as a list of key/value pairs.
+
+```julia
+g["A"] = A  # basic
+g["A", "chunk", (5,5)] = A # add chunks
+
+B=h5read(fn,"mygroup/B", # two parameters
+  "fapl_mpio", (ccomm,cinfo), # if parameter requires multiple args use tuples
+  "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE ) 
+```
+
+This will automatically create the correct property lists, add the properties,
+and apply the property list while reading/writing the data.
+The naming of the properties generally follows that of HDF5, i.e. the key
+`fapl_mpio` returns the HDF5 functions `h5pget/set_fapl_mpio` and their
+corresponding property list type `H5P_FILE_ACCESS`.
+The complete list if routines and their interfaces is available at the
+[H5P: Property List Interface](https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html)
+documentation. Note that not all properties are available. When searching
+for a property check whether the corresponding `h5pget/set` functions are
+available.
+
+
+Chunking and compression
+------------------------
 
 You can also optionally "chunk" and/or compress your data. For example,
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -2,10 +2,15 @@ __precompile__()
 
 module HDF5
 
-using Compat
+using Compat: 
+    AbstractRange, @compat, equalto, StringVector, findfirst
 
+<<<<<<< HEAD
 using Base: unsafe_convert, StringVector
 using Compat: findfirst
+=======
+using Base: unsafe_convert
+>>>>>>> Bump Compat version and explicitly specify all used symbols. Remove readp and add dummy variable to read instead, to avoid conflicts between read with parameters and read for multiple datasets.
 
 import Base:
     close, convert, done, eltype, endof, flush, getindex, ==,
@@ -26,7 +31,7 @@ export
     h5open, h5read, h5rewrite, h5writeattr, h5readattr, h5write,
     has, iscontiguous, ishdf5, ismmappable, name,
     o_copy, o_delete, o_open, p_create,
-    readmmap, @read, readp, @write, root, set_dims!, t_create, t_commit
+    readmmap, @read, @write, root, set_dims!, t_create, t_commit
 
 include("datafile.jl")
 
@@ -1283,14 +1288,9 @@ for (fsym, osym, ptype) in
     end
 end
 
-# Datafile.jl defines generic read for multiple datasets, so we cannot add properties here. Define readp as read with props.
-function read(parent::Union{HDF5File, HDF5Group}, name::String)
-    obj = parent[name]
-    val = read(obj)
-    close(obj)
-    val
-end
-function readp(parent::Union{HDF5File, HDF5Group}, name::String, pv...)
+# Datafile.jl defines generic read for multiple datasets, so we cannot simply add properties here.
+# Add `withargs` as unused dummy argument, to provide a distinct interface and enable arguments.
+function read(parent::Union{HDF5File, HDF5Group}, name::String, withargs::Bool=true, pv...)
     obj = parent[name, pv...]
     val = read(obj)
     close(obj)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -649,7 +649,7 @@ end
 Open or create an HDF5 file where `mode` is one of:
  - "r"  read only
  - "r+" read and write
- - "cw" read and write, create file if not existing, to not truncate
+ - "cw" read and write, create file if not existing, do not truncate
  - "w"  read and write, create a new file (destroys any existing contents)
 
 Pass `swmr=true` to enable (Single Writer Multiple Reader) SWMR write access for "w" and
@@ -2290,18 +2290,14 @@ function h5l_get_info(link_loc_id::Hid, link_name::String, lapl_id::Hid)
     info[]
 end
 
-"""
-Set MPIO properties in HDF5.
-Note: HDF5 creates a COPY of the comm and info objects.
-"""
+# Set MPIO properties in HDF5.
+# Note: HDF5 creates a COPY of the comm and info objects.
 function h5p_set_fapl_mpio(fapl_id,comm,info)
     h5comm = h5_mpihandle(comm)
     h5info = h5_mpihandle(info)
     sizeof(comm) == 4 ? h5p_set_fapl_mpio32(fapl_id, comm, info) : h5p_set_fapl_mpio64(fapl_id, comm, info)
 end
-"""
-Retrieves the copies of the comm and info MPIO objects from the HDF5 property list. 
-"""
+# Retrieves the copies of the comm and info MPIO objects from the HDF5 property list. 
 function h5p_get_fapl_mpio(fapl_id,h)
     comm, info = Ref{h}(), Ref{h}()
     h == Hmpih32 ? h5p_get_fapl_mpio32(fapl_id, comm, info) : h5p_get_fapl_mpio64(fapl_id, comm, info)
@@ -2425,18 +2421,26 @@ end
 end
 
 # Map property names to function and attribute symbol
+# Property names should follow the naming introduced by HDF5, i.e.
+# keyname => (h5p_get_keyname, h5p_set_keyname, id )
 const hdf5_prop_get_set = Dict(
-    "blosc"         => (nothing, h5p_set_blosc,                   H5P_DATASET_CREATE),
-    "chunk"         => (get_chunk, set_chunk,                     H5P_DATASET_CREATE),
-    "compress"      => (nothing, h5p_set_deflate,                 H5P_DATASET_CREATE),
-    "deflate"       => (nothing, h5p_set_deflate,                 H5P_DATASET_CREATE),
-    "fclose_degree" => (get_fclose_degree, h5p_set_fclose_degree, H5P_FILE_ACCESS),
-    "layout"        => (h5p_get_layout, h5p_set_layout,           H5P_DATASET_CREATE),
-    "libver_bounds" => (get_libver_bounds, h5p_set_libver_bounds, H5P_FILE_ACCESS),
-    "shuffle"       => (nothing, h5p_set_shuffle,                 H5P_DATASET_CREATE),
-    "userblock"     => (get_userblock, h5p_set_userblock,         H5P_FILE_CREATE),
-    "fapl_mpio"     => (h5p_get_fapl_mpio, h5p_set_fapl_mpio,     H5P_FILE_ACCESS),
-    "dxpl_mpio"     => (h5p_get_dxpl_mpio, h5p_set_dxpl_mpio,     H5P_DATASET_XFER),
+    "blosc"         => (nothing, h5p_set_blosc,                       H5P_DATASET_CREATE),
+    "char_encoding" => (nothing, h5p_set_char_encoding,               H5P_LINK_CREATE),
+    "chunk"         => (get_chunk, set_chunk,                         H5P_DATASET_CREATE),
+    "compress"      => (nothing, h5p_set_deflate,                     H5P_DATASET_CREATE),
+    "create_intermediate_group" => (nothing, h5p_set_create_intermediate_group, H5P_LINK_CREATE),
+    "deflate"       => (nothing, h5p_set_deflate,                     H5P_DATASET_CREATE),
+    "driver"        => (h5p_get_driver, nothing,                      H5P_FILE_ACCESS),
+    "driver_info"   => (h5p_get_driver_info, nothing,                 H5P_FILE_ACCESS),
+    "external"      => (nothing, h5p_set_external,                    H5P_DATASET_CREATE),
+    "fclose_degree" => (get_fclose_degree, h5p_set_fclose_degree,     H5P_FILE_ACCESS),
+    "layout"        => (h5p_get_layout, h5p_set_layout,               H5P_DATASET_CREATE),
+    "libver_bounds" => (get_libver_bounds, h5p_set_libver_bounds,     H5P_FILE_ACCESS),
+    "local_heap_size_hint" => (nothing, h5p_set_local_heap_size_hint, H5P_GROUP_CREATE),
+    "shuffle"       => (nothing, h5p_set_shuffle,                     H5P_DATASET_CREATE),
+    "userblock"     => (get_userblock, h5p_set_userblock,             H5P_FILE_CREATE),
+    "fapl_mpio"     => (h5p_get_fapl_mpio, h5p_set_fapl_mpio,         H5P_FILE_ACCESS),
+    "dxpl_mpio"     => (h5p_get_dxpl_mpio, h5p_set_dxpl_mpio,         H5P_DATASET_XFER),
 )
 
 # properties that require chunks in order to work (e.g. any filter)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1356,7 +1356,7 @@ end
 # Clean up string buffer according to padding mode
 function unpad(s::String, pad::Integer)
     if pad == H5T_STR_NULLTERM
-        v = findfirst(equalto('\0'), s)
+        v = findfirst(isequal('\0'), s)
         v === nothing ? s : s[1:v-1]
     elseif pad == H5T_STR_NULLPAD
         rstrip(s, '\0')

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1361,7 +1361,7 @@ end
 # Clean up string buffer according to padding mode
 function unpad(s::String, pad::Integer)
     if pad == H5T_STR_NULLTERM
-        v = findfirst(isequal('\0'),s)
+        v = Compat.findfirst(equalto('\0'), s)
         v === nothing ? s : s[1:v-1]
     elseif pad == H5T_STR_NULLPAD
         rstrip(s, '\0')

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -152,7 +152,7 @@ const H5O_TYPE_GROUP   = 0
 const H5O_TYPE_DATASET = 1
 const H5O_TYPE_NAMED_DATATYPE = 2
 # Property constants
-const H5P_DEFAULT          = 0
+const H5P_DEFAULT          = convert(Hid, 0)
 const H5P_OBJECT_CREATE    = read_const(libversion >= v"1.8.14" ? :H5P_CLS_OBJECT_CREATE_ID_g    : :H5P_CLS_OBJECT_CREATE_g)
 const H5P_FILE_CREATE      = read_const(libversion >= v"1.8.14" ? :H5P_CLS_FILE_CREATE_ID_g      : :H5P_CLS_FILE_CREATE_g)
 const H5P_FILE_ACCESS      = read_const(libversion >= v"1.8.14" ? :H5P_CLS_FILE_ACCESS_ID_g      : :H5P_CLS_FILE_ACCESS_g)
@@ -2366,10 +2366,10 @@ function hdf5array(objtype)
 end
 
 ### Property manipulation ###
-get_create_properties(dset::HDF5Dataset) = HDF5Properties(h5d_get_create_plist(dset.id))
-get_create_properties(g::HDF5Group) = HDF5Properties(h5g_get_create_plist(dset.id),class=:gcpl)
-get_create_properties(g::HDF5File) = HDF5Properties(h5f_get_create_plist(dset.id))
-get_create_properties(g::HDF5Attribute) = HDF5Properties(h5a_get_create_plist(dset.id))
+get_create_properties(d::HDF5Dataset)   = HDF5Properties(h5d_get_create_plist(d.id),true,H5P_DATASET_CREATE)
+get_create_properties(g::HDF5Group)     = HDF5Properties(h5g_get_create_plist(g.id),true,H5P_GROUP_CREATE)
+get_create_properties(f::HDF5File)      = HDF5Properties(h5f_get_create_plist(f.id),true,H5P_FILE_CREATE)
+get_create_properties(a::HDF5Attribute) = HDF5Properties(h5a_get_create_plist(a.id),true,H5P_ATTRIBUTE_CREATE)
 function get_chunk(p::HDF5Properties)
     n = h5p_get_chunk(p, 0, C_NULL)
     cdims = Vector{Hsize}(undef,n)

--- a/test/mpio.jl
+++ b/test/mpio.jl
@@ -1,0 +1,68 @@
+using Compat
+using MPI
+using HDF5
+using Base.Test
+
+MPI.Init()
+info=MPI.Info()
+
+h = HDF5.mpihandles[sizeof(MPI.CComm)]
+if MPI.HAVE_MPI_COMM_C2F
+    ccomm=ccall(:MPI_Comm_f2c, h, (Cint,), MPI.COMM_WORLD.val)
+    cinfo=ccall(:MPI_Info_f2c, h, (Cint,), info.val)
+elseif sizeof(MPI.CComm) == sizeof(Cint)
+    ccomm = reinterpret(h, MPI.COMM_WORLD.val)
+    cinfo = reinterpret(h, info.val)
+end
+
+@testset "mpio" begin
+
+nprocs = MPI.Comm_size(MPI.COMM_WORLD)
+myrank = MPI.Comm_rank(MPI.COMM_WORLD)
+
+fileprop=p_create(HDF5.H5P_FILE_ACCESS)
+HDF5.h5p_set_fapl_mpio(fileprop,ccomm,cinfo)
+h5comm,h5info=HDF5.h5p_get_fapl_mpio(fileprop,h)
+
+# compare the pointer in case of OpenMPI
+if h == HDF5.Hmpih64
+  c2 = unsafe_load(reinterpret(Ptr{Clong},ccomm))
+  c3 = unsafe_load(reinterpret(Ptr{Clong},h5comm))
+  #
+  @test c2 == c3
+end
+
+# open file in parallel and write dataset
+fn = String(MPI.bcast(collect(tempname()),0,MPI.COMM_WORLD))
+f = h5open(fn, "w", "fapl_mpio", (ccomm,cinfo) )
+@test isopen(f)
+
+g = g_create(f, "mygroup")
+A=[myrank+i for i=1:10]
+dset = d_create(g, "B", datatype(Int64), dataspace(10,nprocs), "chunk", (10,1), "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
+dset[:,myrank+1] = A
+close(f)
+
+
+MPI.Barrier(MPI.COMM_WORLD)
+f = h5open(String(fn), "r", "fapl_mpio", (ccomm,cinfo))
+@test isopen(f)
+@test names(f) == ["mygroup"]
+# read(f, name, pv...) is already taken by multi-dataset read
+B=readp(f, "mygroup/B", "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
+@test !isempty(B)
+@test A == vec(B[:,myrank+1])
+B=f["mygroup/B", "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE]
+@test !isempty(B)
+@test A == vec(B[:,myrank+1])
+close(f)
+
+MPI.Barrier(MPI.COMM_WORLD)
+B=h5read(fn,"mygroup/B", "fapl_mpio", (ccomm,cinfo), "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
+@test A == vec(B[:,myrank+1])
+MPI.Barrier(MPI.COMM_WORLD)
+B=h5read(fn, "mygroup/B", (:,myrank+1), "fapl_mpio", (ccomm,cinfo), "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
+@test A == vec(B)
+MPI.Barrier(MPI.COMM_WORLD)
+
+end # testset mpio

--- a/test/mpio.jl
+++ b/test/mpio.jl
@@ -48,8 +48,8 @@ MPI.Barrier(MPI.COMM_WORLD)
 f = h5open(String(fn), "r", "fapl_mpio", (ccomm,cinfo))
 @test isopen(f)
 @test names(f) == ["mygroup"]
-# read(f, name, pv...) is already taken by multi-dataset read
-B=readp(f, "mygroup/B", "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
+# read(f, name, pv...) is already taken by multi-dataset read, bool withargs is only dummy argument
+B=read(f, "mygroup/B", true, "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
 @test !isempty(B)
 @test A == vec(B[:,myrank+1])
 B=f["mygroup/B", "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE]

--- a/test/mpio.jl
+++ b/test/mpio.jl
@@ -3,66 +3,67 @@ using MPI
 using HDF5
 using Base.Test
 
+@testset "mpio" begin
+
 MPI.Init()
-info=MPI.Info()
+info = MPI.Info()
 
 h = HDF5.mpihandles[sizeof(MPI.CComm)]
-if MPI.HAVE_MPI_COMM_C2F
-    ccomm=ccall(:MPI_Comm_f2c, h, (Cint,), MPI.COMM_WORLD.val)
-    cinfo=ccall(:MPI_Info_f2c, h, (Cint,), info.val)
-elseif sizeof(MPI.CComm) == sizeof(Cint)
-    ccomm = reinterpret(h, MPI.COMM_WORLD.val)
-    cinfo = reinterpret(h, info.val)
-end
-
-@testset "mpio" begin
+ccomm = reinterpret(h, MPI.CComm(MPI.COMM_WORLD))
+cinfo = reinterpret(h, MPI.CInfo(info))
 
 nprocs = MPI.Comm_size(MPI.COMM_WORLD)
 myrank = MPI.Comm_rank(MPI.COMM_WORLD)
 
-fileprop=p_create(HDF5.H5P_FILE_ACCESS)
-HDF5.h5p_set_fapl_mpio(fileprop,ccomm,cinfo)
-h5comm,h5info=HDF5.h5p_get_fapl_mpio(fileprop,h)
+fileprop = p_create(HDF5.H5P_FILE_ACCESS)
+HDF5.h5p_set_fapl_mpio(fileprop, ccomm, cinfo)
+h5comm, h5info = HDF5.h5p_get_fapl_mpio(fileprop, h)
 
 # compare the pointer in case of OpenMPI
 if h == HDF5.Hmpih64
-  c2 = unsafe_load(reinterpret(Ptr{Clong},ccomm))
-  c3 = unsafe_load(reinterpret(Ptr{Clong},h5comm))
+  c2 = unsafe_load(reinterpret(Ptr{Clong}, ccomm))
+  c3 = unsafe_load(reinterpret(Ptr{Clong}, h5comm))
   #
   @test c2 == c3
 end
 
 # open file in parallel and write dataset
-fn = String(MPI.bcast(collect(tempname()),0,MPI.COMM_WORLD))
-f = h5open(fn, "w", "fapl_mpio", (ccomm,cinfo) )
+fn = String(MPI.bcast(collect(tempname()), 0, MPI.COMM_WORLD))
+f = h5open(fn, "w", "fapl_mpio", (ccomm, cinfo) )
 @test isopen(f)
 
 g = g_create(f, "mygroup")
-A=[myrank+i for i=1:10]
-dset = d_create(g, "B", datatype(Int64), dataspace(10,nprocs), "chunk", (10,1), "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
+A = [ myrank + i for i = 1:10]
+dset = d_create(g, "B", datatype(Int64), dataspace(10, nprocs), "chunk", (10, 1), "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
 dset[:,myrank+1] = A
 close(f)
 
 
 MPI.Barrier(MPI.COMM_WORLD)
-f = h5open(String(fn), "r", "fapl_mpio", (ccomm,cinfo))
+f = h5open(String(fn), "r", "fapl_mpio", (ccomm, cinfo))
 @test isopen(f)
 @test names(f) == ["mygroup"]
 # read(f, name, pv...) is already taken by multi-dataset read, bool withargs is only dummy argument
 B=read(f, "mygroup/B", true, "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
 @test !isempty(B)
-@test A == vec(B[:,myrank+1])
+@test A == vec(B[:, myrank + 1])
 B=f["mygroup/B", "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE]
 @test !isempty(B)
-@test A == vec(B[:,myrank+1])
+@test A == vec(B[:, myrank + 1])
 close(f)
 
 MPI.Barrier(MPI.COMM_WORLD)
-B=h5read(fn,"mygroup/B", "fapl_mpio", (ccomm,cinfo), "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
-@test A == vec(B[:,myrank+1])
+B = h5read(fn, "mygroup/B", "fapl_mpio", (ccomm, cinfo), "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
+@test A == vec(B[:, myrank + 1])
 MPI.Barrier(MPI.COMM_WORLD)
-B=h5read(fn, "mygroup/B", (:,myrank+1), "fapl_mpio", (ccomm,cinfo), "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
+B = h5read(fn, "mygroup/B", (:, myrank + 1), "fapl_mpio", (ccomm, cinfo), "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
 @test A == vec(B)
+
+# we need to close HDF5 and finalize the info object before finalizing MPI
+finalize(info)
+HDF5.h5_close()
 MPI.Barrier(MPI.COMM_WORLD)
+MPI.Finalize()
 
 end # testset mpio
+

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -333,9 +333,9 @@ close(fd)
 rm(fn)
 
 # File creation and access property lists
-cpl = HDF5Properties(p_create(HDF5.H5P_FILE_CREATE))
+cpl = p_create(HDF5.H5P_FILE_CREATE)
 cpl["userblock"] = 1024
-apl = HDF5Properties(p_create(HDF5.H5P_FILE_ACCESS))
+apl = p_create(HDF5.H5P_FILE_ACCESS)
 apl["libver_bounds"] = (HDF5.H5F_LIBVER_EARLIEST, HDF5.H5F_LIBVER_LATEST)
 h5open(fn, false, true, true, true, false, cpl, apl) do fid
     write(fid, "intarray", [1, 2, 3])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,3 +8,7 @@ include("extend_test.jl")
 include("gc.jl")
 include("external.jl")
 include("swmr.jl")
+if Pkg.installed("MPI") != nothing
+  # basic MPI tests, for actual parallel tests we need to run in MPI mode
+  include("mpio.jl")
+end


### PR DESCRIPTION
I was quite astonished that the HDF5 wrapper did not yet have support for MPIO since this is quite important on clusters.

 - Add support for MPIO: this is implemented using a thin wrapper  
   without adding a dependency to MPI.jl. This requires at opening
   a file in MPIO mode, thus setting file access / file creation
   properties and setting the dataset transfer property directly when
   writing a dataset. The latter has been implementing by extending the
   dataset struct itself by a xfer property, which can be used when
   writing the dataset. The type wrapper provides primitive type handles
   of size 4 and 8 byte, which should account for MPICH/OpenMPI.
   The particular implementation needs to be provided by the user.
 - MPIO in HDF5 partially depends on MPI.jl supporting MPI_Info or some 
   other method to provide that data. There's another [pull request](https://github.com/JuliaParallel/MPI.jl/pull/198) of mine over
   at MPI.jl adding that support, which has been dangling around for some 
  months without comments.
   MPI sadly does not see to much support and enthusiasm in Julia for sure.
  Hopefully this merge request here will speed up things.

 - These changes required some massive rework of the various properties
   that HDF5 provides. HDF5.jl has been mostly operating using standard
   properties in nearly every case. Most routines have been extended to
   take a set of properties consisting of key value pairs. The property
   get/set dict has been extended by the property identifiers. This now
   permits creating the specific properties (dcpl, dapl, fapl, dxpl,...)
   just using the list of keys. These are now passed through most
   routines so we should be able to set nearly all properties that HDF5
   provides. In addition to that there are some minor bugfixes and
   additions.
 - `read(parent, name::String...)` is a special case, since in datafile.jl
   it is overloaded for reading multiple datasets. However this
   conflicts with function signature of the the property list implementation.
   The particular routine thus has been renamed `readp(parent, name, pv...)`.
 - The libhdf5 aliases are updated to preferably use parallel HDF5
   versions.
 - Some tests are added. By default the MPIO will be tested in serial
   mode. For parallel tests we need to execute mpirun.
 - Fixed a wrong prop setting in the h5p_get/set_driver/info setting.
