### PR TITLE
Do not leak a dlopen library pointer into the precompiled image

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -66,8 +66,10 @@ primitive type Hmpih64 <: Hmpih 64 end # OpenMPI C: pointers (mostly 64 bit)
 
 # Function to extract exported library constants
 # Kudos to the library developers for making these available this way!
-let libhdf5handle = Libdl.dlopen(libhdf5)
-    global read_const(sym::Symbol) = unsafe_load(convert(Ptr{Hid}, Libdl.dlsym(libhdf5handle, sym)))
+function read_const(sym::Symbol)
+    handle = Libdl.dlopen(libhdf5)
+    ccall((:H5open, libhdf5), Herr, ()) < 0 && error("error initializing the HDF5 library")
+    return unsafe_load(convert(Ptr{Hid}, Libdl.dlsym(handle, sym)))
 end
 
 # iteration order constants

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -66,8 +66,9 @@ primitive type Hmpih64 <: Hmpih 64 end # OpenMPI C: pointers (mostly 64 bit)
 
 # Function to extract exported library constants
 # Kudos to the library developers for making these available this way!
-const libhdf5handle = Libdl.dlopen(libhdf5)
-read_const(sym::Symbol) = unsafe_load(convert(Ptr{Hid}, Libdl.dlsym(libhdf5handle, sym)))
+let libhdf5handle = Libdl.dlopen(libhdf5)
+    global read_const(sym::Symbol) = unsafe_load(convert(Ptr{Hid}, Libdl.dlsym(libhdf5handle, sym)))
+end
 
 # iteration order constants
 const H5_ITER_UNKNOWN = -1


### PR DESCRIPTION
The library handle is a pointer, so it should not be cached during precompilation.

With some larger refactoring, the function `read_const` could be hidden completely, but at least now trying to use the function won't segfault Julia, and instead you just get an error about a NULL library handle.

---

This led down a rabbit hole, and as far as I can tell, all of the uses of `read_const` are technically not precompilation-safe either — in principle, the constants being retrieved are actually runtime-generated answers:
```julia
julia> using Libdl

julia> libhdf5 = dlopen("libhdf5");

julia> unsafe_load(convert(Ptr{Int64}, dlsym(libhdf5, :H5P_CLS_DATASET_CREATE_ID_g)))
-1

julia> # Initialize the HDF5 library
       ccall(dlsym(libhdf5, :H5open), Int64, ())
0

julia> unsafe_load(convert(Ptr{Int64}, dlsym(libhdf5, :H5P_CLS_DATASET_CREATE_ID_g)))
720575940379279369
```
Emprically, though, they must be generated in some mostly-stable fashion for this to have gone unnoticed (or maybe just unmentioned in the code, but already known/discussed in an old issue?).
