### PR TITLE
improve performance/ergonomics of reading compound datatypes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ HDF5_jll = "0234f1f7-429e-5d53-9886-15a909be8d59"
 Blosc = "a74b3585-a348-5f62-a45c-50e91977d574"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 julia = "1.3"

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1578,7 +1578,6 @@ function read(obj::DatasetOrAttribute, ::Type{HDF5Vlen{T}}) where {T<:Union{HDF5
     for i = 1:len
         h = structbuf[i]
         data[i] = p2a(convert(Ptr{T}, h.p), Int(h.len))
-
     end
     data
 end

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1510,6 +1510,7 @@ function read(dset::HDF5Dataset, T::Union{Type{Array{U}}, Type{U}}) where U <: N
   reclaim = any(t -> t <: Cstring, types)
   if reclaim
     dspace = dataspace(dset)
+    # NOTE I have seen this call fail but I cannot reproduce
     h5d_vlen_reclaim(memtype_id, dspace.id, H5P_DEFAULT, buf)
   end
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1491,7 +1491,8 @@ end
 # get a vector of all the leaf types in a (possibly nested) named tuple
 function get_all_types(::Type{NamedTuple{T, U}}) where T where U
   types = []
-  for Ui in fieldtypes(U)
+  for i in 1:fieldcount(U)
+    Ui = fieldtype(U, i)
     if Ui <: NamedTuple
       append!(types, get_all_types(Ui))
     else

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -465,13 +465,6 @@ end
 ==(a::HDF5ReferenceObj, b::HDF5ReferenceObj) = a.r == b.r
 hash(x::HDF5ReferenceObj, h::UInt) = hash(x.r, h)
 
-# Compound types
-struct HDF5Compound{N}
-    data::NTuple{N,Any}
-    membername::NTuple{N,String}
-    membertype::NTuple{N,Type}
-end
-
 # Opaque types
 struct HDF5Opaque
     data
@@ -482,9 +475,11 @@ end
 struct EmptyArray{T} end
 
 # Stub types to encode fixed-size arrays for H5T_ARRAY
-struct FixedArray{T,D} end
-size(::Type{FixedArray{T,D}}) where {T,D} = D
-eltype(::Type{FixedArray{T,D}}) where {T,D} = T
+struct FixedArray{T,D,L}
+  data::NTuple{L, T}
+end
+size(::Type{FixedArray{T,D,L}}) where {T,D,L} = D
+eltype(::Type{FixedArray{T,D,L}}) where {T,D,L} = T
 
 # VLEN objects
 struct HDF5Vlen{T}
@@ -1459,73 +1454,21 @@ function getindex(parent::Union{HDF5File, HDF5Group, HDF5Dataset}, r::HDF5Refere
     h5object(obj_id, parent)
 end
 
-# Helper for reading compound types
-function read_row(io::IO, membertype, membersize)
-    row = Any[]
-    for (dtype, dsize) in zip(membertype, membersize)
-        if dtype === String
-            push!(row, unpad(read!(io, Vector{UInt8}(undef,dsize)), H5T_STR_NULLPAD))
-        elseif dtype<:HDF5.FixedArray && eltype(dtype)<:HDF5BitsKind
-            val = read!(io, Vector{eltype(dtype)}(undef,prod(size(dtype))))
-            push!(row, reshape(val, size(dtype)))
-        elseif dtype<:HDF5BitsKind
-            push!(row, read(io, dtype))
-        else
-            # for other types, just store the raw bytes and let the user
-            # decide what to do
-            push!(row, read!(io, Vector{UInt8}(undef,dsize)))
-        end
-    end
-    return (row...,)
-end
+function read(dset::HDF5Dataset, T::Union{Type{Array{U}}, Type{U}}) where U <: NamedTuple
+  filetype = HDF5.datatype(dset)
+  memtype_id = HDF5.h5t_get_native_type(filetype.id)  # padded layout in memory
+  @assert sizeof(U) == HDF5.h5t_get_size(memtype_id) "Type sizes mismatch!"
 
-# Read compound type
-function read(obj::HDF5Dataset, T::Union{Type{Array{HDF5Compound{N}}},Type{HDF5Compound{N}}}) where {N}
-    t = datatype(obj)
-    local sz = 0; local n;
-    local membername; local membertype;
-    local memberoffset; local memberfiletype; local membersize;
-    try
-        memberfiletype = Vector{HDF5Datatype}(undef,N)
-        membertype = Vector{Type}(undef,N)
-        membername = Vector{String}(undef,N)
-        memberoffset = Vector{UInt64}(undef,N)
-        membersize = Vector{UInt32}(undef,N)
-        for i = 1:N
-            filetype = HDF5Datatype(h5t_get_member_type(t.id, i-1))
-            memberfiletype[i] = filetype
-            membertype[i] = hdf5_to_julia_eltype(filetype)
-            memberoffset[i] = sz
-            membersize[i] = sizeof(filetype)
-            sz += sizeof(filetype)
-            membername[i] = h5t_get_member_name(t.id, i-1)
-        end
-    finally
-        close(t)
-    end
-    # Build the "memory type"
-    memtype_id = h5t_create(H5T_COMPOUND, sz)
-    for i = 1:N
-        h5t_insert(memtype_id, membername[i], memberoffset[i], memberfiletype[i].id) # FIXME strings
-    end
-    # Read the raw data
-    buf = Vector{UInt8}(undef,length(obj)*sz)
-    h5d_read(obj.id, memtype_id, H5S_ALL, H5S_ALL, obj.xfer, buf)
+  out = Array{U}(undef, size(dset))
 
-    # Convert to the appropriate data format using iobuffer
-    iobuff = IOBuffer(buf)
-    data = Any[]
-    while !eof(iobuff)
-        push!(data, read_row(iobuff, membertype, membersize))
-    end
-    # convert HDF5Compound type parameters to tuples
-    membername = (membername...,)
-    membertype = (membertype...,)
-    if T === HDF5Compound{N}
-        return HDF5Compound(data[1], membername, membertype)
-    else
-        return [HDF5Compound(elem, membername, membertype) for elem in data]
-    end
+  HDF5.h5d_read(dset.id, memtype_id, HDF5.H5S_ALL, HDF5.H5S_ALL, HDF5.H5P_DEFAULT, out)
+  HDF5.h5t_close(memtype_id)
+
+  if T <: NamedTuple
+    return out[1]
+  else
+    return out
+  end
 end
 
 # Read OPAQUE datasets and attributes
@@ -2007,18 +1950,26 @@ function hdf5_to_julia_eltype(objtype)
         T = HDF5Vlen{hdf5_to_julia_eltype(HDF5Datatype(super_id))}
     elseif class_id == H5T_COMPOUND
         N = Int(h5t_get_nmembers(objtype.id))
+
+        membernames = ntuple(N) do i
+          h5t_get_member_name(objtype.id, i-1)
+        end
+
+        membertypes = ntuple(N) do i
+          hdf5_to_julia_eltype(HDF5Datatype(h5t_get_member_type(objtype.id, i-1)))
+        end
+
         # check if should be interpreted as complex
-        if COMPLEX_SUPPORT[] && N == 2
-          membernames = ntuple(N) do i
-            h5t_get_member_name(objtype.id, i-1)
-          end
-          membertypes = ntuple(N) do i
-            hdf5_to_julia_eltype(HDF5Datatype(h5t_get_member_type(objtype.id, i-1)))
-          end
-          iscomplex = (membernames == COMPLEX_FIELD_NAMES[]) && (membertypes[1] == membertypes[2]) && (membertypes[1] <: HDF5.HDF5Scalar)
-          T = iscomplex ? Complex{membertypes[1]} : HDF5Compound{N}
+        iscomplex = COMPLEX_SUPPORT[] &&
+                    N == 2 &&
+                    (membernames == COMPLEX_FIELD_NAMES[]) &&
+                    (membertypes[1] == membertypes[2]) &&
+                    (membertypes[1] <: HDF5.HDF5Scalar)
+
+        if iscomplex
+          T = Complex{membertypes[1]}
         else
-          T = HDF5Compound{N}
+          T = NamedTuple{Symbol.(membernames), Tuple{membertypes...}}
         end
     elseif class_id == H5T_ARRAY
         T = hdf5array(objtype)
@@ -2423,7 +2374,7 @@ function hdf5array(objtype)
     eltyp = HDF5Datatype(h5t_get_super(objtype.id))
     T = hdf5_to_julia_eltype(eltyp)
     dimsizes = ntuple(i -> Int(dims[nd-i+1]), nd)  # reverse order
-    FixedArray{T, dimsizes}
+    FixedArray{T, dimsizes, prod(dimsizes)}
 end
 
 ### Property manipulation ###

--- a/test/compound.jl
+++ b/test/compound.jl
@@ -24,7 +24,7 @@ function unsafe_convert(::Type{foo_hdf5}, x::foo)
            Base.unsafe_convert(Cstring, x.b),
            ntuple(i -> x.c[i], length(x.c)),
            ntuple(i -> x.d[i], length(x.d)),
-           HDF5.Hvl_t(convert(Csize_t, length(x.e)), convert(Ptr{Cvoid}, pointer(x.e)))
+           HDF5.Hvl_t(length(x.e), pointer(x.e))
           )
 end
 

--- a/test/compound.jl
+++ b/test/compound.jl
@@ -1,0 +1,63 @@
+using Random, Test, HDF5
+
+import HDF5.datatype
+import Base.unsafe_convert
+
+struct foo
+  a::Float64
+  b::String
+  c::String
+  d::Array{ComplexF64,2}
+end
+
+struct foo_hdf5
+  a::Float64
+  b::Cstring
+  c::NTuple{10, Cchar}
+  d::NTuple{9, ComplexF64}
+end
+
+function unsafe_convert(::Type{foo_hdf5}, x::foo)
+  foo_hdf5(x.a, Base.unsafe_convert(Cstring, x.b), ntuple(i -> x.c[i], length(x.c)), ntuple(i -> x.d[i], length(x.d)))
+end
+
+function datatype(::Type{foo_hdf5})
+  dtype = HDF5.h5t_create(HDF5.H5T_COMPOUND, sizeof(foo_hdf5))
+  HDF5.h5t_insert(dtype, "a", fieldoffset(foo_hdf5, 1), datatype(Float64))
+
+  vlenstr_dtype = HDF5.h5t_copy(HDF5.H5T_C_S1)
+  HDF5.h5t_set_size(vlenstr_dtype, HDF5.H5T_VARIABLE)
+  HDF5.h5t_set_cset(vlenstr_dtype, HDF5.H5T_CSET_UTF8)
+  HDF5.h5t_insert(dtype, "b", fieldoffset(foo_hdf5, 2), vlenstr_dtype)
+
+  fixedstr_dtype = HDF5.h5t_copy(HDF5.H5T_C_S1)
+  HDF5.h5t_set_size(fixedstr_dtype, 10 * sizeof(Cchar))
+  HDF5.h5t_set_cset(fixedstr_dtype, HDF5.H5T_CSET_UTF8)
+  HDF5.h5t_insert(dtype, "c", fieldoffset(foo_hdf5, 3), fixedstr_dtype)
+
+  hsz = HDF5.Hsize[3,3]
+  array_dtype = HDF5.h5t_array_create(datatype(ComplexF64).id, 2, hsz)
+  HDF5.h5t_insert(dtype, "d", fieldoffset(foo_hdf5, 4), array_dtype)
+
+  HDF5Datatype(dtype)
+end
+
+@testset "compound" begin
+  N = 10
+  v = [foo(rand(), randstring(rand(10:100)), randstring(10), rand(ComplexF64, 3,3)) for _ in 1:N]
+  v_write = unsafe_convert.(foo_hdf5, v)
+
+  fn = tempname()
+  h5open(fn, "w") do h5f
+    dtype = datatype(foo_hdf5)
+    space = dataspace(v_write)
+    dset = HDF5.h5d_create(h5f.id, "data", dtype.id, space.id)
+    HDF5.h5d_write(dset, dtype.id, v_write)
+  end
+
+  v_read = h5read(fn, "data")
+  for field in (:a, :b, :c, :d)
+    f = x -> getfield(x, field)
+    @test f.(v) == f.(v_read)
+  end
+end

--- a/test/compound.jl
+++ b/test/compound.jl
@@ -76,4 +76,20 @@ end
     f = x -> getfield(x, field)
     @test f.(v) == f.(v_read)
   end
+
+  T = NamedTuple{(:a, :b, :c, :d, :e, :f), Tuple{Int, Int, Int, Int, Int, Cstring}}
+  TT = NamedTuple{(:a, :b, :c, :d, :e, :f), Tuple{Int, Int, Int, Int, Int, T}}
+  TTT = NamedTuple{(:a, :b, :c, :d, :e, :f), Tuple{Int, Int, Int, Int, Int, TT}}
+  TTTT = NamedTuple{(:a, :b, :c, :d, :e, :f), Tuple{Int, Int, Int, Int, Int, TTT}}
+
+  @test HDF5.do_reclaim(TTTT) == true
+  @test HDF5.do_normalize(TTTT) == true
+
+  T = NamedTuple{(:a, :b, :c, :d, :e, :f), Tuple{Int, Int, Int, Int, Int, HDF5.FixedArray}}
+  TT = NamedTuple{(:a, :b, :c, :d, :e, :f), Tuple{Int, Int, Int, Int, Int, T}}
+  TTT = NamedTuple{(:a, :b, :c, :d, :e, :f), Tuple{Int, Int, Int, Int, Int, TT}}
+  TTTT = NamedTuple{(:a, :b, :c, :d, :e, :f), Tuple{Int, Int, Int, Int, Int, TTT}}
+
+  @test HDF5.do_reclaim(TTTT) == false
+  @test HDF5.do_normalize(TTTT) == true
 end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -320,12 +320,7 @@ rm(tmpdir, recursive=true)
 test_files = joinpath(@__DIR__, "test_files")
 
 d = h5read(joinpath(test_files, "compound.h5"), "/data")
-@test typeof(d[1]) === HDF5.HDF5Compound{4}
-@test length(d) == 2
-dtypes = [typeof(x) for x in d[1].data]
-@test dtypes == [Float64, Vector{Float64}, Vector{Float64}, Float64]
-@test length(d[1].data[2]) == 3
-@test d[1].membername == ("wgt", "xyz", "uvw", "E")
+@test typeof(d[1]) == NamedTuple{(:wgt, :xyz, :uvw, :E), Tuple{Float64, HDF5.FixedArray{Float64, (3,), 3}, HDF5.FixedArray{Float64, (3,), 3}, Float64}}
 
 # get-datasets
 fn = tempname()
@@ -450,12 +445,12 @@ end # testset plain
 
   HDF5.disable_complex_support()
   z = read(fr, "ComplexF64")
-  @test isa(z, HDF5.HDF5Compound{2})
+  @test isa(z, NamedTuple{(:r, :i), Tuple{Float64, Float64}})
 
   Acmplx32 = read(fr, "Acmplx32")
-  @test eltype(Acmplx32) == HDF5.HDF5Compound{2}
+  @test eltype(Acmplx32) == NamedTuple{(:r, :i), Tuple{Float32, Float32}}
   Acmplx64 = read(fr, "Acmplx64")
-  @test eltype(Acmplx64) == HDF5.HDF5Compound{2}
+  @test eltype(Acmplx64) == NamedTuple{(:r, :i), Tuple{Float64, Float64}}
 
   close(fr)
 

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -320,7 +320,7 @@ rm(tmpdir, recursive=true)
 test_files = joinpath(@__DIR__, "test_files")
 
 d = h5read(joinpath(test_files, "compound.h5"), "/data")
-@test typeof(d[1]) == NamedTuple{(:wgt, :xyz, :uvw, :E), Tuple{Float64, HDF5.FixedArray{Float64, (3,), 3}, HDF5.FixedArray{Float64, (3,), 3}, Float64}}
+@test typeof(d[1]) == NamedTuple{(:wgt, :xyz, :uvw, :E), Tuple{Float64, Array{Float64, 1}, Array{Float64, 1}, Float64}}
 
 # get-datasets
 fn = tempname()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Pkg
 println("HDF5 version ", HDF5.h5_get_libversion())
 
 include("plain.jl")
+include("compound.jl")
 include("readremote.jl")
 include("extend_test.jl")
 include("gc.jl")


### PR DESCRIPTION
When reading compound datatypes this replaces `HDF5Compound` with a named tuple with the correct data layout. The data is directly read into the output buffer instead of going through an `IOBuffer`. This results in very large performance gains. 

I wrote a small [benchmark](https://gist.github.com/kleinhenz/ddb8fa7de366e917c2520b963e0bb1f4) to test the performance of reading a one million element dataset of a small compound datatype with three float fields.

Before
```
BenchmarkTools.Trial:
  memory estimate:  329.44 MiB
  allocs estimate:  9000084
  --------------
  minimum time:     1.689 s (19.72% GC)
  median time:      1.878 s (24.72% GC)
  mean time:        1.860 s (25.70% GC)
  maximum time:     2.013 s (31.63% GC)
  --------------
  samples:          3
  evals/sample:     1⏎
```

After:
```
BenchmarkTools.Trial:
  memory estimate:  22.89 MiB
  allocs estimate:  64
  --------------
  minimum time:     4.305 ms (20.43% GC)
  median time:      4.584 ms (20.69% GC)
  mean time:        4.717 ms (23.21% GC)
  maximum time:     53.451 ms (91.03% GC)
  --------------
  samples:          1059
  evals/sample:     1⏎
```

Additionally I fixed support for variable length strings as fields of compound datatypes which seemed to be broken before.

In the case where the compound type contains strings/arrays/vlen types a copy is made to convert from the hdf5 compatible type (e.g. `Cstring`, `FixedArray`, etc.) to native julia types. This has some performance cost but I think is almost always what you want to do. 

Besides being much much faster I think that getting an array of `NamedTuples` is much easier to work with than the `HDF5Compound` struct there was before.

This should close #408. I prefer this solution to #559 since it doesn't change the interface and doesn't require manual specification of the struct.