### PR TITLE
Add convenient get_access_properties() functions

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -22,7 +22,8 @@ export
     a_create, a_delete, a_open, a_read, a_write, attrs,
     d_create, d_create_external, d_open, d_read, d_write,
     dataspace, datatype, exists, file, filename,
-    g_create, g_open, get_chunk, get_create_properties, get_datasets,
+    g_create, g_open, get_access_properties, get_create_properties,
+    get_chunk, get_datasets,
     h5open, h5read, h5rewrite, h5writeattr, h5readattr, h5write,
     has, iscontiguous, ishdf5, ismmappable, name,
     o_copy, o_delete, o_open, p_create,
@@ -2309,6 +2310,8 @@ function vlen_get_buf_size(dset::HDF5Dataset, dtype::HDF5Datatype, dspace::HDF5D
 end
 
 ### Property manipulation ###
+get_access_properties(d::HDF5Dataset)   = HDF5Properties(h5d_get_access_plist(d.id), H5P_DATASET_ACCESS)
+get_access_properties(f::HDF5File)      = HDF5Properties(h5f_get_access_plist(f.id), H5P_FILE_ACCESS)
 get_create_properties(d::HDF5Dataset)   = HDF5Properties(h5d_get_create_plist(d.id), H5P_DATASET_CREATE)
 get_create_properties(g::HDF5Group)     = HDF5Properties(h5g_get_create_plist(g.id), H5P_GROUP_CREATE)
 get_create_properties(f::HDF5File)      = HDF5Properties(h5f_get_create_plist(f.id), H5P_FILE_CREATE)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -348,6 +348,18 @@ end
 h5open(fn, "r", libver_bounds=(HDF5.H5F_LIBVER_EARLIEST, HDF5.H5F_LIBVER_LATEST)) do fid
     intarray = read(fid, "intarray")
     @test intarray == [1, 2, 3]
+    fcpl = get_create_properties(fid)
+    @test isvalid(fcpl)
+    fapl = get_access_properties(fid)
+    @test isvalid(fapl)
+end
+# Retrieving dataset creation and access property lists
+h5open(fn, "r") do fid
+    dset = fid["intarray"]
+    dcpl = get_create_properties(dset)
+    @test isvalid(dcpl)
+    dapl = get_access_properties(dset)
+    @test isvalid(dapl)
 end
 
 # Test null terminated ASCII string (e.g. exported by h5py) #332


### PR DESCRIPTION
This adds a method similar to `get_create_properties` which gets the access property list for HDF5 datasets and files — as far as I've found trying to look through the online documentation, those are the only two for which `h5?_get_access_plist` exists, but I might have missed one.

Note that this does add a new export for `get_access_properties`, which can be undone if desired.

This was motivated by trying to figure out how to query the alignment access property which also led to #659 — I just broke up the changes into two smaller PRs.