### PR TITLE
Allow AbstractArray writing

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1171,7 +1171,7 @@ datatype(dset::HDF5Attribute) = HDF5Datatype(h5a_get_type(checkvalid(dset).id), 
 # Create a datatype from in-memory types
 datatype(x::T) where {T<:HDF5Scalar} = HDF5Datatype(hdf5_type_id(T), false)
 datatype(::Type{T}) where {T<:HDF5Scalar} = HDF5Datatype(hdf5_type_id(T), false)
-datatype(A::Array{T}) where {T<:HDF5Scalar} = HDF5Datatype(hdf5_type_id(T), false)
+datatype(A::AbstractArray{T}) where {T<:HDF5Scalar} = HDF5Datatype(hdf5_type_id(T), false)
 function datatype(str::S) where {S<:String}
     type_id = h5t_copy(hdf5_type_id(S))
     h5t_set_size(type_id, max(sizeof(str), 1))
@@ -1225,7 +1225,7 @@ function _dataspace(sz::Tuple{Vararg{Int}}, max_dims::Union{Dims, Tuple{}}=())
     end
     HDF5Dataspace(space_id)
 end
-dataspace(A::Array; max_dims::Union{Dims, Tuple{}} = ()) = _dataspace(size(A), max_dims)
+dataspace(A::AbstractArray; max_dims::Union{Dims, Tuple{}} = ()) = _dataspace(size(A), max_dims)
 dataspace(str::String) = HDF5Dataspace(h5s_create(H5S_SCALAR))
 dataspace(v::HDF5Vlen; max_dims::Union{Dims, Tuple{}}=()) = _dataspace(size(v.data), max_dims)
 dataspace(n::Nothing) = HDF5Dataspace(h5s_create(H5S_NULL))
@@ -1982,7 +1982,7 @@ h5a_open(obj_id::Hid, name::String) = h5a_open(obj_id, name, H5P_DEFAULT)
 h5d_create(loc_id::Hid, name::String, type_id::Hid, space_id::Hid) = h5d_create(loc_id, name, type_id, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)
 h5d_open(obj_id::Hid, name::String) = h5d_open(obj_id, name, H5P_DEFAULT)
 h5d_read(dataset_id::Hid, memtype_id::Hid, buf::Array, xfer::Hid=H5P_DEFAULT) = h5d_read(dataset_id, memtype_id, H5S_ALL, H5S_ALL, xfer, buf)
-h5d_write(dataset_id::Hid, memtype_id::Hid, buf::Array, xfer::Hid=H5P_DEFAULT) = h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, xfer, buf)
+h5d_write(dataset_id::Hid, memtype_id::Hid, buf::AbstractArray, xfer::Hid=H5P_DEFAULT) = h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, xfer, buf)
 function h5d_write(dataset_id::Hid, memtype_id::Hid, str::String, xfer::Hid=H5P_DEFAULT)
     ccall((:H5Dwrite, libhdf5), Herr, (Hid, Hid, Hid, Hid, Hid, Cstring), dataset_id, memtype_id, H5S_ALL, H5S_ALL, xfer, str)
 end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -416,16 +416,17 @@ end # testset null and undefined
 # test writing reinterpreted data
 @testset "reinterpreted data" begin
 fn = tempname()
+try
+    h5open(fn, "w") do f
+        data = reinterpret(UInt8, [true, false, false])
+        write(f, "reinterpret array", data)
+    end
 
-h5open(fn, "w") do f
-    data = reinterpret(UInt8, [true, false, false])
-    write(f, "reinterpret array", data)
+    @test h5open(fn, "r") do f
+        read(f, "reinterpret array")
+    end == UInt8[0x01, 0x00, 0x00]
+finally
+    rm(fn)
 end
-
-@test h5open(fn, "r") do f
-    read(f, "reinterpret array")
-end == UInt8[0x01, 0x00, 0x00]
-
-rm(fn)
 
 end # writing reinterpreted data

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -226,11 +226,11 @@ z = read(fr, "Float64", "Int16")
 @test typeof(z) == Tuple{Float64,Int16}
 # Test function syntax
 read(fr, "Float64") do x
-	@test x == 3.2
+    @test x == 3.2
 end
 read(fr, "Float64", "Int16") do x, y
-	@test x == 3.2
-	@test y == 4
+    @test x == 3.2
+    @test y == 4
 end
 # Test reading entire file at once
 z = read(fr)
@@ -363,7 +363,7 @@ Wr = h5read(fn, "newgroup/W")
 close(f)
 rm(fn)
 
-if !isempty(HDF5.libhdf5_hl) 
+if !isempty(HDF5.libhdf5_hl)
     # Test direct chunk writing
     h5open(fn, "w") do f
       d = d_create(f, "dataset", datatype(Int), dataspace(4, 4), "chunk", (2, 2))
@@ -412,3 +412,20 @@ close(f)
 rm(fn)
 
 end # testset null and undefined
+
+# test writing reinterpreted data
+@testset "reinterpreted data" begin
+fn = tempname()
+
+h5open(fn, "w") do f
+    data = reinterpret(UInt8, [true, false, false])
+    write(f, "reinterpret array", data)
+end
+
+@test h5open(fn, "r") do f
+    read(f, "reinterpret array")
+end == UInt8[0x01, 0x00, 0x00]
+
+rm(fn)
+
+end # writing reinterpreted data


### PR DESCRIPTION
On 1.0 calling `reinterpret` on arrays returns a `ReinterpretArray` which is a subtype of AbstractArray and fails with the current master of HDF5. This allows those arrays to be written.