### PR TITLE
Expose H5Pset_obj_track_times object creation property

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -2107,6 +2107,7 @@ for (jlname, h5name, outtype, argtypes, argsyms, msg) in
      (:h5p_set_local_heap_size_hint, :H5Pset_local_heap_size_hint, Herr, (Hid, Cuint), (:fapl_id, :size_hint), "Error setting local heap size hint"),
      (:h5p_set_shuffle, :H5Pset_shuffle, Herr, (Hid,), (:plist_id,), "Error enabling shuffle filter"),
      (:h5p_set_userblock, :H5Pset_userblock, Herr, (Hid, Hsize), (:plist_id, :len), "Error setting userblock"),
+     (:h5p_set_obj_track_times, :H5Pset_obj_track_times, Herr, (Hid, UInt8), (:plist_id, :track_times), "Error setting object time tracking"),
      (:h5s_close, :H5Sclose, Herr, (Hid,), (:space_id,), "Error closing dataspace"),
      (:h5s_select_hyperslab, :H5Sselect_hyperslab, Herr, (Hid, Cint, Ptr{Hsize}, Ptr{Hsize}, Ptr{Hsize}, Ptr{Hsize}), (:dspace_id, :seloper, :start, :stride, :count, :block), "Error selecting hyperslab"),
      (:h5t_commit, :H5Tcommit2, Herr, (Hid, Ptr{UInt8}, Hid, Hid, Hid, Hid), (:loc_id, :name, :dtype_id, :lcpl_id, :tcpl_id, :tapl_id), "Error committing type"),
@@ -2443,6 +2444,7 @@ const hdf5_prop_get_set = Dict(
     "userblock"     => (get_userblock, h5p_set_userblock,             H5P_FILE_CREATE),
     "fapl_mpio"     => (h5p_get_fapl_mpio, h5p_set_fapl_mpio,         H5P_FILE_ACCESS),
     "dxpl_mpio"     => (h5p_get_dxpl_mpio, h5p_set_dxpl_mpio,         H5P_DATASET_XFER),
+    "track_times"   => (nothing, h5p_set_obj_track_times,             H5P_OBJECT_CREATE),
 )
 
 # properties that require chunks in order to work (e.g. any filter)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -1,4 +1,5 @@
 using HDF5
+using CRC32c
 using Test
 
 @testset "plain" begin
@@ -380,6 +381,16 @@ if !isempty(HDF5.libhdf5_hl)
     close(f)
     rm(fn)
 end
+
+# Test that switching time tracking off results in identical files
+h5open("tt1.h5", "w") do f
+    f["x", "track_times", false] = [1, 2, 3]
+end
+h5open("tt2.h5", "w") do f
+    f["x", "track_times", false] = [1, 2, 3]
+end
+
+@test open(crc32c, "tt1.h5") == open(crc32c, "tt2.h5")
 
 end # testset plain
 


### PR DESCRIPTION
HDF5 tracks object access/modification times, which in general makes any two files with identical contents differ byte-wise. This PR allows to disable/enable time tracking for datasets. This, for example, may help to reduce disk space when files are stored in a key-value store, where key is derived by hashing the file contents.

To illustrate the idea:

* With time tracking (the default behavior):
```jl
h5open("a.h5", "w") do f
    f["y"] = [1, 2, 3]
end
h5open("b.h5", "w") do f
    f["y"] = [1, 2, 3]
end
```
```sh
md5sum a.h5 b.h5
d85cfc58cce44f08efc7ab360d48016f  a.h5
51c6fa2b556b73911a5e4479853c5ce5  b.h5
```

* Without time tracking:
```jl
h5open("a.h5", "w") do f
    f["y", "track_times", false] = [1, 2, 3]
end
h5open("b.h5", "w") do f
    f["y", "track_times", false] = [1, 2, 3]
end
```
```sh
9e1b6badd6152d65871dc4dc8bfb2dd1  a.h5
9e1b6badd6152d65871dc4dc8bfb2dd1  b.h5
```