### PR TITLE
Add ability to set dataset create-time allocation policy

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -80,6 +80,12 @@ const H5_INDEX_CRT_ORDER = 1
 const H5D_COMPACT      = 0
 const H5D_CONTIGUOUS   = 1
 const H5D_CHUNKED      = 2
+# allocation times (C enum H5D_alloc_time_t)
+const H5D_ALLOC_TIME_ERROR = -1
+const H5D_ALLOC_TIME_DEFAULT = 0
+const H5D_ALLOC_TIME_EARLY = 1
+const H5D_ALLOC_TIME_LATE = 2
+const H5D_ALLOC_TIME_INCR = 3
 # error-related constants
 const H5E_DEFAULT      = 0
 # file access modes
@@ -2132,11 +2138,13 @@ for (jlname, h5name, outtype, argtypes, argsyms, msg) in
      (:h5o_get_info, :H5Oget_info1, Herr, (Hid, Ptr{H5Oinfo}), (:object_id, :buf), "Error getting object info"),
      (:h5o_close, :H5Oclose, Herr, (Hid,), (:object_id,), "Error closing object"),
      (:h5p_close, :H5Pclose, Herr, (Hid,), (:id,), "Error closing property list"),
+     (:h5p_get_alloc_time, :H5Pget_alloc_time, Herr, (Hid, Ptr{Cint}), (:plist_id, :alloc_time), "Error getting allocation timing"),
      (:h5p_get_dxpl_mpio,   :H5Pget_dxpl_mpio, Herr, (Hid, Ptr{Cint}), (:dxpl_id, :xfer_mode), "Error getting MPIO transfer mode"),
      (:h5p_get_fapl_mpio32, :H5Pget_fapl_mpio, Herr, (Hid, Ptr{Hmpih32}, Ptr{Hmpih32}), (:fapl_id, :comm, :info), "Error getting MPIO properties"),
      (:h5p_get_fapl_mpio64, :H5Pget_fapl_mpio, Herr, (Hid, Ptr{Hmpih64}, Ptr{Hmpih64}), (:fapl_id, :comm, :info), "Error getting MPIO properties"),
      (:h5p_get_fclose_degree, :H5Pget_fclose_degree, Herr, (Hid, Ptr{Cint}), (:plist_id, :fc_degree), "Error getting close degree"),
      (:h5p_get_userblock, :H5Pget_userblock, Herr, (Hid, Ptr{Hsize}), (:plist_id, :len), "Error getting userblock"),
+     (:h5p_set_alloc_time, :H5Pset_alloc_time, Herr, (Hid, Cint), (:plist_id, :alloc_time), "Error setting allocation timing"),
      (:h5p_set_char_encoding, :H5Pset_char_encoding, Herr, (Hid, Cint), (:plist_id, :encoding), "Error setting char encoding"),
      (:h5p_set_chunk, :H5Pset_chunk, Herr, (Hid, Cint, Ptr{Hsize}), (:plist_id, :ndims, :dims), "Error setting chunk size"),
      (:h5p_set_create_intermediate_group, :H5Pset_create_intermediate_group, Herr, (Hid, Cuint), (:plist_id, :setting), "Error setting create intermediate group"),
