### PR TITLE
try suggested changes in #349

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -605,7 +605,7 @@ function h5open(filename::AbstractString, rd::Bool, wr::Bool, cr::Bool, tr::Bool
     end
     close_apl = false
     if apl.id == H5P_DEFAULT
-        apl = p_create(H5P_FILE_ACCESS, false)
+        apl = p_create(H5P_FILE_ACCESS, true)
         close_apl = true
         # With garbage collection, the other modes don't make sense
         apl["fclose_degree"] = H5F_CLOSE_STRONG
@@ -649,11 +649,11 @@ function h5open(filename::AbstractString, mode::AbstractString="r", pv...; swmr=
     # pv is interpreted as pairs of arguments
     # the first of a pair is a key of hdf5_prop_get_set
     # the second of a pair is a property value
-    fapl = p_create(H5P_FILE_ACCESS, false, pv...) # file access property list
+    fapl = p_create(H5P_FILE_ACCESS, true, pv...) # file access property list
     # With garbage collection, the other modes don't make sense
     # (Set this first, so that the user-passed properties can overwrite this.)
     fapl["fclose_degree"] = H5F_CLOSE_STRONG
-    fcpl = p_create(H5P_FILE_CREATE, false, pv...) # file create property list
+    fcpl = p_create(H5P_FILE_CREATE, true, pv...) # file create property list
     modes =
         mode == "r"  ? (true,  false, false, false, false) :
         mode == "r+" ? (true,  true,  false, false, true ) :


### PR DESCRIPTION
@yuyichao suggested this two years ago in https://github.com/JuliaIO/HDF5.jl/issues/349#issuecomment-313563553

I can't tell if there are negative consequences to switching these to `true`/ why these are false in the first place... I just know that I have been using a local dev-copy of HDF5.jl with these changes for a couple months, and the only difference I see is that the memory usage is much much less.

For my use, if I run my program that uses multiprocessing and does a bunch of small writes to separate files in each process, in the current master branch, my final memory goes from ~7Gb at the start of the run to 17GB.
When I make these changes, it stays below 10Gb... this still makes me think the problem in #349 is not fully solved by it, but it seems much better to me.