### PR TITLE
Backport #645: Add ability to set dataset create-time allocation policy

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -184,6 +184,31 @@ Note that `readmmap` returns an `Array` rather than an HDF5 object.
 **Note**: if you use `readmmap` on a dataset and subsequently close the file, the array data are still available---and file continues to be in use---until all of the arrays are garbage-collected.
 This is in contrast to standard HDF5 datasets, where closing the file prevents further access to any of the datasets, but the file is also detached and can safely be rewritten immediately.
 
+Under the default
+[allocation-time policy](https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetAllocTime),
+a newly added `ismmappable` dataset can only be memory mapped after it has been written
+to.
+The following fails:
+```julia
+vec_dset = d_create(g, "v", datatype(Float64), dataspace(10_000,1))
+ismmappable(vec_dset)    # == true
+vec = readmmap(vec_dset) # throws ErrorException("Error mmapping array")
+```
+because although the dataset description has been added, the space within the HDF5 file
+has not yet actually been allocated (so the file region cannot be memory mapped by the OS).
+The storage can be allocated by making at least one write:
+```julia
+vec_dset[1,1] = 0.0      # force allocation of /g/v within the file
+vec = readmmap(vec_dset) # and now the memory mapping can succeed
+```
+
+Alternatlively, the policy can be set so that the space is allocated immediately upon
+creation of the data set with the `alloc_time` property key-value pair:
+```julia
+mtx_dset = d_create(g, "M", datatype(Float64), dataspace(100, 1000),
+                    "alloc_time", HDF5.H5D_ALLOC_TIME_EARLY)
+mtx = readmmap(mtx_dset) # succeeds immediately
+```
 
 ## Supported data types
 

--- a/test/mmap.jl
+++ b/test/mmap.jl
@@ -8,10 +8,15 @@ fn = tempname()
 f = h5open(fn, "w")
 @test isopen(f)
 
-# Create unallocated dataset which cannot yet be mapped
-hdf5_A = d_create(f,"A",datatype(Int64),dataspace(3,3));
+# Create two datasets, one with late allocation (the default for contiguous
+# datasets) and the other with explicit early allocation.
+hdf5_A = d_create(f, "A", datatype(Int64), dataspace(3,3))
+hdf5_B = d_create(f, "B", datatype(Float64), dataspace(3,3),
+                  "alloc_time", HDF5.H5D_ALLOC_TIME_EARLY)
+# The late case cannot be mapped yet.
 @test_throws ErrorException("Error mmapping array") readmmap(f["A"])
-# then write and fill the dataset, making it mappable
+# Then write and fill dataset A, making it mappable. B was filled with 0.0 at
+# creation.
 A = rand(Int64,3,3)
 hdf5_A[:,:] = A
 flush(f)
@@ -20,6 +25,7 @@ close(f)
 f = h5open(fn,"r")
 A_mmaped = readmmap(f["A"])
 @test all(A .== A_mmaped)
+@test all(iszero, readmmap(f["B"]))
 # Check that it is read only
 @test_throws ReadOnlyMemoryError A_mmaped[1,1] = 33
 close(f)

--- a/test/properties.jl
+++ b/test/properties.jl
@@ -1,0 +1,33 @@
+using HDF5
+using Test
+
+@testset "properties" begin
+
+fn = tempname()
+h5open(fn, "w") do hfile
+    # generic
+    g = g_create(hfile, "group")
+    d = d_create(g, "dataset", datatype(Int), dataspace((1,1)))
+    attrs(d)["metadata"] = "test"
+
+    # datasets for allocation time tests
+    d_create(hfile, "alloc_default", datatype(Int), dataspace((1,1)))
+    d_create(hfile, "alloc_early",   datatype(Int), dataspace((1,1)),
+             "alloc_time", HDF5.H5D_ALLOC_TIME_EARLY)
+end
+
+h5open(fn, "r") do hfile
+    # Retrievability of properties
+    @test isvalid(get_create_properties(hfile))
+    @test isvalid(get_create_properties(hfile["group"]))
+    @test isvalid(get_create_properties(hfile["group"]["dataset"]))
+    @test isvalid(get_create_properties(attrs(hfile["group"]["dataset"])["metadata"]))
+
+    ## Test specific dataset creation properties
+    @test HDF5.get_alloc_time(get_create_properties(hfile["alloc_default"])) == HDF5.H5D_ALLOC_TIME_LATE
+    @test HDF5.get_alloc_time(get_create_properties(hfile["alloc_early"]))   == HDF5.H5D_ALLOC_TIME_EARLY
+end
+
+rm(fn, force=true)
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ include("gc.jl")
 include("external.jl")
 include("swmr.jl")
 include("mmap.jl")
+include("properties.jl")
 if get(Pkg.installed(), "MPI", nothing) !== nothing
   # basic MPI tests, for actual parallel tests we need to run in MPI mode
   include("mpio.jl")


### PR DESCRIPTION
This is a backport of #645 to the v0.13 release branch. It's nearly the same, with the only required changes being that the string key/property value pairs are used (instead of function keywords) to account for "undoing" #632.