### PR TITLE
add Array constructor for HDF5Dataset

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1344,6 +1344,9 @@ function read(obj::DatasetOrAttribute, ::Type{Array{A}}) where {A<:FixedArray}
     ret
 end
 
+# Array constructor for datasets
+Array(x::HDF5Dataset) = read(x)
+
 # Clean up string buffer according to padding mode
 function unpad(s::String, pad::Integer)
     if pad == H5T_STR_NULLTERM

--- a/test/extend_test.jl
+++ b/test/extend_test.jl
@@ -36,6 +36,9 @@ set_dims!(d, (1, 5))
 @test d[1, 1:2:5] == [1.1231, 5.123, 4.1231]
 @test d[1:1, 2:2:4] == [1.313 2.231]
 
+# Test Array constructor
+Array(d) == [1.1231 1.313 5.123 2.231 4.1231]
+
 #println("d is size current $(map(int,HDF5.get_dims(d)[1])) max $(map(int,HDF5.get_dims(d)[2]))")
 b = d_create(fid, "b", Int, ((1000,), (-1,)), "chunk", (100,)) #-1 is equivalent to typemax(Hsize) as far as I can tell
 #println("b is size current $(map(int,HDF5.get_dims(b)[1])) max $(map(int,HDF5.get_dims(b)[2]))")


### PR DESCRIPTION
This adds a constructor for `Array`, which allows loading the whole dataset  (ie without specifying indices) as you can do with any real `AbstractArray`. This removes the need for boilerplate special casing of HDF5 with `HDF5.read` when working with multiple data sources.