### PR TITLE
extend lastindex to use `end` at any index

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1150,6 +1150,7 @@ function iterate(parent::Union{HDF5File, HDF5Group}, iter = (1,nothing))
 end
 
 lastindex(dset::HDF5Dataset) = length(dset)
+lastindex(dset::HDF5Dataset, d::Int) = size(dset, d)
 
 function parent(obj::Union{HDF5File, HDF5Group, HDF5Dataset})
     f = file(obj)

--- a/test/extend_test.jl
+++ b/test/extend_test.jl
@@ -19,6 +19,10 @@ dims, max_dims = HDF5.get_dims(d)
 d[1, 1:5] = [1.1231, 1.313, 5.123, 2.231, 4.1231]
 set_dims!(d, (1, 5))
 @test size(d) == (1, 5)
+
+@test d[:, end] ≈ [4.1231]
+@test d[end, :] == [1.1231 1.313 5.123 2.231 4.1231]
+
 #println("d is size current $(map(int,HDF5.get_dims(d)[1])) max $(map(int,HDF5.get_dims(d)[2]))")
 b = d_create(fid, "b", Int, ((1000,), (-1,)), "chunk", (100,)) #-1 is equivalent to typemax(Hsize) as far as I can tell
 #println("b is size current $(map(int,HDF5.get_dims(b)[1])) max $(map(int,HDF5.get_dims(b)[2]))")


### PR DESCRIPTION
Without the extra method, `a[:, end]` has no method available.

The current method can't work at all with multi-dimensional arrays, it just throws `Wrong number of indices supplied, supplied length 1 but expected 2.`