### PR TITLE
Fix support for reading more deeply nested types

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -2460,16 +2460,6 @@ function vlen_get_buf_size(dset::HDF5Dataset, dtype::HDF5Datatype, dspace::HDF5D
     sz[]
 end
 
-function hdf5array(objtype)
-    nd = h5t_get_array_ndims(objtype.id)
-    dims = Vector{Hsize}(undef,nd)
-    h5t_get_array_dims(objtype.id, dims)
-    eltyp = HDF5Datatype(h5t_get_super(objtype.id))
-    T = get_mem_compatible_jl_type(objtype)
-    dimsizes = ntuple(i -> Int(dims[nd-i+1]), nd)  # reverse order
-    FixedArray{T, dimsizes, prod(dimsizes)}
-end
-
 ### Property manipulation ###
 get_create_properties(d::HDF5Dataset)   = HDF5Properties(h5d_get_create_plist(d.id), H5P_DATASET_CREATE)
 get_create_properties(g::HDF5Group)     = HDF5Properties(h5g_get_create_plist(g.id), H5P_GROUP_CREATE)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -2376,6 +2376,18 @@ function h5l_get_info(link_loc_id::Hid, link_name::String, lapl_id::Hid)
     info[]
 end
 
+function h5lt_dtype_to_text(dtype_id; max_len=512)
+  buf = Vector{UInt8}(undef, max_len)
+  sz = Csize_t[length(buf)]
+  status = ccall((:H5LTdtype_to_text, libhdf5_hl), Int, (HDF5.Hid, Ptr{UInt8}, Int, Ptr{Csize_t}), dtype_id, buf, 0, sz)
+  if status < 0
+    error("Error getting dtype text representation")
+  end
+  buf[end] = 0 # nullterm
+  dtype_text = rstrip(unsafe_string(pointer(buf)))
+  return dtype_text
+end
+
 # Set MPIO properties in HDF5.
 # Note: HDF5 creates a COPY of the comm and info objects.
 function h5p_set_fapl_mpio(fapl_id, comm, info)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1491,7 +1491,7 @@ function read(dset::HDF5Dataset, T::Union{Type{Array{U}}, Type{U}}) where U <: N
     h5type_str = h5lt_dtype_to_text(memtype.id)
     error("""
           Type size mismatch
-          sizeof($T) = $(sizeof(T))
+          sizeof($U) = $(sizeof(U))
           sizeof($h5type_str) = $(h5t_get_size(memtype.id))
           """)
   end

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -479,7 +479,7 @@ eltype(::Type{FixedArray{T,D,L}}) where {T,D,L} = T
 eltype(x::T) where T <: FixedArray = eltype(T)
 
 struct FixedString{N, PAD}
-  data::NTuple{N, Cchar}
+  data::NTuple{N, UInt8}
 end
 length(::Type{FixedString{N, PAD}}) where {N, PAD} = N
 length(x::T) where T <: FixedString = length(T)
@@ -1470,7 +1470,7 @@ end
 normalize_types(x) = x
 normalize_types(x::NamedTuple{T}) where T = NamedTuple{T}(map(normalize_types, values(x)))
 normalize_types(x::Cstring) = unsafe_string(x)
-normalize_types(x::FixedString) = unpad(join(Char.(x.data)), pad(x))
+normalize_types(x::FixedString) = unpad(String(collect(x.data)), pad(x))
 normalize_types(x::FixedArray) = reshape(collect(x.data), size(x)...)
 normalize_types(x::VariableArray) = copy(unsafe_wrap(Array, convert(Ptr{eltype(x)}, x.p), x.len, own=false))
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -2386,15 +2386,16 @@ function h5l_get_info(link_loc_id::Hid, link_name::String, lapl_id::Hid)
     info[]
 end
 
-function h5lt_dtype_to_text(dtype_id; max_len=512)
-  buf = Vector{UInt8}(undef, max_len)
-  sz = Csize_t[length(buf)]
-  status = ccall((:H5LTdtype_to_text, libhdf5_hl), Int, (HDF5.Hid, Ptr{UInt8}, Int, Ptr{Csize_t}), dtype_id, buf, 0, sz)
-  if status < 0
-    error("Error getting dtype text representation")
-  end
-  buf[end] = 0 # nullterm
-  dtype_text = rstrip(unsafe_string(pointer(buf)))
+function h5lt_dtype_to_text(dtype_id)
+  len = Csize_t[0]
+  status = ccall((:H5LTdtype_to_text, libhdf5_hl), Int, (HDF5.Hid, Ptr{UInt8}, Int, Ptr{Csize_t}), dtype_id, C_NULL, 0, len)
+  status < 0 && error("Error getting dtype text representation")
+
+  buf = Vector{UInt8}(undef, len[1])
+  status = ccall((:H5LTdtype_to_text, libhdf5_hl), Int, (HDF5.Hid, Ptr{UInt8}, Int, Ptr{Csize_t}), dtype_id, buf, 0, len)
+  status < 0 && error("Error getting dtype text representation")
+
+  dtype_text = unsafe_string(pointer(buf))
   return dtype_text
 end
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1471,8 +1471,8 @@ normalize_types(x) = x
 normalize_types(x::NamedTuple{T}) where T = NamedTuple{T}(map(normalize_types, values(x)))
 normalize_types(x::Cstring) = unsafe_string(x)
 normalize_types(x::FixedString) = unpad(String(collect(x.data)), pad(x))
-normalize_types(x::FixedArray) = reshape(collect(x.data), size(x)...)
-normalize_types(x::VariableArray) = copy(unsafe_wrap(Array, convert(Ptr{eltype(x)}, x.p), x.len, own=false))
+normalize_types(x::FixedArray) = normalize_types.(reshape(collect(x.data), size(x)...))
+normalize_types(x::VariableArray) = normalize_types.(copy(unsafe_wrap(Array, convert(Ptr{eltype(x)}, x.p), x.len, own=false)))
 
 do_normalize(::Type{T}) where T = false
 do_normalize(::Type{NamedTuple{T, U}}) where T where U = any(i -> do_normalize(fieldtype(U,i)), 1:fieldcount(U))

--- a/test/compound.jl
+++ b/test/compound.jl
@@ -1,6 +1,7 @@
 using Random, Test, HDF5
 
 import HDF5.datatype
+import Base.convert
 import Base.unsafe_convert
 
 struct foo
@@ -14,7 +15,7 @@ end
 struct foo_hdf5
   a::Float64
   b::Cstring
-  c::NTuple{20, Cchar}
+  c::NTuple{20, UInt8}
   d::NTuple{9, ComplexF64}
   e::HDF5.Hvl_t
 end
@@ -22,7 +23,7 @@ end
 function unsafe_convert(::Type{foo_hdf5}, x::foo)
   foo_hdf5(x.a,
            Base.unsafe_convert(Cstring, x.b),
-           ntuple(i -> i <= length(x.c) ? x.c[i] : '\0', 20),
+           ntuple(i -> i <= ncodeunits(x.c) ? codeunit(x.c, i) : '\0', 20),
            ntuple(i -> x.d[i], length(x.d)),
            HDF5.Hvl_t(length(x.e), pointer(x.e))
           )
@@ -38,7 +39,7 @@ function datatype(::Type{foo_hdf5})
   HDF5.h5t_insert(dtype, "b", fieldoffset(foo_hdf5, 2), vlenstr_dtype)
 
   fixedstr_dtype = HDF5.h5t_copy(HDF5.H5T_C_S1)
-  HDF5.h5t_set_size(fixedstr_dtype, 20 * sizeof(Cchar))
+  HDF5.h5t_set_size(fixedstr_dtype, 20 * sizeof(UInt8))
   HDF5.h5t_set_cset(fixedstr_dtype, HDF5.H5T_CSET_UTF8)
   HDF5.h5t_set_strpad(fixedstr_dtype, HDF5.H5T_STR_NULLPAD)
   HDF5.h5t_insert(dtype, "c", fieldoffset(foo_hdf5, 3), fixedstr_dtype)
@@ -53,6 +54,34 @@ function datatype(::Type{foo_hdf5})
   HDF5Datatype(dtype)
 end
 
+struct bar
+  a::Vector{String}
+end
+
+struct bar_hdf5
+  a::NTuple{2, NTuple{20, UInt8}}
+end
+
+function datatype(::Type{bar_hdf5})
+  dtype = HDF5.h5t_create(HDF5.H5T_COMPOUND, sizeof(bar_hdf5))
+
+  fixedstr_dtype = HDF5.h5t_copy(HDF5.H5T_C_S1)
+  HDF5.h5t_set_size(fixedstr_dtype, 20 * sizeof(UInt8))
+  HDF5.h5t_set_cset(fixedstr_dtype, HDF5.H5T_CSET_UTF8)
+
+  hsz = HDF5.Hsize[2]
+  array_dtype = HDF5.h5t_array_create(fixedstr_dtype, 1, hsz)
+
+  HDF5.h5t_insert(dtype, "a", fieldoffset(bar_hdf5, 1), array_dtype)
+
+  HDF5Datatype(dtype)
+end
+
+function convert(::Type{bar_hdf5}, x::bar)
+  bar_hdf5(ntuple(i -> ntuple(j -> j <= ncodeunits(x.a[i]) ? codeunit(x.a[i], j) : '\0', 20), 2))
+end
+
+
 @testset "compound" begin
   N = 10
   v = [foo(rand(),
@@ -62,20 +91,41 @@ end
            rand(1:10, rand(10:100))
           )
        for _ in 1:N]
+
+  v[1] = foo(1.0,
+             "uniçº∂e",
+             "uniçº∂e",
+             rand(ComplexF64, 3,3),
+             rand(1:10, rand(10:100)))
+
   v_write = unsafe_convert.(foo_hdf5, v)
+
+  w = [bar(["uniçº∂e", "hello"])]
+  w_write = convert.(bar_hdf5, w)
 
   fn = tempname()
   h5open(fn, "w") do h5f
-    dtype = datatype(foo_hdf5)
-    space = dataspace(v_write)
-    dset = HDF5.h5d_create(h5f.id, "data", dtype.id, space.id)
-    HDF5.h5d_write(dset, dtype.id, v_write)
+    foo_dtype = datatype(foo_hdf5)
+    foo_space = dataspace(v_write)
+    foo_dset = HDF5.h5d_create(h5f.id, "foo", foo_dtype.id, foo_space.id)
+    HDF5.h5d_write(foo_dset, foo_dtype.id, v_write)
+
+    bar_dtype = datatype(bar_hdf5)
+    bar_space = dataspace(w_write)
+    bar_dset = HDF5.h5d_create(h5f.id, "bar", bar_dtype.id, bar_space.id)
+    HDF5.h5d_write(bar_dset, bar_dtype.id, w_write)
   end
 
-  v_read = h5read(fn, "data")
+  v_read = h5read(fn, "foo")
   for field in (:a, :b, :c, :d, :e)
     f = x -> getfield(x, field)
     @test f.(v) == f.(v_read)
+  end
+
+  w_read = h5read(fn, "bar")
+  for field in (:a,)
+    f = x -> getfield(x, field)
+    @test f.(w) == f.(w_read)
   end
 
   T = NamedTuple{(:a, :b, :c, :d, :e, :f), Tuple{Int, Int, Int, Int, Int, Cstring}}


### PR DESCRIPTION
This should close #634. I also fixed unicode support in fixed sized strings which had previously been broken and maybe fixed the ci failure from the `h5d_vlen_reclaim` call although it is still mysterious to me why that failure only appears on some builds. 