### PR TITLE
Enable parallel hdf5 builds if mpi is installed

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -51,7 +51,7 @@ if dl_info === nothing && unsatisfied || force_compile
     # If we don't have a compatible .tar.gz to download
     # fall back to building from source, giving the library a different name
     # so that it is not overwritten by BinaryBuilder downloads or vice-versa.
-    Sys.iswindows() && error('Manual compilation mode not available for this platform')
+    Sys.iswindows() && error("Manual compilation mode not available for this platform")
     verbose && @info "Building from source for your platform (\"$(Sys.MACHINE)\", parsed as \"$(triplet(platform_key_abi()))\")."
 
     libname = "libhdf5_from_src"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -51,6 +51,7 @@ if dl_info === nothing && unsatisfied || force_compile
     # If we don't have a compatible .tar.gz to download
     # fall back to building from source, giving the library a different name
     # so that it is not overwritten by BinaryBuilder downloads or vice-versa.
+    Sys.iswindows() && error('Manual compilation mode not available for this platform')
     verbose && @info "Building from source for your platform (\"$(Sys.MACHINE)\", parsed as \"$(triplet(platform_key_abi()))\")."
 
     libname = "libhdf5_from_src"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -51,8 +51,8 @@ if dl_info === nothing && unsatisfied || force_compile
     # If we don't have a compatible .tar.gz to download
     # fall back to building from source, giving the library a different name
     # so that it is not overwritten by BinaryBuilder downloads or vice-versa.
-    Sys.iswindows() && error("Manual compilation mode not available for this platform")
-    verbose && @info "Building from source for your platform (\"$(Sys.MACHINE)\", parsed as \"$(triplet(platform_key_abi()))\")."
+    Sys.iswindows() && error("Manual compilation mode from source is not available for this platform.")
+    verbose && @info("Building from source for your platform (\"$(Sys.MACHINE)\", parsed as \"$(triplet(platform_key_abi()))\").")
 
     libname = "libhdf5_from_src"
     products = [

--- a/deps/compile.jl
+++ b/deps/compile.jl
@@ -20,8 +20,10 @@ function compile(libname, tarball_url, hash; prefix=BinaryProvider.global_prefix
     mkdir(build_dir)
     verbose && @info("Compiling in $build_dir...")
     cd(build_dir) do
-        run(`$cmake_executable -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON -DHDF5_BUILD_CPP_LIB=OFF ..`)
-        run(`$cmake_executable --build . --config release`)
+        # build in parallel hdf5 mode if mpi is installed
+        parallel_mode_flag = Sys.which("mpicc") !== nothing ? "ON" : "OFF"
+        run(`$cmake_executable -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON -DHDF5_BUILD_CPP_LIB=OFF -DHDF5_ENABLE_PARALLEL=$parallel_mode_flag ..`)
+        run(`$cmake_executable --build . --config release -j $(Sys.CPU_THREADS + 1)`)
         mkpath(libdir(prefix))
         cp("bin/libhdf5.$dlext",       joinpath(libdir(prefix), libname*"."*dlext),       force=true, follow_symlinks=true)
         cp("bin/libhdf5_hl.$dlext",    joinpath(libdir(prefix), libname*"_hl."*dlext),    force=true, follow_symlinks=true)


### PR DESCRIPTION
- Enable parallel hdf5 builds if mpi is installed 
- Enable parallel make
- Disable manual compilation on windows