### PR TITLE
Fix depwarns on julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
     - osx
 julia:
     - 0.6
+    - 0.7
     - nightly
 notifications:
     email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 using HDF5
 using Compat.Test
 using Compat.Distributed
+@static if VERSION ≥ v"0.7.0-DEV.3637"
+    using Pkg
+end
 
 println("HDF5 version ", HDF5.h5_get_libversion())
 

--- a/test/swmr.jl
+++ b/test/swmr.jl
@@ -39,7 +39,7 @@ function dataset_write(d, ch_written, ch_read)
     for i = 1:10
         @assert take!(ch_read) == true
         set_dims!(d, (i*10,))
-        inds = (1:10) + (i - 1) * 10
+        inds::UnitRange{Int} = VERSION < v"0.7.0-DEV.1759" ? (1:10) + (i - 1) * 10 : (1:10) .+ (i - 1) * 10
         d[inds] = inds
         flush(d) # flush the dataset
         put!(ch_written,i)


### PR DESCRIPTION
With this, tests pass (locally) without deprecation warnings on both 0.6 and 0.7.
It also fixes a warning about using Mmap, which doesn't appear in HDF5 tests but appears when running JLD tests.

It also enables CI testing on 0.7.