### PR TITLE
Check that HDF5Properties is valid before closing

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -832,7 +832,9 @@ end
 
 function close(obj::HDF5Properties)
     if obj.toclose && obj.id != -1
-        h5p_close(obj.id)
+        if isvalid(obj)
+            h5p_close(obj.id)
+        end
         obj.id = -1
     end
     nothing

--- a/test/gc.jl
+++ b/test/gc.jl
@@ -63,6 +63,11 @@ for i = 1:10
     close(file)
 end
 GC.enable(true)
+
+h5open(identity, fn, "r", "alignment", (0, 64))  # issue 620
+HDF5.h5_close()
+@test_nowarn GC.gc()  # this will fail when trying to close objects already closed by h5_close
+
 rm(fn)
 
 end # testset gc

--- a/test/gc.jl
+++ b/test/gc.jl
@@ -64,9 +64,10 @@ for i = 1:10
 end
 GC.enable(true)
 
-h5open(identity, fn, "r", "alignment", (0, 64))  # issue 620
-HDF5.h5_close()
-@test_nowarn GC.gc()  # this will fail when trying to close objects already closed by h5_close
+let plist = p_create(HDF5.H5P_FILE_ACCESS, true)  # related to issue #620
+    HDF5.h5p_close(plist)
+    @test_nowarn finalize(plist)
+end
 
 rm(fn)
 


### PR DESCRIPTION
This fixes issue when a property list is closed by a call to `h5_close` before its `HDF5Properties` wrapper being destroyed by the GC.

Fixes #620 