### PR TITLE
Wrap more of the HDF5 API with generated bindings

### DIFF
--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -20,7 +20,9 @@
 
 @bind h5_close()::Herr "Error closing the HDF5 resources"
 @bind h5_dont_atexit()::Herr "Error calling dont_atexit"
+@bind h5_free_memory(buf::Ptr{Cvoid})::Herr "Error freeing memory"
 @bind h5_garbage_collect()::Herr "Error on garbage collect"
+@bind h5_get_libversion(majnum::Ref{Cuint}, minnum::Ref{Cuint}, relnum::Ref{Cuint})::Herr "Error getting HDF5 library version"
 @bind h5_open()::Herr "Error initializing the HDF5 library"
 @bind h5_set_free_list_limits(reg_global_lim::Cint, reg_list_lim::Cint, arr_global_lim::Cint, arr_list_lim::Cint, blk_global_lim::Cint, blk_list_lim::Cint)::Herr "Error setting limits on free lists"
 
@@ -69,6 +71,7 @@
 ### Error Interface
 ###
 
+@bind h5e_get_auto(estack_id::Hid, func::Ref{Ptr{Cvoid}}, client_data::Ref{Ptr{Cvoid}})::Herr "Error getting error reporting behavior"
 @bind h5e_set_auto(estack_id::Hid, func::Ptr{Cvoid}, client_data::Ptr{Cvoid})::Herr "Error setting error reporting behavior"
 
 ###
@@ -82,6 +85,8 @@
 @bind h5f_get_create_plist(file_id::Hid)::Hid "Error getting file create property list"
 @bind h5f_get_intent(file_id::Hid, intent::Ptr{Cuint})::Herr "Error getting file intent"
 @bind h5f_get_name(obj_id::Hid, buf::Ptr{UInt8}, buf_size::Csize_t)::Cssize_t "Error getting file name"
+@bind h5f_get_obj_count(file_id::Hid, types::Cuint)::Cssize_t "Error getting object count"
+@bind h5f_get_obj_ids(file_id::Hid, types::Cuint, max_objs::Csize_t, obj_id_list::Ptr{Hid})::Cssize_t "Error getting objects"
 @bind h5f_get_vfd_handle(file_id::Hid, fapl_id::Hid, file_handle::Ptr{Ptr{Cint}})::Herr "Error getting VFD handle"
 @bind h5f_is_hdf5(pathname::Cstring)::Htri error("Cannot access file ", pathname)
 @bind h5f_open(pathname::Cstring, flags::Cuint, fapl_id::Hid)::Hid error("Error opening file ", pathname)
@@ -178,6 +183,7 @@
 ###
 
 @bind h5r_create(ref::Ptr{HDF5ReferenceObj}, loc_id::Hid, pathname::Ptr{UInt8}, ref_type::Cint, space_id::Hid)::Herr error("Error creating reference to object ", hi5_get_name(loc_id), "/", pathname)
+@bind h5r_dereference(obj_id::Hid, ref_type::Cint, ref::Ref{HDF5ReferenceObj})::Hid "Error dereferencing object"
 @bind h5r_get_obj_type(loc_id::Hid, ref_type::Cint, ref::Ptr{Cvoid}, obj_type::Ptr{Cint})::Herr "Error getting object type"
 @bind h5r_get_region(loc_id::Hid, ref_type::Cint, ref::Ptr{Cvoid})::Hid "Error getting region from reference"
 
@@ -228,6 +234,10 @@
 @bind h5t_set_size(dtype_id::Hid, sz::Csize_t)::Herr "Error setting size of datatype"
 @bind h5t_set_strpad(dtype_id::Hid, sz::Cint)::Herr "Error setting size of datatype"
 @bind h5t_vlen_create(base_type_id::Hid)::Hid "Error creating vlen type"
