### PR TITLE
Workaround for mmap issues with Julia 0.7

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1630,7 +1630,9 @@ function readmmap(obj::HDF5Dataset, ::Type{Array{T}}) where {T}
     if offset == reinterpret(Hsize, convert(Hssize, -1))
         error("Error mmapping array")
     end
-    Mmap.mmap(fdio(fd), Array{T,length(dims)}, dims, offset)
+    # Mmap.mmap(fdio(fd), Array{T,length(dims)}, dims, offset) # does not work on julia 0.7
+    A = Mmap.mmap(fdio(fd), Array{UInt8,1}, prod(dims)*sizeof(T), offset)
+    return reshape(reinterpret(T,A),dims)
 end
 
 function readmmap(obj::HDF5Dataset)


### PR DESCRIPTION
This is a workaround for the alignment issue within Julia 0.7 and higher. I ask @Keno: Is this the official workaround? Will the `reinterpret` be fast in the future? @vtjnash indicated in https://github.com/JuliaLang/julia/issues/28424 that `reinterpret` is slow and in turn this workaround should not be baked into the `mmap` function directly (where it IMHO belongs).