### PR TITLE
Update gh actions to skip x86 on MacOS 

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,5 @@
+comment: false
+
 coverage:
   status:
     project:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,3 @@
-comment: false
-
 coverage:
   status:
     project:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,4 +34,5 @@ jobs:
       - uses: julia-actions/julia-processcoverage@latest
       - uses: codecov/codecov-action@v1
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,11 +7,19 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        julia-version: ['1', '1.3', 'nightly']
-        julia-arch: [x64, x86]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        arch: [x64, x86]
+        version:
+          - '1.3'
+          - '1.5'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+          - x86
         exclude:
           - os: macOS-latest
             arch: x86
@@ -19,7 +27,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: ${{ matrix.julia-version }}
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
         exclude:
           - os: macOS-latest
             arch: x86
-          - version: '1.3'
+          - version: ['1.3', 'nightly']
             arch: x86
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,4 +38,5 @@ jobs:
       - uses: julia-actions/julia-processcoverage@latest
       - uses: codecov/codecov-action@v1
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,9 @@ jobs:
         exclude:
           - os: macOS-latest
             arch: x86
-          - version: ['1.3', 'nightly']
+          - version: '1.3'
+            arch: x86
+          - version: 'nightly'
             arch: x86
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,5 +34,4 @@ jobs:
       - uses: julia-actions/julia-processcoverage@latest
       - uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,8 @@ jobs:
         exclude:
           - os: macOS-latest
             arch: x86
+          - version: '1.3'
+            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
         arch: [x64, x86]
         exclude:
           - os: macOS-latest
-            julia-arch: x86
+            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -1,4 +1,4 @@
-name: Documenter
+name: CI
 
 on:
   push:


### PR DESCRIPTION
Typo