+# The following are not autoatically wrapped since they have requirements about freeing
+# the memory that is returned from the calls.
+#@bind h5t_get_member_name(dtype_id::Hid, index::Cuint)::Cstring error("Error getting name of compound datatype member #", index)
+#@bind h5t_get_tag(type_id::Hid)::Cstring "Error getting datatype opaque tag"
 
 ###
 ### Optimized Functions Interface
@@ -235,6 +245,12 @@
 
 @bind h5do_append(dset_id::Hid, dxpl_id::Hid, index::Cuint, num_elem::Hsize, memtype::Hid, buffer::Ptr{Cvoid})::Herr "error appending"
 @bind h5do_write_chunk(dset_id::Hid, dxpl_id::Hid, filter_mask::Int32, offset::Ptr{Hsize}, bufsize::Csize_t, buf::Ptr{Cvoid})::Herr "Error writing chunk"
+
+###
+### HDF5 Lite Interface
+###
+
+@bind h5lt_dtype_to_text(datatype::Hid, str::Ptr{UInt8}, lang_type::Cint, len::Ref{Csize_t})::Herr "Error getting datatype text representation"
 
 ###
 ### Table Interface

--- a/gen/bind_generator.jl
+++ b/gen/bind_generator.jl
@@ -8,11 +8,13 @@ const bind_exceptions = Dict{Symbol,Symbol}()
 push!(bind_exceptions, :h5a_create => :H5Acreate2)
 push!(bind_exceptions, :h5d_create => :H5Dcreate2)
 push!(bind_exceptions, :h5d_open => :H5Dopen2)
+push!(bind_exceptions, :h5e_get_auto => :H5Eget_auto2)
 push!(bind_exceptions, :h5e_set_auto => :H5Eset_auto2)
 push!(bind_exceptions, :h5g_create => :H5Gcreate2)
 push!(bind_exceptions, :h5g_open => :H5Gopen2)
 push!(bind_exceptions, :h5o_get_info => :H5Oget_info1)
 push!(bind_exceptions, :h5p_get_filter_by_id => :H5Pget_filter_by_id2)
+push!(bind_exceptions, :h5r_dereference => :H5Rdereference1)
 push!(bind_exceptions, :h5r_get_obj_type => :H5Rget_obj_type2)
 push!(bind_exceptions, :h5t_array_create => :H5Tarray_create2)
 push!(bind_exceptions, :h5t_commit => :H5Tcommit2)
@@ -105,7 +107,7 @@ macro bind(sig::Expr, err::Union{String,Expr,Nothing} = nothing)
     end
 
     # Determine the underlying C library to call
-    lib = startswith(string(cfuncname), r"H5(DO|TB)") ? :libhdf5_hl : :libhdf5
+    lib = startswith(string(cfuncname), r"H5(DO|LT|TB)") ? :libhdf5_hl : :libhdf5
 
     # Now start building up the full expression:
     statsym = Symbol("#status#") # not using gensym() to have stable naming

--- a/src/api.jl
+++ b/src/api.jl
@@ -15,9 +15,21 @@ function h5_dont_atexit()
     return nothing
 end
 
+function h5_free_memory(buf)
+    var"#status#" = ccall((:H5free_memory, libhdf5), Herr, (Ptr{Cvoid},), buf)
+    var"#status#" < 0 && error("Error freeing memory")
+    return nothing
+end
+
 function h5_garbage_collect()
     var"#status#" = ccall((:H5garbage_collect, libhdf5), Herr, ())
     var"#status#" < 0 && error("Error on garbage collect")
+    return nothing
+end
+
+function h5_get_libversion(majnum, minnum, relnum)
+    var"#status#" = ccall((:H5get_libversion, libhdf5), Herr, (Ref{Cuint}, Ref{Cuint}, Ref{Cuint}), majnum, minnum, relnum)
+    var"#status#" < 0 && error("Error getting HDF5 library version")
     return nothing
 end
 
