### PR TITLE
Lazy-load MPI using Requires

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ HDF5_jll = "0234f1f7-429e-5d53-9886-15a909be8d59"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 Blosc = "0.5.1, 0.6, 0.7"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,4 @@
+using MPI  # needed to generate docs for parallel HDF5 API
 using HDF5
 using Documenter
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -362,6 +362,116 @@ HDF5 is a large library, and the low-level wrap is not complete. However, many o
 Note that Julia's HDF5 directly uses the "2" interfaces, e.g., `H5Dcreate2`, so you need to have version 1.8 of the HDF5 library or later.
 
 
+## System-provided HDF5 libraries
+
+Starting from Julia 1.3, the HDF5 binaries are by default downloaded using the
+[HDF5_jll](https://github.com/JuliaBinaryWrappers/HDF5_jll.jl) package.
+To use system-provided HDF5 binaries instead, set the environment variable
+`JULIA_HDF5_LIBRARY_PATH` to the HDF5 library path and then run
+`Pkg.build("HDF5")`.
+This is in particular needed for [parallel HDF5 support](@ref Parallel-HDF5),
+which is not provided by the `HDF5_jll` binaries.
+
+For example, you can set `JULIA_HDF5_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/hdf5/mpich/`
+if you're using the system package [`libhdf5-mpich-dev`](https://packages.ubuntu.com/focal/libhdf5-mpich-dev)
+on Ubuntu 20.04.
+
+
+## Parallel HDF5
+
+It is possible to read and write [parallel
+HDF5](https://portal.hdfgroup.org/display/HDF5/Parallel+HDF5) files using MPI.
+For this, the HDF5 binaries loaded by HDF5.jl must have been compiled with
+parallel support, and linked to the specific MPI implementation that will be used for parallel I/O.
+
+Parallel-enabled HDF5 libraries are usually included in computing clusters and
+linked to the available MPI implementations.
+They are also available via the package manager of a number of Linux
+distributions.
+
+Finally, note that the MPI.jl package is lazy-loaded by HDF5.jl
+using [Requires](https://github.com/JuliaPackaging/Requires.jl).
+In practice, this means that in Julia code, `MPI` must be imported *before*
+`HDF5` for parallel functionality to be available.
+
+### Setting-up Parallel HDF5
+
+The following step-by-step guide assumes one already has access to
+parallel-enabled HDF5 libraries linked to an existent MPI installation.
+
+#### 1. Using system-provided MPI libraries
+
+Set the environment variable `JULIA_MPI_BINARY=system` and then run
+`]build MPI` from Julia.
+For more control, one can also set the `JULIA_MPI_PATH` environment variable
+to the top-level installation directory of the MPI library.
+See the [MPI.jl
+docs](https://juliaparallel.github.io/MPI.jl/stable/configuration/#Using-a-system-provided-MPI-1)
+for details.
+
+#### 2. Using parallel HDF5 libraries
+
+As detailed in [System-provided HDF5 libraries](@ref), set the
+`JULIA_HDF5_LIBRARY_PATH` environment variable to the directory where
+the HDF5 libraries compiled with parallel support are found.
+
+#### 3. Loading MPI-enabled HDF5
+
+In Julia code, MPI.jl must be loaded *before* HDF5.jl for MPI functionality to
+be available:
+
+```julia
+using MPI
+using HDF5
+```
+
+### Reading and writing data in parallel
+
+A parallel HDF5 file may be opened by passing a `MPI.Comm` (and optionally a
+`MPI.Info`) object to [`h5open`](@ref).
+For instance:
+
+```julia
+comm = MPI.COMM_WORLD
+info = MPI.Info()
+ff = h5open(filename, "w", comm, info)
+```
+
+MPI-distributed data is typically written by first creating a dataset
+describing the global dimensions of the data.
+The following example writes a `10 × Nproc` array distributed over `Nproc` MPI
+processes.
+
+```julia
+Nproc = MPI.Comm_size(comm)
+myrank = MPI.Comm_rank(comm)
+M = 10
+A = fill(myrank, M)  # local data
+dims = (M, Nproc)    # dimensions of global data
+
+# Create dataset
+dset = d_create(ff, "/data", datatype(eltype(A)), dataspace(dims))
+
+# Write local data
+dset[:, myrank + 1] = A
+```
+
+Note that all MPI processes must call `d_create` with the same arguments.
+
+Sometimes, it may be more efficient to write data in chunks, so that each
+process writes to a separate chunk of the file.
+This is especially the case when data is uniformly distributed among MPI
+processes.
+In this example, this can be achieved by passing `chunk=(M, 1)` to `d_create`.
+
+For better performance, it is sometimes preferable to perform [collective
+I/O](https://portal.hdfgroup.org/display/HDF5/Introduction+to+Parallel+HDF5)
+when reading and writing datasets in parallel.
+This is achieved by passing `dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE` to `d_create`.
+See also the [HDF5 docs](https://portal.hdfgroup.org/display/HDF5/H5P_SET_DXPL_MPIO).
+
+A few more examples are available in [`test/mpio.jl`](https://github.com/JuliaIO/HDF5.jl/blob/master/test/mpio.jl).
+
 ## Details
 
 Julia, like Fortran and Matlab, stores arrays in column-major order.

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -2561,6 +2561,18 @@ const ASCII_ATTRIBUTE_PROPERTIES = Ref{HDF5Properties}()
 
 const DEFAULT_PROPERTIES = HDF5Properties(H5P_DEFAULT, H5P_DEFAULT)
 
+const HAS_PARALLEL = Ref(false)
+
+"""
+    has_parallel()
+
+Returns `true` if the HDF5 libraries were compiled with parallel support,
+and if parallel support was loaded into HDF5.jl.
+
+For the second condition to be true, MPI must be imported before HDF5.
+"""
+has_parallel() = HAS_PARALLEL[]
+
 function __init__()
     check_deps()
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -2567,9 +2567,9 @@ const HAS_PARALLEL = Ref(false)
     has_parallel()
 
 Returns `true` if the HDF5 libraries were compiled with parallel support,
-and if parallel support was loaded into HDF5.jl.
+and if parallel functionality was loaded into HDF5.jl.
 
-For the second condition to be true, MPI must be imported before HDF5.
+For the second condition to be true, MPI.jl must be imported before HDF5.jl.
 """
 has_parallel() = HAS_PARALLEL[]
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -2601,7 +2601,7 @@ function __init__()
     rehash!(hdf5_prop_get_set, length(hdf5_prop_get_set.keys))
     rehash!(hdf5_obj_open, length(hdf5_obj_open.keys))
 
-    @require MPI="da04e1cc-30fd-572f-bb4f-1f8673147195" include("mpio.jl")
+    @require MPI="da04e1cc-30fd-572f-bb4f-1f8673147195" @eval include("mpio.jl")
 
     return nothing
 end

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -634,7 +634,7 @@ function h5open(filename::AbstractString, rd::Bool, wr::Bool, cr::Bool, tr::Bool
 end
 
 """
-    h5open(filename::AbstractString, mode::AbstractString="r"; swmr=false)
+    h5open(filename::AbstractString, mode::AbstractString="r"; swmr=false, pv...)
 
 Open or create an HDF5 file where `mode` is one of:
  - "r"  read only
@@ -663,7 +663,7 @@ function h5open(filename::AbstractString, mode::AbstractString="r"; swmr=false, 
 end
 
 """
-    function h5open(f::Function, args...; swmr=false)
+    function h5open(f::Function, args...; swmr=false, pv...)
 
 Apply the function f to the result of `h5open(args...;kwargs...)` and close the resulting
 `HDF5File` upon completion. For example with a `do` block:

--- a/src/mpio.jl
+++ b/src/mpio.jl
@@ -50,3 +50,6 @@ h5p_get_fapl_mpio(fapl_id, comm::Ref{Hmpih64}, info::Ref{Hmpih64}) =
 
 hdf5_prop_get_set["fapl_mpio"] =
     (h5p_get_fapl_mpio, h5p_set_fapl_mpio, H5P_FILE_ACCESS)
+
+hdf5_prop_get_set["dxpl_mpio"] =
+    (h5p_get_dxpl_mpio, h5p_set_dxpl_mpio, H5P_DATASET_XFER)

--- a/src/mpio.jl
+++ b/src/mpio.jl
@@ -1,4 +1,10 @@
 using .MPI
+import Libdl
+
+# Check whether the HDF5 libraries were compiled with parallel support.
+HAS_PARALLEL[] = Libdl.dlopen(libhdf5) do lib
+    Libdl.dlsym(lib, :H5Pget_fapl_mpio, throw_error=false) !== nothing
+end
 
 # Low-level MPI handles.
 const MPIHandle = Union{MPI.MPI_Comm, MPI.MPI_Info}

--- a/src/mpio.jl
+++ b/src/mpio.jl
@@ -1,0 +1,52 @@
+using .MPI
+
+# Low-level MPI handles.
+const MPIHandle = Union{MPI.MPI_Comm, MPI.MPI_Info}
+
+# MPI.jl wrapper types.
+const MPIHandleWrapper = Union{MPI.Comm, MPI.Info}
+
+const H5MPIHandle = let csize = sizeof(MPI.MPI_Comm)
+    @assert csize in (4, 8)
+    csize == 4 ? Hmpih32 : Hmpih64
+end
+
+h5_to_mpi(handle::H5MPIHandle) = reinterpret(MPI.MPI_Comm, handle)
+
+mpi_to_h5(handle::MPIHandle) = reinterpret(H5MPIHandle, handle)
+mpi_to_h5(mpiobj::MPIHandleWrapper) = mpi_to_h5(mpiobj.val)
+
+# Set MPIO properties in HDF5.
+# Note: HDF5 creates a COPY of the comm and info objects.
+function h5p_set_fapl_mpio(fapl_id, comm::MPI.Comm, info::MPI.Info)
+    h5comm = mpi_to_h5(comm)
+    h5info = mpi_to_h5(info)
+    h5p_set_fapl_mpio(fapl_id, h5comm, h5info)
+end
+
+h5p_set_fapl_mpio(fapl_id, comm::Hmpih32, info::Hmpih32) =
+    h5p_set_fapl_mpio32(fapl_id, comm, info)
+h5p_set_fapl_mpio(fapl_id, comm::Hmpih64, info::Hmpih64) =
+    h5p_set_fapl_mpio64(fapl_id, comm, info)
+
+# Retrieves the copies of the comm and info MPIO objects from the HDF5 property list.
+function h5p_get_fapl_mpio(fapl_id)
+    h5comm, h5info = h5p_get_fapl_mpio(fapl_id, H5MPIHandle)
+    comm = MPI.Comm(h5_to_mpi(h5comm))
+    info = MPI.Info(h5_to_mpi(h5info))
+    comm, info
+end
+
+function h5p_get_fapl_mpio(fapl_id, ::Type{h}) where {h}
+    comm, info = Ref{h}(), Ref{h}()
+    h5p_get_fapl_mpio(fapl_id, comm, info)
+    comm[], info[]
+end
+
+h5p_get_fapl_mpio(fapl_id, comm::Ref{Hmpih32}, info::Ref{Hmpih32}) =
+    h5p_get_fapl_mpio32(fapl_id, comm, info)
+h5p_get_fapl_mpio(fapl_id, comm::Ref{Hmpih64}, info::Ref{Hmpih64}) =
+    h5p_get_fapl_mpio64(fapl_id, comm, info)
+
+hdf5_prop_get_set["fapl_mpio"] =
+    (h5p_get_fapl_mpio, h5p_set_fapl_mpio, H5P_FILE_ACCESS)

--- a/src/mpio.jl
+++ b/src/mpio.jl
@@ -59,3 +59,36 @@ hdf5_prop_get_set[:fapl_mpio] =
 
 hdf5_prop_get_set[:dxpl_mpio] =
     (h5p_get_dxpl_mpio, h5p_set_dxpl_mpio, H5P_DATASET_XFER)
+
+function check_hdf5_parallel()
+    has_parallel() && return
+    error(
+        "HDF5.jl has no parallel support." *
+        " Make sure that you're using MPI-enabled HDF5 libraries, and that" *
+        " MPI was loaded before HDF5." *
+        " See HDF5.jl docs for details."
+    )
+end
+
+"""
+    h5open(filename, [mode="r"], comm::MPI.Comm, [info::MPI.Info]; pv...)
+
+Open or create a parallel HDF5 file using the MPI-IO driver.
+
+Equivalent to `h5open(filename, mode; fapl_mpio=(comm, info), pv...)`.
+Throws an informative error if the loaded HDF5 libraries do not include parallel
+support.
+
+See the [HDF5 docs](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_MPIO)
+for details on the `comm` and `info` arguments.
+"""
+function h5open(
+        filename::AbstractString, mode::AbstractString,
+        comm::MPI.Comm, info::MPI.Info = MPI.Info(); pv...
+    )
+    check_hdf5_parallel()
+    h5open(filename, mode; fapl_mpio=(comm, info), pv...)
+end
+
+h5open(filename::AbstractString, comm::MPI.Comm, args...; pv...) =
+    h5open(filename, "r", comm, args...; pv...)

--- a/src/mpio.jl
+++ b/src/mpio.jl
@@ -54,8 +54,8 @@ h5p_get_fapl_mpio(fapl_id, comm::Ref{Hmpih32}, info::Ref{Hmpih32}) =
 h5p_get_fapl_mpio(fapl_id, comm::Ref{Hmpih64}, info::Ref{Hmpih64}) =
     h5p_get_fapl_mpio64(fapl_id, comm, info)
 
-hdf5_prop_get_set["fapl_mpio"] =
+hdf5_prop_get_set[:fapl_mpio] =
     (h5p_get_fapl_mpio, h5p_set_fapl_mpio, H5P_FILE_ACCESS)
 
-hdf5_prop_get_set["dxpl_mpio"] =
+hdf5_prop_get_set[:dxpl_mpio] =
     (h5p_get_dxpl_mpio, h5p_set_dxpl_mpio, H5P_DATASET_XFER)

--- a/test/mpio.jl
+++ b/test/mpio.jl
@@ -5,63 +5,65 @@ using Test
 @testset "mpio" begin
 
 MPI.Init()
+
 info = MPI.Info()
+comm = MPI.COMM_WORLD
 
-h = HDF5.mpihandles[sizeof(MPI.CComm)]
-ccomm = reinterpret(h, MPI.CComm(MPI.COMM_WORLD))
-cinfo = reinterpret(h, MPI.CInfo(info))
-
-nprocs = MPI.Comm_size(MPI.COMM_WORLD)
-myrank = MPI.Comm_rank(MPI.COMM_WORLD)
+nprocs = MPI.Comm_size(comm)
+myrank = MPI.Comm_rank(comm)
 
 fileprop = p_create(HDF5.H5P_FILE_ACCESS)
-HDF5.h5p_set_fapl_mpio(fileprop, ccomm, cinfo)
-h5comm, h5info = HDF5.h5p_get_fapl_mpio(fileprop, h)
 
-# compare the pointer in case of OpenMPI
-if h == HDF5.Hmpih64
-  c2 = unsafe_load(reinterpret(Ptr{Clong}, ccomm))
-  c3 = unsafe_load(reinterpret(Ptr{Clong}, h5comm))
-  #
-  @test c2 == c3
+HDF5.h5p_set_fapl_mpio(fileprop, comm, info)
+h5comm, h5info = HDF5.h5p_get_fapl_mpio(fileprop)
+
+# check that the two communicators point to the same group
+if isdefined(MPI, :Comm_compare)  # requires recent MPI.jl version
+    @test MPI.Comm_compare(comm, h5comm) === MPI.CONGRUENT
 end
 
 # open file in parallel and write dataset
-fn = String(MPI.bcast(collect(tempname()), 0, MPI.COMM_WORLD))
-f = h5open(fn, "w", fapl_mpio=(ccomm, cinfo) )
-@test isopen(f)
+fn = MPI.bcast(tempname(), 0, comm)
+A = [myrank + i for i = 1:10]
+h5open(fn, "w", fapl_mpio=(comm, info)) do f
+    @test isopen(f)
+    g = g_create(f, "mygroup")
+    dset = d_create(g, "B", datatype(Int64), dataspace(10, nprocs), chunk=(10, 1), dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
+    dset[:, myrank + 1] = A
+end
 
-g = g_create(f, "mygroup")
-A = [ myrank + i for i = 1:10]
-dset = d_create(g, "B", datatype(Int64), dataspace(10, nprocs), chunk=(10, 1), dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
-dset[:,myrank+1] = A
-close(f)
+MPI.Barrier(comm)
+h5open(fn, "r", fapl_mpio=(comm, info)) do f
+    @test isopen(f)
+    @test names(f) == ["mygroup"]
 
+    # read(f, name, pv...) is already taken by multi-dataset read, bool withargs
+    # is only dummy argument
+    B = read(f, "mygroup/B", true, dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
+    @test !isempty(B)
+    @test A == vec(B[:, myrank + 1])
 
-MPI.Barrier(MPI.COMM_WORLD)
-f = h5open(String(fn), "r", "fapl_mpio", (ccomm, cinfo))
-@test isopen(f)
-@test names(f) == ["mygroup"]
-# read(f, name, pv...) is already taken by multi-dataset read, bool withargs is only dummy argument
-B=read(f, "mygroup/B", true, "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
-@test !isempty(B)
+    B = f["mygroup/B", dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE]
+    @test !isempty(B)
+    @test A == vec(B[:, myrank + 1])
+end
+
+MPI.Barrier(comm)
+
+B = h5read(fn, "mygroup/B", fapl_mpio=(comm, info), dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
 @test A == vec(B[:, myrank + 1])
-B=f["mygroup/B", "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE]
-@test !isempty(B)
-@test A == vec(B[:, myrank + 1])
-close(f)
 
-MPI.Barrier(MPI.COMM_WORLD)
-B = h5read(fn, "mygroup/B", fapl_mpio=(ccomm, cinfo), dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
-@test A == vec(B[:, myrank + 1])
-MPI.Barrier(MPI.COMM_WORLD)
-B = h5read(fn, "mygroup/B", (:, myrank + 1), fapl_mpio=(ccomm, cinfo), dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
+MPI.Barrier(comm)
+
+B = h5read(fn, "mygroup/B", (:, myrank + 1), fapl_mpio=(comm, info), dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
 @test A == vec(B)
 
 # we need to close HDF5 and finalize the info object before finalizing MPI
 finalize(info)
 HDF5.h5_close()
+
 MPI.Barrier(MPI.COMM_WORLD)
+
 MPI.Finalize()
 
 end # testset mpio

--- a/test/mpio.jl
+++ b/test/mpio.jl
@@ -39,9 +39,7 @@ h5open(fn, "r", fapl_mpio=(comm, info)) do f
     @test isopen(f)
     @test names(f) == ["mygroup"]
 
-    # read(f, name, pv...) is already taken by multi-dataset read, bool withargs
-    # is only dummy argument
-    B = read(f, "mygroup/B", true, dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
+    B = read(f, "mygroup/B", dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
     @test !isempty(B)
     @test A == vec(B[:, myrank + 1])
 

--- a/test/mpio.jl
+++ b/test/mpio.jl
@@ -12,6 +12,8 @@ comm = MPI.COMM_WORLD
 nprocs = MPI.Comm_size(comm)
 myrank = MPI.Comm_rank(comm)
 
+@test HDF5.has_parallel()
+
 fileprop = p_create(HDF5.H5P_FILE_ACCESS)
 
 HDF5.h5p_set_fapl_mpio(fileprop, comm, info)


### PR DESCRIPTION
As discussed in #619, this proposal modifies parallel HDF5 support, defining certain MPI I/O specific functions only if MPI.jl was previously loaded. This is done using [Requires](https://github.com/JuliaPackaging/Requires.jl), so that MPI.jl is not added to the dependency list of HDF5.jl.

The main advantage of this approach is that we now have access to types such as `MPI.MPI_Comm` (a C object) and `MPI.Comm` (its Julia wrapper). In particular, we know their sizes, which simplifies the previous implementation, and solves some (minor) type inference issues.

MPI I/O functions such as `h5p_set_fapl_mpio` and `h5p_get_fapl_mpio` now have definitions that accept (or return) MPI wrappers, which are properly managed by MPI.jl. This greatly simplifies opening parallel HDF5 files, as `MPI.Comm` and `MPI.Info` objects no longer need to be converted to their HDF5 counterparts by the user.

In particular, the following is now possible with the proposed changes:

```julia
comm = MPI.COMM_WORLD
info = MPI.Info()

h5open("filename.h5", "w", "fapl_mpio", (comm, info)) do ff
    # do stuff...
end
```

In its current form, this proposal breaks compatibility with previous versions with regard to parallel HDF5 support, since the `mpihandles` dict and `h5_mpihandle` function were removed. If this is not acceptable, I guess these could be kept for backwards compatibility. It also breaks compatibility in a second way (very minor, in my opinion): due to Requires, MPI necessarily needs to be imported before HDF5 for parallel I/O to work.

Finally, this updates the `test/mpio.jl` script (which was broken under recent MPI.jl versions) to use the new functionality.