### PR TITLE
RFC: use keyword args for setting properties

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,7 @@
+## v0.14
+
+* Properties are now set using keyword arguments instead of by pairs of string and value positional arguments.
+  For example `dset = d_create(h5f, "A", datatype(Int64), dataspace(10,10), "chunk", (3,3))` is now written as
+  `dset = d_create(h5f, "A", datatype(Int64), dataspace(10,10), chunk=(3,3))`. Additionally the key type used for
+  directly setting `HDF5Properties` objects has changed from a `String` to a `Symbol`, e.g.
+  `apl["fclose_degree"] = H5F_CLOSE_STRONG` is now written as `apl[:fclose_degree] = H5F_CLOSE_STRONG` ([#632](https://github.com/JuliaIO/HDF5.jl/pull/632)).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -96,15 +96,15 @@ It is often required to pass parameters to specific routines, which are collecte
 in so-called property lists in HDF5. There are different property lists for
 different tasks, e.g. for the access/creation of files, datasets, groups.
 In this high level framework multiple parameters can be simply applied by
-appending them at the end of function calls as a list of key/value pairs.
+appending them at the end of function calls as keyword arguments.
 
 ```julia
 g["A"] = A  # basic
-g["A", "chunk", (5,5)] = A # add chunks
+g["A", chunk=(5,5)] = A # add chunks
 
 B=h5read(fn,"mygroup/B", # two parameters
-  "fapl_mpio", (ccomm,cinfo), # if parameter requires multiple args use tuples
-  "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE )
+  fapl_mpio=(ccomm,cinfo), # if parameter requires multiple args use tuples
+  dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE )
 ```
 
 This will automatically create the correct property lists, add the properties,
@@ -125,7 +125,7 @@ You can also optionally "chunk" and/or compress your data. For example,
 
 ```julia
 A = rand(100,100)
-g["A", "chunk", (5,5)] = A
+g["A", chunk=(5,5)] = A
 ```
 
 stores the matrix `A` in 5-by-5 chunks. Chunking improves efficiency if you
@@ -134,9 +134,9 @@ contiguously.
 
 ```julia
 A = rand(100,100)
-g1["A", "chunk", (5,5), "compress", 3] = A
-g2["A", "chunk", (5,5), "shuffle", (), "deflate", 3] = A
-g3["A", "chunk", (5,5), "blosc", 3] = A
+g1["A", chunk=(5,5), compress=3] = A
+g2["A", chunk=(5,5), shuffle=(), deflate=3] = A
+g3["A", chunk=(5,5), blosc=3] = A
 ```
 
 Standard compression in HDF5 (`"compress"`) corresponds to (`"deflate"`) and
@@ -154,7 +154,7 @@ useful to incrementally save to very large datasets you don't want to keep in
 memory. For example,
 
 ```julia
-dset = d_create(g, "B", datatype(Float64), dataspace(1000,100,10), "chunk", (100,100,1))
+dset = d_create(g, "B", datatype(Float64), dataspace(1000,100,10), chunk=(100,100,1))
 dset[:,1,1] = rand(1000)
 ```
 
@@ -311,12 +311,12 @@ a_write(parent, name, data)
 
 You can use extendible dimensions,
 ```julia
-d = d_create(parent, name, dtype, (dims, max_dims), "chunk", (chunk_dims), [lcpl, dcpl, dapl])
+d = d_create(parent, name, dtype, (dims, max_dims), chunk=(chunk_dims))
 set_dims!(d, new_dims)
 ```
 where dims is a tuple of integers.  For example
 ```julia
-b = d_create(fid, "b", Int, ((1000,),(-1,)), "chunk", (100,)) #-1 is equivalent to typemax(Hsize)
+b = d_create(fid, "b", Int, ((1000,),(-1,)), chunk=(100,)) #-1 is equivalent to typemax(Hsize)
 set_dims!(b, (10000,))
 b[1:10000] = collect(1:10000)
 ```

--- a/test/extend_test.jl
+++ b/test/extend_test.jl
@@ -7,7 +7,7 @@ fn = tempname()
 
 fid = h5open(fn, "w")
 g = g_create(fid, "shoe")
-d = d_create(g, "foo", datatype(Float64), ((10, 20), (100, 200)), "chunk", (1, 1))
+d = d_create(g, "foo", datatype(Float64), ((10, 20), (100, 200)), chunk=(1, 1))
 #println("d is size current $(map(int,HDF5.get_dims(d)[1])) max $(map(int,HDF5.get_dims(d)[2]))")
 dims, max_dims = HDF5.get_dims(d)
 @test dims == (UInt64(10), UInt64(20))
@@ -40,7 +40,7 @@ set_dims!(d, (1, 5))
 Array(d) == [1.1231 1.313 5.123 2.231 4.1231]
 
 #println("d is size current $(map(int,HDF5.get_dims(d)[1])) max $(map(int,HDF5.get_dims(d)[2]))")
-b = d_create(fid, "b", Int, ((1000,), (-1,)), "chunk", (100,)) #-1 is equivalent to typemax(Hsize) as far as I can tell
+b = d_create(fid, "b", Int, ((1000,), (-1,)), chunk=(100,)) #-1 is equivalent to typemax(Hsize) as far as I can tell
 #println("b is size current $(map(int,HDF5.get_dims(b)[1])) max $(map(int,HDF5.get_dims(b)[2]))")
 b[1:200] = ones(200)
 dims, max_dims = HDF5.get_dims(b)

--- a/test/memtest.jl
+++ b/test/memtest.jl
@@ -14,11 +14,11 @@ macro memtest(ex)
     end
 end
 @memtest h5open("/tmp/memtest.h5", "w") do file
-    dset = d_create(file, "A", datatype(DATA), dataspace(DATA), "chunk", (100,))
+    dset = d_create(file, "A", datatype(DATA), dataspace(DATA), chunk=(100,))
     dset[:] = DATA[:]
 end
 @memtest h5open("/tmp/memtest.h5", "w") do file
-    file["A", "chunk", (100,)] = DATA[:]
+    file["A", chunk=(100,)] = DATA[:]
 end
 @memtest h5open("/tmp/memtest.h5", "r") do file
     file["A","dxpl_mpio", 0]

--- a/test/mpio.jl
+++ b/test/mpio.jl
@@ -28,12 +28,12 @@ end
 
 # open file in parallel and write dataset
 fn = String(MPI.bcast(collect(tempname()), 0, MPI.COMM_WORLD))
-f = h5open(fn, "w", "fapl_mpio", (ccomm, cinfo) )
+f = h5open(fn, "w", fapl_mpio=(ccomm, cinfo) )
 @test isopen(f)
 
 g = g_create(f, "mygroup")
 A = [ myrank + i for i = 1:10]
-dset = d_create(g, "B", datatype(Int64), dataspace(10, nprocs), "chunk", (10, 1), "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
+dset = d_create(g, "B", datatype(Int64), dataspace(10, nprocs), chunk=(10, 1), dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
 dset[:,myrank+1] = A
 close(f)
 
@@ -52,10 +52,10 @@ B=f["mygroup/B", "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE]
 close(f)
 
 MPI.Barrier(MPI.COMM_WORLD)
-B = h5read(fn, "mygroup/B", "fapl_mpio", (ccomm, cinfo), "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
+B = h5read(fn, "mygroup/B", fapl_mpio=(ccomm, cinfo), dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
 @test A == vec(B[:, myrank + 1])
 MPI.Barrier(MPI.COMM_WORLD)
-B = h5read(fn, "mygroup/B", (:, myrank + 1), "fapl_mpio", (ccomm, cinfo), "dxpl_mpio", HDF5.H5FD_MPIO_COLLECTIVE)
+B = h5read(fn, "mygroup/B", (:, myrank + 1), fapl_mpio=(ccomm, cinfo), dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
 @test A == vec(B)
 
 # we need to close HDF5 and finalize the info object before finalizing MPI

--- a/test/swmr.jl
+++ b/test/swmr.jl
@@ -27,7 +27,7 @@ end
 @testset "h5d_oappend" begin
     h5open(fname, "w") do h5
         g = g_create(h5, "shoe")
-        d = d_create(g, "bar", datatype(Float64), ((1,), (-1,)), "chunk", (100,))
+        d = d_create(g, "bar", datatype(Float64), ((1,), (-1,)), chunk=(100,))
         dxpl_id = HDF5.get_create_properties(d)
         v = [1.0, 2.0]
         memtype = datatype(Float64).id
@@ -89,14 +89,14 @@ end
 
 # create datasets and attributes before staring swmr writing
 function prep_h5_file(h5)
-    d = d_create(h5, "foo", datatype(Int), ((1,), (100,)), "chunk", (1,))
+    d = d_create(h5, "foo", datatype(Int), ((1,), (100,)), chunk=(1,))
     attrs(h5)["bar"] = "bar"
     g = g_create(h5, "group")
 end
 
 @testset "create by libver, then start_swmr_write" begin
     #test this h5open method with keyword arg
-    h5open(fname, "w", "libver_bounds", (HDF5.H5F_LIBVER_LATEST, HDF5.H5F_LIBVER_LATEST), swmr=false) do h5
+    h5open(fname, "w", libver_bounds=(HDF5.H5F_LIBVER_LATEST, HDF5.H5F_LIBVER_LATEST), swmr=false) do h5
         prep_h5_file(h5)
         HDF5.start_swmr_write(h5) # after creating datasets
         remote_test(h5)


### PR DESCRIPTION
I decided to try this while looking at #631. This replaces the current method of setting properties using varargs with keyword arguments. This is breaking so we should discuss if it is worth it. In #462 where the current behavior was introduced it looks like this wasn't done because the behavior of keyword arguments was still stabilizing in julia. Now that julia has stabilized I think this is a better interface.