### PR TITLE
Fix getter function for [hypothetical] getindex(apl::HDF5Properties, :alignment)

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -2383,6 +2383,7 @@ end
 # Property names should follow the naming introduced by HDF5, i.e.
 # keyname => (h5p_get_keyname, h5p_set_keyname, id )
 const hdf5_prop_get_set = Dict(
+    :alignment     => (get_alignment, h5p_set_alignment,             H5P_FILE_ACCESS),
     :alloc_time    => (get_alloc_time, h5p_set_alloc_time,           H5P_DATASET_CREATE),
     :blosc         => (nothing, h5p_set_blosc,                       H5P_DATASET_CREATE),
     :char_encoding => (nothing, h5p_set_char_encoding,               H5P_LINK_CREATE),
@@ -2400,7 +2401,6 @@ const hdf5_prop_get_set = Dict(
     :shuffle       => (nothing, h5p_set_shuffle,                     H5P_DATASET_CREATE),
     :userblock     => (get_userblock, h5p_set_userblock,             H5P_FILE_CREATE),
     :track_times   => (nothing, h5p_set_obj_track_times,             H5P_OBJECT_CREATE),
-    :alignment     => (h5p_get_alignment, h5p_set_alignment,         H5P_FILE_ACCESS)
 )
 
 # properties that require chunks in order to work (e.g. any filter)


### PR DESCRIPTION
PR #616 added the `alignment` file access property, but the getter function in the `hdf5_prop_get_set` dictionary should point to the wrapper `get_alignment` function rather than the underlying `h5p_get_alignment`.

There actually aren't any uses (or tests, as far as I've found with quick greps) of the getter functions — probably since `getindex(::HDF5Properties, ::Symbol)` isn't defined.

(I also just moved the entry in the `hdf5_prop_get_set` list to be in its alphabetically-sorted position.)