@@ -219,6 +231,12 @@ function h5d_write(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_pl
     return nothing
 end
 
+function h5e_get_auto(estack_id, func, client_data)
+    var"#status#" = ccall((:H5Eget_auto2, libhdf5), Herr, (Hid, Ref{Ptr{Cvoid}}, Ref{Ptr{Cvoid}}), estack_id, func, client_data)
+    var"#status#" < 0 && error("Error getting error reporting behavior")
+    return nothing
+end
+
 function h5e_set_auto(estack_id, func, client_data)
     var"#status#" = ccall((:H5Eset_auto2, libhdf5), Herr, (Hid, Ptr{Cvoid}, Ptr{Cvoid}), estack_id, func, client_data)
     var"#status#" < 0 && error("Error setting error reporting behavior")
@@ -264,6 +282,18 @@ end
 function h5f_get_name(obj_id, buf, buf_size)
     var"#status#" = ccall((:H5Fget_name, libhdf5), Cssize_t, (Hid, Ptr{UInt8}, Csize_t), obj_id, buf, buf_size)
     var"#status#" < 0 && error("Error getting file name")
+    return var"#status#"
+end
+
+function h5f_get_obj_count(file_id, types)
+    var"#status#" = ccall((:H5Fget_obj_count, libhdf5), Cssize_t, (Hid, Cuint), file_id, types)
+    var"#status#" < 0 && error("Error getting object count")
+    return var"#status#"
+end
+
+function h5f_get_obj_ids(file_id, types, max_objs, obj_id_list)
+    var"#status#" = ccall((:H5Fget_obj_ids, libhdf5), Cssize_t, (Hid, Cuint, Csize_t, Ptr{Hid}), file_id, types, max_objs, obj_id_list)
+    var"#status#" < 0 && error("Error getting objects")
     return var"#status#"
 end
 
@@ -662,6 +692,12 @@ function h5r_create(ref, loc_id, pathname, ref_type, space_id)
     return nothing
 end
 
+function h5r_dereference(obj_id, ref_type, ref)
+    var"#status#" = ccall((:H5Rdereference1, libhdf5), Hid, (Hid, Cint, Ref{HDF5ReferenceObj}), obj_id, ref_type, ref)
+    var"#status#" < 0 && error("Error dereferencing object")
+    return var"#status#"
+end
+
 function h5r_get_obj_type(loc_id, ref_type, ref, obj_type)
     var"#status#" = ccall((:H5Rget_obj_type2, libhdf5), Herr, (Hid, Cint, Ptr{Cvoid}, Ptr{Cint}), loc_id, ref_type, ref, obj_type)
     var"#status#" < 0 && error("Error getting object type")
@@ -910,6 +946,12 @@ end
 function h5do_write_chunk(dset_id, dxpl_id, filter_mask, offset, bufsize, buf)
     var"#status#" = ccall((:H5DOwrite_chunk, libhdf5_hl), Herr, (Hid, Hid, Int32, Ptr{Hsize}, Csize_t, Ptr{Cvoid}), dset_id, dxpl_id, filter_mask, offset, bufsize, buf)
     var"#status#" < 0 && error("Error writing chunk")
+    return nothing
+end
+
+function h5lt_dtype_to_text(datatype, str, lang_type, len)
+    var"#status#" = ccall((:H5LTdtype_to_text, libhdf5_hl), Herr, (Hid, Ptr{UInt8}, Cint, Ref{Csize_t}), datatype, str, lang_type, len)
+    var"#status#" < 0 && error("Error getting datatype text representation")
     return nothing
 end
 


### PR DESCRIPTION
This wraps more direct uses of `ccall`s with bindings made with the generator.

There are a few notable exceptions due to either (a) memory handling which the binding generator cannot (yet?) deal with, and (b) a case where a call to the underlying `H5Dwrite` is relying on being able to declare the buffer to type `Cstring` for its data validation features.

One more interesting change is to the `h5t_get_member_name` and `h5t_get_tag` functions — this changes to using `h5_free_memory` from `Libc.free` as noted in the [`h5t_get_member_name` documentation](https://portal.hdfgroup.org/display/HDF5/H5T_GET_MEMBER_NAME) (which says it's more important on Windows).