### PR TITLE
Initial support for reading BITFIELD type

### DIFF
--- a/test/plain.jl
+++ b/test/plain.jl
@@ -29,6 +29,9 @@ write(f, "Auint8", convert(Matrix{UInt8}, Ai))
 write(f, "Auint16", convert(Matrix{UInt16}, Ai))
 write(f, "Auint32", convert(Matrix{UInt32}, Ai))
 write(f, "Auint64", convert(Matrix{UInt64}, Ai))
+# Arrays of bools (pull request #540)
+Abool = [false, true, false]
+write(f, "Abool", Abool)
 
 salut = "Hi there"
 ucode = "uniçº∂e"
@@ -155,6 +158,11 @@ Ai32 = read(fr, "Auint32")
 Ai64 = read(fr, "Auint64")
 @test Ai == Ai64
 @test eltype(Ai64) == UInt64
+
+Abool_read = read(fr, "Abool")
+@test Abool_read == Abool
+@test eltype(Abool_read) == Bool
+
 salutr = read(fr, "salut")
 @test salut == salutr
 salutr = read(fr, "salut-vlen")


### PR DESCRIPTION
In order to able to be able to read files written with the PyTables, it is necessary to read the BITFIELD type. 
This only enables reading of 1-bit width BITFIELD types, I don't fully understand their purpose to be able to implement the more general case. Resolves #307 