### PR TITLE
fix hyperslab support for complex datasets

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1764,7 +1764,7 @@ function getindex(dset::HDF5Dataset, indices::Union{AbstractRange{Int},Int}...)
     _getindex(dset,T, indices...)
 end
 function _getindex(dset::HDF5Dataset, T::Type, indices::Union{AbstractRange{Int},Int}...)
-    if !(T <: HDF5Scalar)
+    if !(T <: Union{HDF5Scalar, Complex{<:HDF5Scalar}})
         error("Dataset indexing (hyperslab) is available only for bits types")
     end
     dsel_id = hyperslab(dset, indices...)
@@ -1791,7 +1791,7 @@ function _setindex!(dset::HDF5Dataset,T::Type, X::Array, indices::Union{Abstract
         error("Dataset indexing (hyperslab) is available only for arrays")
     end
     ET = eltype(T)
-    if !(ET <: HDF5Scalar)
+    if !(ET <: Union{HDF5Scalar, Complex{<:HDF5Scalar}})
         error("Dataset indexing (hyperslab) is available only for bits types")
     end
     if length(X) != prod(map(length, indices))

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -415,6 +415,11 @@ end # testset plain
   write(f, "Acmplx64", convert(Matrix{ComplexF64}, Acmplx))
   write(f, "Acmplx32", convert(Matrix{ComplexF32}, Acmplx))
 
+  dset = d_create(f, "Acmplx64_hyperslab", datatype(Complex{Float64}), dataspace(Acmplx))
+  for i in 1:size(Acmplx, 2)
+    dset[:, i] = Acmplx[:,i]
+  end
+
   HDF5.disable_complex_support()
   @test_throws ErrorException f["_ComplexF64"] = 1.0 + 2.0im
   @test_throws ErrorException write(f, "_Acmplx64", convert(Matrix{ComplexF64}, Acmplx))
@@ -435,6 +440,13 @@ end # testset plain
   Acmplx64 = read(fr, "Acmplx64")
   @test convert(Matrix{ComplexF64}, Acmplx) == Acmplx64
   @test eltype(Acmplx64) == ComplexF64
+
+  dset = fr["Acmplx64_hyperslab"]
+  Acmplx64_hyperslab = zeros(eltype(dset), size(dset))
+  for i in 1:size(dset, 2)
+    Acmplx64_hyperslab[:,i] = dset[:,i]
+  end
+  @test convert(Matrix{ComplexF64}, Acmplx) == Acmplx64_hyperslab
 
   HDF5.disable_complex_support()
   z = read(fr, "ComplexF64")


### PR DESCRIPTION
Fix type check in `getindex/setindex!` to allow using hyperslabs with complex datasets. Should fix the issue mentioned [here](https://github.com/JuliaIO/HDF5.jl/pull/558#issuecomment-548123645).