### PR TITLE
Implement julia 0.7 iteration protocol

### DIFF
--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -2,3 +2,4 @@ builds
 src
 deps.jl
 downloads
+build.log


### PR DESCRIPTION
The old start/next/done protocol was deprecated during the beta phase.
(This also adds deps/build.log in .gitignore while at it.)

When this is merged it would be a good idea to tag a new release I guess.