@@ -2408,6 +2416,11 @@ get_create_properties(d::HDF5Dataset)   = HDF5Properties(h5d_get_create_plist(d.
 get_create_properties(g::HDF5Group)     = HDF5Properties(h5g_get_create_plist(g.id), H5P_GROUP_CREATE)
 get_create_properties(f::HDF5File)      = HDF5Properties(h5f_get_create_plist(f.id), H5P_FILE_CREATE)
 get_create_properties(a::HDF5Attribute) = HDF5Properties(h5a_get_create_plist(a.id), H5P_ATTRIBUTE_CREATE)
+function get_alloc_time(p::HDF5Properties)
+    alloc_time = Ref{Cint}()
+    h5p_get_alloc_time(p.id, alloc_time)
+    return alloc_time[]
+end
 function get_chunk(p::HDF5Properties)
     n = h5p_get_chunk(p, 0, C_NULL)
     cdims = Vector{Hsize}(undef,n)
@@ -2473,6 +2486,7 @@ end
 # Property names should follow the naming introduced by HDF5, i.e.
 # keyname => (h5p_get_keyname, h5p_set_keyname, id )
 const hdf5_prop_get_set = Dict(
+    :alloc_time    => (get_alloc_time, h5p_set_alloc_time,           H5P_DATASET_CREATE),
     :blosc         => (nothing, h5p_set_blosc,                       H5P_DATASET_CREATE),
     :char_encoding => (nothing, h5p_set_char_encoding,               H5P_LINK_CREATE),
     :chunk         => (get_chunk, set_chunk,                         H5P_DATASET_CREATE),

--- a/test/mmap.jl
+++ b/test/mmap.jl
@@ -8,10 +8,15 @@ fn = tempname()
 f = h5open(fn, "w")
 @test isopen(f)
 
-# Create unallocated dataset which cannot yet be mapped
-hdf5_A = d_create(f,"A",datatype(Int64),dataspace(3,3));
+# Create two datasets, one with late allocation (the default for contiguous
+# datasets) and the other with explicit early allocation.
+hdf5_A = d_create(f, "A", datatype(Int64), dataspace(3,3))
+hdf5_B = d_create(f, "B", datatype(Float64), dataspace(3,3);
+                  alloc_time = HDF5.H5D_ALLOC_TIME_EARLY)
+# The late case cannot be mapped yet.
 @test_throws ErrorException("Error mmapping array") readmmap(f["A"])
-# then write and fill the dataset, making it mappable
+# Then write and fill dataset A, making it mappable. B was filled with 0.0 at
+# creation.
 A = rand(Int64,3,3)
 hdf5_A[:,:] = A
 flush(f)
@@ -20,6 +25,7 @@ close(f)
 f = h5open(fn,"r")
 A_mmaped = readmmap(f["A"])
 @test all(A .== A_mmaped)
+@test all(iszero, readmmap(f["B"]))
 # Check that it is read only
 @test_throws ReadOnlyMemoryError A_mmaped[1,1] = 33
 close(f)

--- a/test/properties.jl
+++ b/test/properties.jl
@@ -1,0 +1,33 @@
+using HDF5
+using Test
+
+@testset "properties" begin
+
+fn = tempname()
+h5open(fn, "w") do hfile
+    # generic
+    g = g_create(hfile, "group")
+    d = d_create(g, "dataset", datatype(Int), dataspace((1,1)))
+    attrs(d)["metadata"] = "test"
+
+    # datasets for allocation time tests
+    d_create(hfile, "alloc_default", datatype(Int), dataspace((1,1)))
+    d_create(hfile, "alloc_early",   datatype(Int), dataspace((1,1)),
+             alloc_time = HDF5.H5D_ALLOC_TIME_EARLY)
+end
+
+h5open(fn, "r") do hfile
+    # Retrievability of properties
+    @test isvalid(get_create_properties(hfile))
+    @test isvalid(get_create_properties(hfile["group"]))
+    @test isvalid(get_create_properties(hfile["group"]["dataset"]))
+    @test isvalid(get_create_properties(attrs(hfile["group"]["dataset"])["metadata"]))
+
+    ## Test specific dataset creation properties
+    @test HDF5.get_alloc_time(get_create_properties(hfile["alloc_default"])) == HDF5.H5D_ALLOC_TIME_LATE
+    @test HDF5.get_alloc_time(get_create_properties(hfile["alloc_early"]))   == HDF5.H5D_ALLOC_TIME_EARLY
+end
+
+rm(fn, force=true)
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ include("gc.jl")
 include("external.jl")
 include("swmr.jl")
 include("mmap.jl")
+include("properties.jl")
 if get(Pkg.installed(), "MPI", nothing) !== nothing
   # basic MPI tests, for actual parallel tests we need to run in MPI mode
   include("mpio.jl")


### PR DESCRIPTION
This PR adds the `H5D_alloc_time_t` constants and getter/setter functions to control the dataset allocation policy, as described by https://portal.hdfgroup.org/display/HDF5/H5P_SET_ALLOC_TIME.

This is built upon #644 since I found that bug while learning about early vs late allocation, and I've got a use case where I'd like to try using early allocation with mmaped arrays. I also see #632 is proposed to overhaul the keyword handling a bunch, so I can rebase this change on that if it lands first.

~~I haven't added any tests that the `get_alloc_time()` function works since I didn't see any obvious place them, but I could create a new file/testset just for setting and getting property values if desired (which will probably be needed if more of the properties such as fill value and fill time are hooked up later).~~ Added in a new commit.