### PR TITLE
fix deprecations of cfunction

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 BinDeps 0.6.0
 Blosc
-Compat 0.61.0
+Compat 0.68.0
 @osx Homebrew 0.3.1
 @windows WinRPM

--- a/src/blosc_filter.jl
+++ b/src/blosc_filter.jl
@@ -119,10 +119,10 @@ end
 
 # register the Blosc filter function with HDF5
 function register_blosc()
-    c_blosc_set_local = cfunction(blosc_set_local, Herr, Tuple{Hid,Hid,Hid})
-    c_blosc_filter = cfunction(blosc_filter, Csize_t,
-                               Tuple{Cuint, Csize_t, Ptr{Cuint}, Csize_t,
-                                     Ptr{Csize_t}, Ptr{Ptr{Cvoid}}})
+    c_blosc_set_local = @cfunction(blosc_set_local, Herr, (Hid,Hid,Hid))
+    c_blosc_filter = @cfunction(blosc_filter, Csize_t,
+                                (Cuint, Csize_t, Ptr{Cuint}, Csize_t,
+                                 Ptr{Csize_t}, Ptr{Ptr{Cvoid}}))
     if ccall((:H5Zregister, libhdf5), Herr, (Ref{H5Z_class2_t},),
              H5Z_class2_t(H5Z_CLASS_T_VERS,
                           FILTER_BLOSC,


### PR DESCRIPTION
This fixes deprecations of the cfunction syntax on Julia 0.7.0-beta.

```
┌ Warning: The function `cfunction` is now written as a macro `@cfunction`.
│   caller = register_blosc() at blosc_filter.jl:122
└ @ HDF5 blosc_filter.jl:122
┌ Warning: The function `cfunction` is now written as a macro `@cfunction`.
│   caller = register_blosc() at blosc_filter.jl:123
└ @ HDF5 blosc_filter.jl:123
```