### PR TITLE
WIP: add tree command

### DIFF
--- a/doc/hdf5.md
+++ b/doc/hdf5.md
@@ -225,6 +225,15 @@ Getting information
 -------------------
 
 ```julia
+tree(obj)
+```
+
+will display the hierarchical structure of object `obj`, much like the bash
+`tree` command does for file system paths.  Similar to `h5dump` on the
+linux command line but more concise as it omits the full contents of
+datasets.
+
+```julia
 name(obj)
 ```
 


### PR DESCRIPTION
still a work in progress as i haven't tested all corner cases.  please let me know if something doesn't work for you.

for example:

```
help?> tree
  tree(obj::Union{HDF5File,HDF5Group})

  Display the hierarchical structure of object obj, much like the bash tree command does for file
  system paths. Similar to h5dump on the linux command line but more concise as it omits the full
  contents of datasets.

julia> fid=h5open("plate_001/patch_attempt_0000_000/camera_clamp2_000/000/Clamp2.ma")

julia> tree(fid)
MetaArray: 2
data (80000, 3) Float64
└─ info
   ├─ _metaType_: list
   ├─ 0
   │  ├─ _metaType_: dict
   │  ├─ name: 'Channel'
   │  └─ cols
   │     ├─ _metaType_: list
   │     ├─ 0
   │     │  ├─ _metaType_: dict
   │     │  ├─ name: 'command'
   │     │  └─ units: 'V'
   │     ├─ 1
   │     │  ├─ _metaType_: dict
   │     │  ├─ name: 'primary'
   │     │  └─ units: 'A'
   │     └─ 2
   │        ├─ _metaType_: dict
   │        ├─ name: 'secondary'
   │        └─ units: 'V'
   ├─ 1
   │  ├─ _metaType_: dict
   │  ├─ name: 'Time'
   │  ├─ units: 's'
   │  └─ values (80000,) Float64
   └─ 2
      ├─ _metaType_: dict
      ├─ startTime: 1.5627830491764686e9
      ├─ ClampState
      │  ├─ LPFCutoff: 20000.0
      │  ├─ _metaType_: dict
      │  ├─ extCmdScale: 0.02
      │  ├─ holding: -0.07
      │  ├─ membraneCapacitance: 0.0
      │  ├─ mode: 'VC'
      │  ├─ primaryGain: 2.0
      │  ├─ primaryScaleFactor: 1.0e-9
      │  ├─ primarySignal: 'Membrane Current'
      │  ├─ primaryUnits: 'A'
      │  ├─ secondaryGain: 1.0
      │  ├─ secondaryScaleFactor: 0.1
      │  ├─ secondarySignal: 'Membrane Potential'
      │  ├─ secondaryUnits: 'V'
      │  └─ ClampParams
      │     ├─ BridgeBalEnable: 6004
      │     ├─ BridgeBalResist: 8.413395979806202e-42
      │     ├─ FastCompCap: 1.848093076142754e-12
      │     ├─ FastCompTau: 1.7999999499807018e-6
      │     ├─ Holding: -4.915825115858752e-7
      │     ├─ HoldingEnable: 0
      │     ├─ LeakSubEnable: 0
      │     ├─ LeakSubResist: 4.0950001664e10
      │     ├─ NeutralizationCap: 8.413395979806202e-42
      │     ├─ NeutralizationEnable: 6004
      │     ├─ OutputZeroAmplitude: 0.0
      │     ├─ OutputZeroEnable: 0
      │     ├─ PipetteOffset: 0.038417998701334
      │     ├─ PrimarySignalHPF: 0.0
      │     ├─ PrimarySignalLPF: 20000.0
      │     ├─ RsCompBandwidth: 2867.199951171875
      │     ├─ RsCompCorrection: 0.0
      │     ├─ RsCompEnable: 0
      │     ├─ SlowCompCap: 0.0
      │     ├─ SlowCompTau: 9.999999747378752e-6
      │     ├─ WholeCellCompCap: 2.7520702730599034e-11
      │     ├─ WholeCellCompEnable: 0
      │     ├─ WholeCellCompResist: 8.969545e6
      │     └─ _metaType_: dict
      ├─ DAQ
      │  ├─ _metaType_: dict
      │  ├─ command
      │  │  ├─ _metaType_: dict
      │  │  ├─ holding: -0.07
      │  │  ├─ numPts: 80000L
      │  │  ├─ rate: 40000.0
      │  │  ├─ startTime: 1.5627830491764686e9
      │  │  └─ type: 'ao'
      │  ├─ primary
      │  │  ├─ _metaType_: dict
      │  │  ├─ numPts: 80000L
      │  │  ├─ rate: 40000.0
      │  │  ├─ startTime: 1.5627830491764686e9
      │  │  └─ type: 'ai'
      │  └─ secondary
      │     ├─ _metaType_: dict
      │     ├─ numPts: 80000L
      │     ├─ rate: 40000.0
      │     ├─ startTime: 1.5627830491764686e9
      │     └─ type: 'ai'
      └─ Protocol
         ├─ _metaType_: dict
         ├─ mode: 'VC'
         ├─ primary: None
         ├─ recordState: 1
         └─ secondary: None
```