### PR TITLE
getindex returns arrays with correct dims, or scalars

### DIFF
--- a/test/extend_test.jl
+++ b/test/extend_test.jl
@@ -20,8 +20,21 @@ d[1, 1:5] = [1.1231, 1.313, 5.123, 2.231, 4.1231]
 set_dims!(d, (1, 5))
 @test size(d) == (1, 5)
 
+# Indexing returns correct array dimensions
+@test d[1, end] ≈ 4.1231
 @test d[:, end] ≈ [4.1231]
-@test d[end, :] == [1.1231 1.313 5.123 2.231 4.1231]
+@test d[end, :] == [1.1231, 1.313, 5.123, 2.231, 4.1231]
+@test d[:, :] == [1.1231 1.313 5.123 2.231 4.1231]
+
+# Test all integer types work
+@test d[UInt8(1), UInt16(1)] == 1.1231
+@test d[UInt32(1), UInt128(1)] == 1.1231
+@test d[Int8(1), Int16(1)] == 1.1231
+@test d[Int32(1), Int128(1)] == 1.1231
+
+# Test ranges work with steps
+@test d[1, 1:2:5] == [1.1231, 5.123, 4.1231]
+@test d[1:1, 2:2:4] == [1.313 2.231]
 
 #println("d is size current $(map(int,HDF5.get_dims(d)[1])) max $(map(int,HDF5.get_dims(d)[2]))")
 b = d_create(fid, "b", Int, ((1000,), (-1,)), "chunk", (100,)) #-1 is equivalent to typemax(Hsize) as far as I can tell


### PR DESCRIPTION
This standardises the return value of `getindex` to match base julia `Array` behaviour. 

Dimensions indexed with Int are dropped using `reshape`. If all are dropped, a scalar is returned.