### PR TITLE
use h5lt_dtype_to_text for showing HDF5Datatype

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -420,7 +420,7 @@ mutable struct HDF5Datatype
     end
 end
 convert(::Type{Hid}, dtype::HDF5Datatype) = dtype.id
-show(io::IO, dtype::HDF5Datatype) = print(io, "HDF5 datatype ", dtype.id) # TODO: compound datatypes?
+show(io::IO, dtype::HDF5Datatype) = print(io, "HDF5 datatype: ", h5lt_dtype_to_text(dtype.id))
 hash(dtype::HDF5Datatype, h::UInt) =
     (dtype.id % UInt + h) ^ (0xadaf9b66bc962084 % UInt)
 ==(dt1::HDF5Datatype, dt2::HDF5Datatype) = h5t_equal(dt1, dt2) > 0
@@ -1464,11 +1464,10 @@ function read(dset::HDF5Dataset, T::Union{Type{Array{U}}, Type{U}}) where U <: N
   close(filetype)
 
   if sizeof(U) != h5t_get_size(memtype.id)
-    h5type_str = h5lt_dtype_to_text(memtype.id)
     error("""
           Type size mismatch
           sizeof($U) = $(sizeof(U))
-          sizeof($h5type_str) = $(h5t_get_size(memtype.id))
+          sizeof($memtype) = $(h5t_get_size(memtype.id))
           """)
   end
 


### PR DESCRIPTION
Before:
```
datatype(dset) = HDF5 datatype 216172782113784123
```

After:
```
datatype(dset) = HDF5 datatype: H5T_COMPOUND {
      H5T_IEEE_F64LE "a" : 0;
      H5T_STRING {
         STRSIZE H5T_VARIABLE;
         STRPAD H5T_STR_NULLTERM;
         CSET H5T_CSET_UTF8;
         CTYPE H5T_C_S1;
      } "b" : 8;
      H5T_STRING {
         STRSIZE 20;
         STRPAD H5T_STR_NULLPAD;
         CSET H5T_CSET_UTF8;
         CTYPE H5T_C_S1;
      } "c" : 16;
      H5T_ARRAY {
         [3][3] H5T_COMPOUND {
            H5T_IEEE_F64LE "r" : 0;
            H5T_IEEE_F64LE "i" : 8;
         }
      } "d" : 40;
      H5T_VLEN {
         H5T_STD_I64LE
      } "e" : 184;
   }
```

This does make the high level library more required.