### PR TITLE
Fix typos in show() and test custom printing

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -347,7 +347,7 @@ function show(io::IO, fid::HDF5File)
     if isvalid(fid)
         print(io, "HDF5 data file: ", fid.filename)
     else
-        print(io, "HFD5 data file (closed): ", fid.filename)
+        print(io, "HDF5 data file (closed): ", fid.filename)
     end
 end
 
@@ -367,7 +367,7 @@ function show(io::IO, g::HDF5Group)
     if isvalid(g)
         print(io, "HDF5 group: ", name(g), " (file: ", g.file.filename, ")")
     else
-        print(io, "HFD5 group (invalid)")
+        print(io, "HDF5 group (invalid)")
     end
 end
 
@@ -399,7 +399,7 @@ function show(io::IO, dset::HDF5Dataset)
     if isvalid(dset)
         print(io, "HDF5 dataset: ", name(dset), " (file: ", dset.file.filename, " xfer_mode: ", dset.xfer.id, ")")
     else
-        print(io, "HFD5 dataset (invalid)")
+        print(io, "HDF5 dataset (invalid)")
     end
 end
 


### PR DESCRIPTION
While playing around data types, I discovered printing of `HDF5Datatype` objects throws if the datatype has been closed — see #671. I didn't find any evidence that any of the custom `show()` methods are being tested, so this PR just adds testing to all but the `HDF5Datatype` case.

I found that three cases had misspelled "HDF5" as "HFD5" in the closed branch.