### PR TITLE
fix dtype printing for closed datatypes

### DIFF
--- a/test/plain.jl
+++ b/test/plain.jl
@@ -559,10 +559,8 @@ dspace = dataspace((1,))
 close(dspace)
 @test sprint(show, dspace) == "HDF5Dataspace(-1)"
 
-# TODO: Test HDF5Datatypes once printing of built-in datatypes (i.e. H5T_NATIVE_INT8 and
-# the like) is sorted out. See #671. Commented out because libhdf5 prints.
-#close(dtype)
-#@test_broken sprint(show, dtype) == "HDF5 datatype: (invalid)"
+close(dtype)
+@test sprint(show, dtype) == "HDF5 datatype: (invalid)"
 
 close(prop)
 @test occursin(r"^HDF5Properties\(-1, \d+\)", sprint(show, prop))


### PR DESCRIPTION
Closes #671 

Note we have to use return value from H5LTdtype_to_text to detect closed datatypes
because `H5Iis_valid` does not work for basic atomic types (H5T_NATIVE_INT etc.) since
these types do not have their reference count incremented. We disable automatic error
printing during this probe to prevent spurious error messages. Error reporting is restored
to its previous state at function exit.