### PR TITLE
fix dataset printing

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -390,7 +390,7 @@ end
 convert(::Type{Hid}, dset::HDF5Dataset) = dset.id
 function show(io::IO, dset::HDF5Dataset)
     if isvalid(dset)
-        print(io, "HDF5 dataset: ", name(dset), " (file: ", dset.file.filename, "xfer_mode: ", dset.xfer ," )" )
+        print(io, "HDF5 dataset: ", name(dset), " (file: ", dset.file.filename, " xfer_mode: ", dset.xfer, ")")
     else
         print(io, "HFD5 dataset (invalid)")
     end


### PR DESCRIPTION
Before:

```
julia> file = h5open("test/tt1.h5")
HDF5 data file: test/tt1.h5

julia> file["/x"]
HDF5 dataset: /x (file: test/tt1.h5xfer_mode: 0 )
```

After:

```
julia> file = h5open("test/tt1.h5")
HDF5 data file: test/tt1.h5

julia> file["/x"]
HDF5 dataset: /x (file: test/tt1.h5 xfer_mode: 0)

```