### PR TITLE
Add h5read_compound to read compound structures efficiently

### DIFF
--- a/test/plain.jl
+++ b/test/plain.jl
@@ -390,6 +390,30 @@ if !isempty(HDF5.libhdf5_hl)
     rm(fn)
 end
 
+# Test h5read_compound
+struct Vec3
+    a::Float64
+    b::Float64
+    c::Float64
+end
+struct Data
+    wgt::Float64
+    xyz::Vec3
+    uvw::Vec3
+    E::Float64
+end
+function test_data(data)
+    @test 2 == length(data)
+    @test -2.45590412 ≈ data[1].xyz.a
+end
+fn = joinpath(test_files, "compound.h5")
+test_data(HDF5.h5read_compound(fn, "/data", Data))
+h5open(fn, "r") do f
+    test_data(HDF5.h5read_compound(f, "/data", Data))
+    test_data(HDF5.h5read_compound(f["/data"], Data))
+end
+
+
 # Test that switching time tracking off results in identical files
 h5open("tt1.h5", "w") do f
     f["x", "track_times", false] = [1, 2, 3]

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -2,6 +2,20 @@ using HDF5
 using CRC32c
 using Test
 
+# Structures for the compound.h5 file
+struct Vec3
+    a::Float64
+    b::Float64
+    c::Float64
+end
+struct Data
+    wgt::Float64
+    xyz::Vec3
+    uvw::Vec3
+    E::Float64
+end
+
+
 @testset "plain" begin
 
 # Create a new file
@@ -391,17 +405,6 @@ if !isempty(HDF5.libhdf5_hl)
 end
 
 # Test h5read_compound
-struct Vec3
-    a::Float64
-    b::Float64
-    c::Float64
-end
-struct Data
-    wgt::Float64
-    xyz::Vec3
-    uvw::Vec3
-    E::Float64
-end
 function test_data(data)
     @test 2 == length(data)
     @test -2.45590412 ≈ data[1].xyz.a


### PR DESCRIPTION
The `h5read_compound` function with its three methods is already in use in all of my projects where I have to read `HDF5Compound` and is roughly two orders of magnitudes faster than using `read` or `h5read` and then parsing the data manually.

I carry over these functions all over the place and I would really like them to be included in `HDF5.jl`.

Credits go to @damiendr who provided the base code snippet back in 2017: https://github.com/JuliaIO/HDF5.jl/issues/408

For demonstration purposes I created a file `compound.h5` using Python+PyTables with  a compound structure using this Python script:

```python
import tables as tb


class Foo(tb.IsDescription):
    a = tb.Int32Col()
    b = tb.Float64Col()


h5file = tb.open_file("compound.h5", mode="w")
table = h5file.create_table("/", 'foo', Foo)

foo = table.row

for i in range(100_000):
    foo['a'] = i
    foo['b'] = i * 1.1
    foo.append()
```

Here are the results of a simple benchmark:

```julia
using HDF5
using BenchmarkTools

struct Foo
    a::Int32
    b::Float64
end

h5f = h5open("compound.h5", "r")

@btime read(h5f, "/foo");
@btime h5read_compound(h5f["/foo"], Foo);
@btime h5read("compound.h5", "/foo");
@btime h5read_compound("compound.h5", "/foo", Foo);
```

```
 97.445 ms (799562 allocations: 31.37 MiB)
  1.052 ms (25 allocations: 1.53 MiB)
  99.236 ms (799568 allocations: 31.37 MiB)
  3.061 ms (31 allocations: 1.53 MiB)
```
