### PR TITLE
Rename HDF5 constants to C definitions for consistency

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -341,7 +341,7 @@ set_dims!(d, new_dims)
 ```
 where dims is a tuple of integers.  For example
 ```julia
-b = d_create(fid, "b", Int, ((1000,),(-1,)), chunk=(100,)) #-1 is equivalent to typemax(hsize_t )
+b = d_create(fid, "b", Int, ((1000,),(-1,)), chunk=(100,)) #-1 is equivalent to typemax(hsize_t)
 set_dims!(b, (10000,))
 b[1:10000] = collect(1:10000)
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -341,7 +341,7 @@ set_dims!(d, new_dims)
 ```
 where dims is a tuple of integers.  For example
 ```julia
-b = d_create(fid, "b", Int, ((1000,),(-1,)), chunk=(100,)) #-1 is equivalent to typemax(Hsize)
+b = d_create(fid, "b", Int, ((1000,),(-1,)), chunk=(100,)) #-1 is equivalent to typemax(hsize_t )
 set_dims!(b, (10000,))
 b[1:10000] = collect(1:10000)
 ```

--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -18,248 +18,248 @@
 ### HDF5 General library functions
 ###
 
-@bind h5_close()::Herr "Error closing the HDF5 resources"
-@bind h5_dont_atexit()::Herr "Error calling dont_atexit"
-@bind h5_free_memory(buf::Ptr{Cvoid})::Herr "Error freeing memory"
-@bind h5_garbage_collect()::Herr "Error on garbage collect"
-@bind h5_get_libversion(majnum::Ref{Cuint}, minnum::Ref{Cuint}, relnum::Ref{Cuint})::Herr "Error getting HDF5 library version"
-@bind h5_open()::Herr "Error initializing the HDF5 library"
-@bind h5_set_free_list_limits(reg_global_lim::Cint, reg_list_lim::Cint, arr_global_lim::Cint, arr_list_lim::Cint, blk_global_lim::Cint, blk_list_lim::Cint)::Herr "Error setting limits on free lists"
+@bind h5_close()::herr_t "Error closing the HDF5 resources"
+@bind h5_dont_atexit()::herr_t "Error calling dont_atexit"
+@bind h5_free_memory(buf::Ptr{Cvoid})::herr_t "Error freeing memory"
+@bind h5_garbage_collect()::herr_t "Error on garbage collect"
+@bind h5_get_libversion(majnum::Ref{Cuint}, minnum::Ref{Cuint}, relnum::Ref{Cuint})::herr_t "Error getting HDF5 library version"
+@bind h5_open()::herr_t "Error initializing the HDF5 library"
+@bind h5_set_free_list_limits(reg_global_lim::Cint, reg_list_lim::Cint, arr_global_lim::Cint, arr_list_lim::Cint, blk_global_lim::Cint, blk_list_lim::Cint)::herr_t "Error setting limits on free lists"
 
 ###
 ### Attribute Interface
 ###
 
-@bind h5a_close(id::Hid)::Herr "Error closing attribute"
-@bind h5a_create(loc_id::Hid, pathname::Ptr{UInt8}, type_id::Hid, space_id::Hid, acpl_id::Hid, aapl_id::Hid)::Hid error("Error creating attribute ", h5a_get_name(loc_id), "/", pathname)
-@bind h5a_create_by_name(loc_id::Hid, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, type_id::Hid, space_id::Hid, acpl_id::Hid, aapl_id::Hid, lapl_id::Hid)::Hid error("Error creating attribute ", attr_name, " for object ", obj_name)
-@bind h5a_delete(loc_id::Hid, attr_name::Ptr{UInt8})::Herr error("Error deleting attribute ", attr_name)
-@bind h5a_delete_by_idx(loc_id::Hid, obj_name::Ptr{UInt8}, idx_type::Cint, order::Cint, n::Hsize, lapl_id::Hid)::Herr error("Error deleting attribute ", n, " from object ", obj_name)
-@bind h5a_delete_by_name(loc_id::Hid, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, lapl_id::Hid)::Herr error("Error removing attribute ", attr_name, " from object ", obj_name)
-@bind h5a_exists(obj_id::Hid, attr_name::Ptr{UInt8})::Htri error("Error checking whether attribute ", attr_name, " exists")
-@bind h5a_exists_by_name(loc_id::Hid, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, lapl_id::Hid)::Htri error("Error checking whether object ", obj_name, " has attribute ", attr_name)
-@bind h5a_get_create_plist(attr_id::Hid)::Hid error("Cannot get creation property list")
-@bind h5a_get_name(attr_id::Hid, buf_size::Csize_t, buf::Ptr{UInt8})::Cssize_t "Error getting attribute name"
-@bind h5a_get_name_by_idx(loc_id::Hid, obj_name::Ptr{UInt8}, index_type::Cint, order::Cint, idx::Hsize, name::Ptr{UInt8}, size::Csize_t, lapl_id::Hid)::Cssize_t error("Error getting attribute name")
-@bind h5a_get_space(attr_id::Hid)::Hid "Error getting attribute dataspace"
-@bind h5a_get_type(attr_id::Hid)::Hid "Error getting attribute type"
-@bind h5a_open(obj_id::Hid, pathname::Ptr{UInt8}, aapl_id::Hid)::Hid error("Error opening attribute ", h5i_get_name(obj_id), "/", pathname)
-@bind h5a_read(attr_id::Hid, mem_type_id::Hid, buf::Ptr{Cvoid})::Herr error("Error reading attribute ", h5a_get_name(attr_id))
-@bind h5a_write(attr_hid::Hid, mem_type_id::Hid, buf::Ptr{Cvoid})::Herr "Error writing attribute data"
+@bind h5a_close(id::hid_t)::herr_t "Error closing attribute"
+@bind h5a_create(loc_id::hid_t, pathname::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t)::hid_t error("Error creating attribute ", h5a_get_name(loc_id), "/", pathname)
+@bind h5a_create_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t, lapl_id::hid_t)::hid_t error("Error creating attribute ", attr_name, " for object ", obj_name)
+@bind h5a_delete(loc_id::hid_t, attr_name::Ptr{UInt8})::herr_t error("Error deleting attribute ", attr_name)
+@bind h5a_delete_by_idx(loc_id::hid_t, obj_name::Ptr{UInt8}, idx_type::Cint, order::Cint, n::hsize_t , lapl_id::hid_t)::herr_t error("Error deleting attribute ", n, " from object ", obj_name)
+@bind h5a_delete_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, lapl_id::hid_t)::herr_t error("Error removing attribute ", attr_name, " from object ", obj_name)
+@bind h5a_exists(obj_id::hid_t, attr_name::Ptr{UInt8})::htri_t error("Error checking whether attribute ", attr_name, " exists")
+@bind h5a_exists_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, lapl_id::hid_t)::htri_t error("Error checking whether object ", obj_name, " has attribute ", attr_name)
+@bind h5a_get_create_plist(attr_id::hid_t)::hid_t error("Cannot get creation property list")
+@bind h5a_get_name(attr_id::hid_t, buf_size::Csize_t, buf::Ptr{UInt8})::Cssize_t "Error getting attribute name"
+@bind h5a_get_name_by_idx(loc_id::hid_t, obj_name::Ptr{UInt8}, index_type::Cint, order::Cint, idx::hsize_t , name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t)::Cssize_t error("Error getting attribute name")
+@bind h5a_get_space(attr_id::hid_t)::hid_t "Error getting attribute dataspace"
+@bind h5a_get_type(attr_id::hid_t)::hid_t "Error getting attribute type"
+@bind h5a_open(obj_id::hid_t, pathname::Ptr{UInt8}, aapl_id::hid_t)::hid_t error("Error opening attribute ", h5i_get_name(obj_id), "/", pathname)
+@bind h5a_read(attr_id::hid_t, mem_type_id::hid_t, buf::Ptr{Cvoid})::herr_t error("Error reading attribute ", h5a_get_name(attr_id))
+@bind h5a_write(attr_hid::hid_t, mem_type_id::hid_t, buf::Ptr{Cvoid})::herr_t "Error writing attribute data"
 
 ###
 ### Dataset Interface
 ###
 
-@bind h5d_close(dataset_id::Hid)::Herr "Error closing dataset"
-@bind h5d_create(loc_id::Hid, pathname::Ptr{UInt8}, dtype_id::Hid, space_id::Hid, lcpl_id::Hid, dcpl_id::Hid, dapl_id::Hid)::Hid error("Error creating dataset ", h5i_get_name(loc_id), "/", pathname)
-@bind h5d_flush(dataset_id::Hid)::Herr "Error flushing dataset"
-@bind h5d_get_access_plist(dataset_id::Hid)::Hid "Error getting dataset access property list"
-@bind h5d_get_create_plist(dataset_id::Hid)::Hid "Error getting dataset create property list"
-@bind h5d_get_offset(dataset_id::Hid)::Haddr "Error getting offset"
-@bind h5d_get_space(dataset_id::Hid)::Hid "Error getting dataspace"
-@bind h5d_get_type(dataset_id::Hid)::Hid "Error getting dataspace type"
-@bind h5d_open(loc_id::Hid, pathname::Ptr{UInt8}, dapl_id::Hid)::Hid error("Error opening dataset ", h5i_get_name(loc_id), "/", pathname)
-@bind h5d_read(dataset_id::Hid, mem_type_id::Hid, mem_space_id::Hid, file_space_id::Hid, xfer_plist_id::Hid, buf::Ptr{Cvoid})::Herr error("Error reading dataset ", h5i_get_name(dataset_id))
-@bind h5d_refresh(dataset_id::Hid)::Herr "Error refreshing dataset"
-@bind h5d_set_extent(dataset_id::Hid, new_dims::Ptr{Hsize})::Herr "Error extending dataset dimensions"
-@bind h5d_vlen_get_buf_size(dset_id::Hid, type_id::Hid, space_id::Hid, buf::Ptr{Hsize})::Herr "Error getting vlen buffer size"
-@bind h5d_vlen_reclaim(type_id::Hid, space_id::Hid, plist_id::Hid, buf::Ptr{Cvoid})::Herr "Error reclaiming vlen buffer"
-@bind h5d_write(dataset_id::Hid, mem_type_id::Hid, mem_space_id::Hid, file_space_id::Hid, xfer_plist_id::Hid, buf::Ptr{Cvoid})::Herr "Error writing dataset"
+@bind h5d_close(dataset_id::hid_t)::herr_t "Error closing dataset"
+@bind h5d_create(loc_id::hid_t, pathname::Ptr{UInt8}, dtype_id::hid_t, space_id::hid_t, lcpl_id::hid_t, dcpl_id::hid_t, dapl_id::hid_t)::hid_t error("Error creating dataset ", h5i_get_name(loc_id), "/", pathname)
+@bind h5d_flush(dataset_id::hid_t)::herr_t "Error flushing dataset"
+@bind h5d_get_access_plist(dataset_id::hid_t)::hid_t "Error getting dataset access property list"
+@bind h5d_get_create_plist(dataset_id::hid_t)::hid_t "Error getting dataset create property list"
+@bind h5d_get_offset(dataset_id::hid_t)::haddr_t"Error getting offset"
+@bind h5d_get_space(dataset_id::hid_t)::hid_t "Error getting dataspace"
+@bind h5d_get_type(dataset_id::hid_t)::hid_t "Error getting dataspace type"
+@bind h5d_open(loc_id::hid_t, pathname::Ptr{UInt8}, dapl_id::hid_t)::hid_t error("Error opening dataset ", h5i_get_name(loc_id), "/", pathname)
+@bind h5d_read(dataset_id::hid_t, mem_type_id::hid_t, mem_space_id::hid_t, file_space_id::hid_t, xfer_plist_id::hid_t, buf::Ptr{Cvoid})::herr_t error("Error reading dataset ", h5i_get_name(dataset_id))
+@bind h5d_refresh(dataset_id::hid_t)::herr_t "Error refreshing dataset"
+@bind h5d_set_extent(dataset_id::hid_t, new_dims::Ptr{hsize_t })::herr_t "Error extending dataset dimensions"
+@bind h5d_vlen_get_buf_size(dset_id::hid_t, type_id::hid_t, space_id::hid_t, buf::Ptr{hsize_t })::herr_t "Error getting vlen buffer size"
+@bind h5d_vlen_reclaim(type_id::hid_t, space_id::hid_t, plist_id::hid_t, buf::Ptr{Cvoid})::herr_t "Error reclaiming vlen buffer"
+@bind h5d_write(dataset_id::hid_t, mem_type_id::hid_t, mem_space_id::hid_t, file_space_id::hid_t, xfer_plist_id::hid_t, buf::Ptr{Cvoid})::herr_t "Error writing dataset"
 
 ###
 ### Error Interface
 ###
 
-@bind h5e_get_auto(estack_id::Hid, func::Ref{Ptr{Cvoid}}, client_data::Ref{Ptr{Cvoid}})::Herr "Error getting error reporting behavior"
-@bind h5e_set_auto(estack_id::Hid, func::Ptr{Cvoid}, client_data::Ptr{Cvoid})::Herr "Error setting error reporting behavior"
+@bind h5e_get_auto(estack_id::hid_t, func::Ref{Ptr{Cvoid}}, client_data::Ref{Ptr{Cvoid}})::herr_t "Error getting error reporting behavior"
+@bind h5e_set_auto(estack_id::hid_t, func::Ptr{Cvoid}, client_data::Ptr{Cvoid})::herr_t "Error setting error reporting behavior"
 
 ###
 ### File Interface
 ###
 
-@bind h5f_close(file_id::Hid)::Herr "Error closing file"
-@bind h5f_create(pathname::Ptr{UInt8}, flags::Cuint, fcpl_id::Hid, fapl_id::Hid)::Hid error("Error creating file ", pathname)
-@bind h5f_flush(object_id::Hid, scope::Cint)::Herr "Error flushing object to file"
-@bind h5f_get_access_plist(file_id::Hid)::Hid "Error getting file access property list"
-@bind h5f_get_create_plist(file_id::Hid)::Hid "Error getting file create property list"
-@bind h5f_get_intent(file_id::Hid, intent::Ptr{Cuint})::Herr "Error getting file intent"
-@bind h5f_get_name(obj_id::Hid, buf::Ptr{UInt8}, buf_size::Csize_t)::Cssize_t "Error getting file name"
-@bind h5f_get_obj_count(file_id::Hid, types::Cuint)::Cssize_t "Error getting object count"
-@bind h5f_get_obj_ids(file_id::Hid, types::Cuint, max_objs::Csize_t, obj_id_list::Ptr{Hid})::Cssize_t "Error getting objects"
-@bind h5f_get_vfd_handle(file_id::Hid, fapl_id::Hid, file_handle::Ptr{Ptr{Cint}})::Herr "Error getting VFD handle"
-@bind h5f_is_hdf5(pathname::Cstring)::Htri error("Cannot access file ", pathname)
-@bind h5f_open(pathname::Cstring, flags::Cuint, fapl_id::Hid)::Hid error("Error opening file ", pathname)
-@bind h5f_start_swmr_write(id::Hid)::Herr "Error starting SWMR write"
+@bind h5f_close(file_id::hid_t)::herr_t "Error closing file"
+@bind h5f_create(pathname::Ptr{UInt8}, flags::Cuint, fcpl_id::hid_t, fapl_id::hid_t)::hid_t error("Error creating file ", pathname)
+@bind h5f_flush(object_id::hid_t, scope::Cint)::herr_t "Error flushing object to file"
+@bind h5f_get_access_plist(file_id::hid_t)::hid_t "Error getting file access property list"
+@bind h5f_get_create_plist(file_id::hid_t)::hid_t "Error getting file create property list"
+@bind h5f_get_intent(file_id::hid_t, intent::Ptr{Cuint})::herr_t "Error getting file intent"
+@bind h5f_get_name(obj_id::hid_t, buf::Ptr{UInt8}, buf_size::Csize_t)::Cssize_t "Error getting file name"
+@bind h5f_get_obj_count(file_id::hid_t, types::Cuint)::Cssize_t "Error getting object count"
+@bind h5f_get_obj_ids(file_id::hid_t, types::Cuint, max_objs::Csize_t, obj_id_list::Ptr{hid_t})::Cssize_t "Error getting objects"
+@bind h5f_get_vfd_handle(file_id::hid_t, fapl_id::hid_t, file_handle::Ptr{Ptr{Cint}})::herr_t "Error getting VFD handle"
+@bind h5f_is_hdf5(pathname::Cstring)::htri_t error("Cannot access file ", pathname)
+@bind h5f_open(pathname::Cstring, flags::Cuint, fapl_id::hid_t)::hid_t error("Error opening file ", pathname)
+@bind h5f_start_swmr_write(id::hid_t)::herr_t "Error starting SWMR write"
 
 ###
 ### Group Interface
 ###
 
-@bind h5g_close(group_id::Hid)::Herr "Error closing group"
-@bind h5g_create(loc_id::Hid, pathname::Ptr{UInt8}, lcpl_id::Hid, gcpl_id::Hid, gapl_id::Hid)::Hid error("Error creating group ", h5i_get_name(loc_id), "/", pathname)
-@bind h5g_get_create_plist(group_id::Hid)::Hid "Error getting group create property list"
-@bind h5g_get_info(group_id::Hid, buf::Ptr{H5Ginfo})::Herr "Error getting group info"
-@bind h5g_get_num_objs(loc_id::Hid, num_obj::Ptr{Hsize})::Hid "Error getting group length"
-@bind h5g_get_objname_by_idx(loc_id::Hid, idx::Hsize, pathname::Ptr{UInt8}, size::Csize_t)::Cssize_t error("Error getting group object name ", h5i_get_name(loc_id), "/", pathname)
-@bind h5g_open(loc_id::Hid, pathname::Ptr{UInt8}, gapl_id::Hid)::Hid error("Error opening group ", h5i_get_name(loc_id), "/", pathname)
+@bind h5g_close(group_id::hid_t)::herr_t "Error closing group"
+@bind h5g_create(loc_id::hid_t, pathname::Ptr{UInt8}, lcpl_id::hid_t, gcpl_id::hid_t, gapl_id::hid_t)::hid_t error("Error creating group ", h5i_get_name(loc_id), "/", pathname)
+@bind h5g_get_create_plist(group_id::hid_t)::hid_t "Error getting group create property list"
+@bind h5g_get_info(group_id::hid_t, buf::Ptr{H5Ginfo})::herr_t "Error getting group info"
+@bind h5g_get_num_objs(loc_id::hid_t, num_obj::Ptr{hsize_t })::hid_t "Error getting group length"
+@bind h5g_get_objname_by_idx(loc_id::hid_t, idx::hsize_t , pathname::Ptr{UInt8}, size::Csize_t)::Cssize_t error("Error getting group object name ", h5i_get_name(loc_id), "/", pathname)
+@bind h5g_open(loc_id::hid_t, pathname::Ptr{UInt8}, gapl_id::hid_t)::hid_t error("Error opening group ", h5i_get_name(loc_id), "/", pathname)
 
 ###
 ### Identifier Interface
 ###
 
-@bind h5i_dec_ref(obj_id::Hid)::Cint "Error decementing reference"
-@bind h5i_get_file_id(obj_id::Hid)::Hid "Error getting file identifier"
-@bind h5i_get_name(obj_id::Hid, buf::Ptr{UInt8}, buf_size::Csize_t)::Cssize_t "Error getting object name"
-@bind h5i_get_ref(obj_id::Hid)::Cint "Error getting reference count"
-@bind h5i_get_type(obj_id::Hid)::Cint "Error getting type"
-@bind h5i_is_valid(obj_id::Hid)::Htri "Cannot determine whether object is valid"
+@bind h5i_dec_ref(obj_id::hid_t)::Cint "Error decementing reference"
+@bind h5i_get_file_id(obj_id::hid_t)::hid_t "Error getting file identifier"
+@bind h5i_get_name(obj_id::hid_t, buf::Ptr{UInt8}, buf_size::Csize_t)::Cssize_t "Error getting object name"
+@bind h5i_get_ref(obj_id::hid_t)::Cint "Error getting reference count"
+@bind h5i_get_type(obj_id::hid_t)::Cint "Error getting type"
+@bind h5i_is_valid(obj_id::hid_t)::htri_t "Cannot determine whether object is valid"
 
 ###
 ### Link Interface
 ###
 
-@bind h5l_create_external(target_file_name::Ptr{UInt8}, target_obj_name::Ptr{UInt8}, link_loc_id::Hid, link_name::Ptr{UInt8}, lcpl_id::Hid, lapl_id::Hid)::Herr error("Error creating external link ", link_name, " pointing to ", target_obj_name, " in file ", target_file_name)
-@bind h5l_create_hard(obj_loc_id::Hid, obj_name::Ptr{UInt8}, link_loc_id::Hid, link_name::Ptr{UInt8}, lcpl_id::Hid, lapl_id::Hid)::Herr error("Error creating hard link ", link_name, " pointing to ", obj_name)
-@bind h5l_create_soft(target_path::Ptr{UInt8}, link_loc_id::Hid, link_name::Ptr{UInt8}, lcpl_id::Hid, lapl_id::Hid)::Herr error("Error creating soft link ", link_name, " pointing to ", target_path)
-@bind h5l_delete(obj_id::Hid, pathname::Ptr{UInt8}, lapl_id::Hid)::Herr error("Error deleting ", h5i_get_name(obj_id), "/", pathname)
-@bind h5l_exists(loc_id::Hid, pathname::Ptr{UInt8}, lapl_id::Hid)::Htri error("Cannot determine whether ", pathname, " exists")
-@bind h5l_get_info(link_loc_id::Hid, link_name::Ptr{UInt8}, link_buf::Ptr{H5LInfo}, lapl_id::Hid)::Herr error("Error getting info for link ", link_name)
-@bind h5l_get_name_by_idx(loc_id::Hid, group_name::Ptr{UInt8}, index_field::Cint, order::Cint, n::Hsize, name::Ptr{UInt8}, size::Csize_t, lapl_id::Hid)::Cssize_t "Error getting object name"
+@bind h5l_create_external(target_file_name::Ptr{UInt8}, target_obj_name::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)::herr_t error("Error creating external link ", link_name, " pointing to ", target_obj_name, " in file ", target_file_name)
+@bind h5l_create_hard(obj_loc_id::hid_t, obj_name::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)::herr_t error("Error creating hard link ", link_name, " pointing to ", obj_name)
+@bind h5l_create_soft(target_path::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)::herr_t error("Error creating soft link ", link_name, " pointing to ", target_path)
+@bind h5l_delete(obj_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t)::herr_t error("Error deleting ", h5i_get_name(obj_id), "/", pathname)
+@bind h5l_exists(loc_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t)::htri_t error("Cannot determine whether ", pathname, " exists")
+@bind h5l_get_info(link_loc_id::hid_t, link_name::Ptr{UInt8}, link_buf::Ptr{H5LInfo}, lapl_id::hid_t)::herr_t error("Error getting info for link ", link_name)
+@bind h5l_get_name_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_field::Cint, order::Cint, n::hsize_t , name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t)::Cssize_t "Error getting object name"
 
 ###
 ### Object Interface
 ###
 
-@bind h5o_close(object_id::Hid)::Herr "Error closing object"
-@bind h5o_copy(src_loc_id::Hid, src_name::Ptr{UInt8}, dst_loc_id::Hid, dst_name::Ptr{UInt8}, ocpypl_id::Hid, lcpl_id::Hid)::Herr error("Error copying object ", h5i_get_name(src_loc_id), "/", src_name, " to ", h5i_get_name(dst_loc_id), "/", dst_name)
-@bind h5o_get_info(object_id::Hid, buf::Ptr{H5Oinfo})::Herr "Error getting object info"
-@bind h5o_open(loc_id::Hid, pathname::Ptr{UInt8}, lapl_id::Hid)::Hid error("Error opening object ", h5i_get_name(loc_id), "/", pathname)
-@bind h5o_open_by_addr(loc_id::Hid, addr::Haddr)::Hid error("Error opening object by address")
-@bind h5o_open_by_idx(loc_id::Hid, group_name::Ptr{UInt8}, index_type::Cint, order::Cint, n::Hsize, lapl_id::Hid)::Hid error("Error opening object of index ", n)
+@bind h5o_close(object_id::hid_t)::herr_t "Error closing object"
+@bind h5o_copy(src_loc_id::hid_t, src_name::Ptr{UInt8}, dst_loc_id::hid_t, dst_name::Ptr{UInt8}, ocpypl_id::hid_t, lcpl_id::hid_t)::herr_t error("Error copying object ", h5i_get_name(src_loc_id), "/", src_name, " to ", h5i_get_name(dst_loc_id), "/", dst_name)
+@bind h5o_get_info(object_id::hid_t, buf::Ptr{H5Oinfo})::herr_t "Error getting object info"
+@bind h5o_open(loc_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t)::hid_t error("Error opening object ", h5i_get_name(loc_id), "/", pathname)
+@bind h5o_open_by_addr(loc_id::hid_t, addr::haddr_t)::hid_t error("Error opening object by address")
+@bind h5o_open_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_type::Cint, order::Cint, n::hsize_t , lapl_id::hid_t)::hid_t error("Error opening object of index ", n)
 
 ###
 ### Property Interface
 ###
 
-@bind h5p_close(id::Hid)::Herr "Error closing property list"
-@bind h5p_create(cls_id::Hid)::Hid "Error creating property list"
-@bind h5p_get_alignment(plist_id::Hid, threshold::Ptr{Hsize}, alignment::Ptr{Hsize})::Herr "Error getting alignment"
-@bind h5p_get_alloc_time(plist_id::Hid, alloc_time::Ptr{Cint})::Herr "Error getting allocation timing"
-@bind h5p_get_chunk(plist_id::Hid, n_dims::Cint, dims::Ptr{Hsize})::Cint error("Error getting chunk size")
-@bind h5p_get_driver(plist_id::Hid)::Hid "Error getting driver identifier"
-@bind h5p_get_driver_info(plist_id::Hid)::Ptr{Cvoid} # does not error
-@bind h5p_get_dxpl_mpio(dxpl_id::Hid, xfer_mode::Ptr{Cint})::Herr "Error getting MPIO transfer mode"
-@bind h5p_get_fapl_mpio32(fapl_id::Hid, comm::Ptr{Hmpih32}, info::Ptr{Hmpih32})::Herr "Error getting MPIO properties"
-@bind h5p_get_fapl_mpio64(fapl_id::Hid, comm::Ptr{Hmpih64}, info::Ptr{Hmpih64})::Herr "Error getting MPIO properties"
-@bind h5p_get_fclose_degree(plist_id::Hid, fc_degree::Ptr{Cint})::Herr "Error getting close degree"
-@bind h5p_get_filter_by_id(plist_id::Hid, filter_id::H5Z_filter_t, flags::Ref{Cuint}, cd_nelmts::Ref{Csize_t}, cd_values::Ptr{Cuint}, namelen::Csize_t, name::Ptr{UInt8}, filter_config::Ptr{Cuint})::Herr "Error getting filter ID"
-@bind h5p_get_layout(plist_id::Hid)::Cint error("Error getting layout")
-@bind h5p_get_userblock(plist_id::Hid, len::Ptr{Hsize})::Herr "Error getting userblock"
-@bind h5p_modify_filter(plist_id::Hid, filter_id::H5Z_filter_t, flags::Cuint, cd_nelmts::Csize_t, cd_values::Ptr{Cuint})::Herr "Error modifying filter"
-@bind h5p_set_alignment(plist_id::Hid, threshold::Hsize, alignment::Hsize)::Herr "Error setting alignment"
-@bind h5p_set_alloc_time(plist_id::Hid, alloc_time::Cint)::Herr "Error setting allocation timing"
-@bind h5p_set_char_encoding(plist_id::Hid, encoding::Cint)::Herr "Error setting char encoding"
-@bind h5p_set_chunk(plist_id::Hid, ndims::Cint, dims::Ptr{Hsize})::Herr "Error setting chunk size"
-@bind h5p_set_chunk_cache(dapl_id::Hid, rdcc_nslots::Csize_t, rdcc_nbytes::Csize_t, rdcc_w0::Cdouble)::Herr "Error setting chunk cache"
-@bind h5p_set_create_intermediate_group(plist_id::Hid, setting::Cuint)::Herr "Error setting create intermediate group"
-@bind h5p_set_deflate(plist_id::Hid, setting::Cuint)::Herr "Error setting compression method and level (deflate)"
-@bind h5p_set_dxpl_mpio(dxpl_id::Hid, xfer_mode::Cint)::Herr "Error setting MPIO transfer mode"
-@bind h5p_set_external(plist_id::Hid, name::Ptr{UInt8}, offset::Int, size::Csize_t)::Herr "Error setting external property"
-@bind h5p_set_fapl_mpio32(fapl_id::Hid, comm::Hmpih32, info::Hmpih32)::Herr "Error setting MPIO properties"
-@bind h5p_set_fapl_mpio64(fapl_id::Hid, comm::Hmpih64, info::Hmpih64)::Herr "Error setting MPIO properties"
-@bind h5p_set_fclose_degree(plist_id::Hid, fc_degree::Cint)::Herr "Error setting close degree"
-@bind h5p_set_filter(plist_id::Hid, filter_id::H5Z_filter_t, flags::Cuint, cd_nelmts::Csize_t, cd_values::Ptr{Cuint})::Herr "Error setting filter"
-@bind h5p_set_layout(plist_id::Hid, setting::Cint)::Herr "Error setting layout"
-@bind h5p_set_libver_bounds(fapl_id::Hid, libver_low::Cint, libver_high::Cint)::Herr "Error setting library version bounds"
-@bind h5p_set_local_heap_size_hint(fapl_id::Hid, size_hint::Cuint)::Herr "Error setting local heap size hint"
-@bind h5p_set_obj_track_times(plist_id::Hid, track_times::UInt8)::Herr "Error setting object time tracking"
-@bind h5p_set_shuffle(plist_id::Hid)::Herr "Error enabling shuffle filter"
-@bind h5p_set_userblock(plist_id::Hid, len::Hsize)::Herr "Error setting userblock"
-@bind h5p_set_virtual(dcpl_id::Hid, vspace_id::Hid, src_file_name::Ptr{UInt8}, src_dset_name::Ptr{UInt8}, src_space_id::Hid)::Herr "Error setting virtual"
+@bind h5p_close(id::hid_t)::herr_t "Error closing property list"
+@bind h5p_create(cls_id::hid_t)::hid_t "Error creating property list"
+@bind h5p_get_alignment(plist_id::hid_t, threshold::Ptr{hsize_t }, alignment::Ptr{hsize_t })::herr_t "Error getting alignment"
+@bind h5p_get_alloc_time(plist_id::hid_t, alloc_time::Ptr{Cint})::herr_t "Error getting allocation timing"
+@bind h5p_get_chunk(plist_id::hid_t, n_dims::Cint, dims::Ptr{hsize_t })::Cint error("Error getting chunk size")
+@bind h5p_get_driver(plist_id::hid_t)::hid_t "Error getting driver identifier"
+@bind h5p_get_driver_info(plist_id::hid_t)::Ptr{Cvoid} # does not error
+@bind h5p_get_dxpl_mpio(dxpl_id::hid_t, xfer_mode::Ptr{Cint})::herr_t "Error getting MPIO transfer mode"
+@bind h5p_get_fapl_mpio32(fapl_id::hid_t, comm::Ptr{Hmpih32}, info::Ptr{Hmpih32})::herr_t "Error getting MPIO properties"
+@bind h5p_get_fapl_mpio64(fapl_id::hid_t, comm::Ptr{Hmpih64}, info::Ptr{Hmpih64})::herr_t "Error getting MPIO properties"
+@bind h5p_get_fclose_degree(plist_id::hid_t, fc_degree::Ptr{Cint})::herr_t "Error getting close degree"
+@bind h5p_get_filter_by_id(plist_id::hid_t, filter_id::H5Z_filter_t, flags::Ref{Cuint}, cd_nelmts::Ref{Csize_t}, cd_values::Ptr{Cuint}, namelen::Csize_t, name::Ptr{UInt8}, filter_config::Ptr{Cuint})::herr_t "Error getting filter ID"
+@bind h5p_get_layout(plist_id::hid_t)::Cint error("Error getting layout")
+@bind h5p_get_userblock(plist_id::hid_t, len::Ptr{hsize_t })::herr_t "Error getting userblock"
+@bind h5p_modify_filter(plist_id::hid_t, filter_id::H5Z_filter_t, flags::Cuint, cd_nelmts::Csize_t, cd_values::Ptr{Cuint})::herr_t "Error modifying filter"
+@bind h5p_set_alignment(plist_id::hid_t, threshold::hsize_t , alignment::hsize_t )::herr_t "Error setting alignment"
+@bind h5p_set_alloc_time(plist_id::hid_t, alloc_time::Cint)::herr_t "Error setting allocation timing"
+@bind h5p_set_char_encoding(plist_id::hid_t, encoding::Cint)::herr_t "Error setting char encoding"
+@bind h5p_set_chunk(plist_id::hid_t, ndims::Cint, dims::Ptr{hsize_t })::herr_t "Error setting chunk size"
+@bind h5p_set_chunk_cache(dapl_id::hid_t, rdcc_nslots::Csize_t, rdcc_nbytes::Csize_t, rdcc_w0::Cdouble)::herr_t "Error setting chunk cache"
+@bind h5p_set_create_intermediate_group(plist_id::hid_t, setting::Cuint)::herr_t "Error setting create intermediate group"
+@bind h5p_set_deflate(plist_id::hid_t, setting::Cuint)::herr_t "Error setting compression method and level (deflate)"
+@bind h5p_set_dxpl_mpio(dxpl_id::hid_t, xfer_mode::Cint)::herr_t "Error setting MPIO transfer mode"
+@bind h5p_set_external(plist_id::hid_t, name::Ptr{UInt8}, offset::Int, size::Csize_t)::herr_t "Error setting external property"
+@bind h5p_set_fapl_mpio32(fapl_id::hid_t, comm::Hmpih32, info::Hmpih32)::herr_t "Error setting MPIO properties"
+@bind h5p_set_fapl_mpio64(fapl_id::hid_t, comm::Hmpih64, info::Hmpih64)::herr_t "Error setting MPIO properties"
+@bind h5p_set_fclose_degree(plist_id::hid_t, fc_degree::Cint)::herr_t "Error setting close degree"
+@bind h5p_set_filter(plist_id::hid_t, filter_id::H5Z_filter_t, flags::Cuint, cd_nelmts::Csize_t, cd_values::Ptr{Cuint})::herr_t "Error setting filter"
+@bind h5p_set_layout(plist_id::hid_t, setting::Cint)::herr_t "Error setting layout"
+@bind h5p_set_libver_bounds(fapl_id::hid_t, libver_low::Cint, libver_high::Cint)::herr_t "Error setting library version bounds"
+@bind h5p_set_local_heap_size_hint(fapl_id::hid_t, size_hint::Cuint)::herr_t "Error setting local heap size hint"
+@bind h5p_set_obj_track_times(plist_id::hid_t, track_times::UInt8)::herr_t "Error setting object time tracking"
+@bind h5p_set_shuffle(plist_id::hid_t)::herr_t "Error enabling shuffle filter"
+@bind h5p_set_userblock(plist_id::hid_t, len::hsize_t )::herr_t "Error setting userblock"
+@bind h5p_set_virtual(dcpl_id::hid_t, vspace_id::hid_t, src_file_name::Ptr{UInt8}, src_dset_name::Ptr{UInt8}, src_space_id::hid_t)::herr_t "Error setting virtual"
 
 ###
 ### Reference Interface
 ###
 
-@bind h5r_create(ref::Ptr{HDF5ReferenceObj}, loc_id::Hid, pathname::Ptr{UInt8}, ref_type::Cint, space_id::Hid)::Herr error("Error creating reference to object ", hi5_get_name(loc_id), "/", pathname)
-@bind h5r_dereference(obj_id::Hid, ref_type::Cint, ref::Ref{HDF5ReferenceObj})::Hid "Error dereferencing object"
-@bind h5r_get_obj_type(loc_id::Hid, ref_type::Cint, ref::Ptr{Cvoid}, obj_type::Ptr{Cint})::Herr "Error getting object type"
-@bind h5r_get_region(loc_id::Hid, ref_type::Cint, ref::Ptr{Cvoid})::Hid "Error getting region from reference"
+@bind h5r_create(ref::Ptr{HDF5ReferenceObj}, loc_id::hid_t, pathname::Ptr{UInt8}, ref_type::Cint, space_id::hid_t)::herr_t error("Error creating reference to object ", hi5_get_name(loc_id), "/", pathname)
+@bind h5r_dereference(obj_id::hid_t, ref_type::Cint, ref::Ref{HDF5ReferenceObj})::hid_t "Error dereferencing object"
+@bind h5r_get_obj_type(loc_id::hid_t, ref_type::Cint, ref::Ptr{Cvoid}, obj_type::Ptr{Cint})::herr_t "Error getting object type"
+@bind h5r_get_region(loc_id::hid_t, ref_type::Cint, ref::Ptr{Cvoid})::hid_t "Error getting region from reference"
 
 ###
 ### Dataspace Interface
 ###
 
-@bind h5s_close(space_id::Hid)::Herr "Error closing dataspace"
-@bind h5s_copy(space_id::Hid)::Hid "Error copying dataspace"
-@bind h5s_create(class::Cint)::Hid "Error creating dataspace"
-@bind h5s_create_simple(rank::Cint, current_dims::Ptr{Hsize}, maximum_dims::Ptr{Hsize})::Hid "Error creating simple dataspace"
-@bind h5s_get_simple_extent_dims(space_id::Hid, dims::Ptr{Hsize}, maxdims::Ptr{Hsize})::Cint "Error getting the dimensions for a dataspace"
-@bind h5s_get_simple_extent_ndims(space_id::Hid)::Cint "Error getting the number of dimensions for a dataspace"
-@bind h5s_get_simple_extent_type(space_id::Hid)::Cint "Error getting the dataspace type"
-@bind h5s_is_simple(space_id::Hid)::Htri "Error determining whether dataspace is simple"
-@bind h5s_select_hyperslab(dspace_id::Hid, seloper::Cint, start::Ptr{Hsize}, stride::Ptr{Hsize}, count::Ptr{Hsize}, block::Ptr{Hsize})::Herr "Error selecting hyperslab"
+@bind h5s_close(space_id::hid_t)::herr_t "Error closing dataspace"
+@bind h5s_copy(space_id::hid_t)::hid_t "Error copying dataspace"
+@bind h5s_create(class::Cint)::hid_t "Error creating dataspace"
+@bind h5s_create_simple(rank::Cint, current_dims::Ptr{hsize_t }, maximum_dims::Ptr{hsize_t })::hid_t "Error creating simple dataspace"
+@bind h5s_get_simple_extent_dims(space_id::hid_t, dims::Ptr{hsize_t }, maxdims::Ptr{hsize_t })::Cint "Error getting the dimensions for a dataspace"
+@bind h5s_get_simple_extent_ndims(space_id::hid_t)::Cint "Error getting the number of dimensions for a dataspace"
+@bind h5s_get_simple_extent_type(space_id::hid_t)::Cint "Error getting the dataspace type"
+@bind h5s_is_simple(space_id::hid_t)::htri_t "Error determining whether dataspace is simple"
+@bind h5s_select_hyperslab(dspace_id::hid_t, seloper::Cint, start::Ptr{hsize_t }, stride::Ptr{hsize_t }, count::Ptr{hsize_t }, block::Ptr{hsize_t })::herr_t "Error selecting hyperslab"
 
 ###
 ### Datatype Interface
 ###
 
-@bind h5t_array_create(basetype_id::Hid, ndims::Cuint, sz::Ptr{Hsize})::Hid error("Error creating H5T_ARRAY of id ", basetype_id, " and size ", sz)
-@bind h5t_close(dtype_id::Hid)::Herr "Error closing datatype"
-@bind h5t_committed(dtype_id::Hid)::Htri error("Error determining whether datatype is committed")
-@bind h5t_commit(loc_id::Hid, name::Ptr{UInt8}, dtype_id::Hid, lcpl_id::Hid, tcpl_id::Hid, tapl_id::Hid)::Herr "Error committing type"
-@bind h5t_copy(dtype_id::Hid)::Hid "Error copying datatype"
-@bind h5t_create(class_id::Cint, sz::Csize_t)::Hid error("Error creating datatype of id ", class_id)
-@bind h5t_equal(dtype_id1::Hid, dtype_id2::Hid)::Hid "Error checking datatype equality"
-@bind h5t_get_array_dims(dtype_id::Hid, dims::Ptr{Hsize})::Cint "Error getting dimensions of array"
-@bind h5t_get_array_ndims(dtype_id::Hid)::Cint "Error getting ndims of array"
-@bind h5t_get_class(dtype_id::Hid)::Cint "Error getting class"
-@bind h5t_get_cset(dtype_id::Hid)::Cint "Error getting character set encoding"
-@bind h5t_get_member_class(dtype_id::Hid, index::Cuint)::Cint error("Error getting class of compound datatype member #", index)
-@bind h5t_get_member_index(dtype_id::Hid, membername::Ptr{UInt8})::Cint error("Error getting index of compound datatype member \"", membername, "\"")
-@bind h5t_get_member_offset(dtype_id::Hid, index::Cuint)::Csize_t # does not error
-@bind h5t_get_member_type(dtype_id::Hid, index::Cuint)::Hid error("Error getting type of compound datatype member #", index)
-@bind h5t_get_native_type(dtype_id::Hid, direction::Cint)::Hid "Error getting native type"
-@bind h5t_get_nmembers(dtype_id::Hid)::Cint "Error getting the number of members"
-@bind h5t_get_sign(dtype_id::Hid)::Cint "Error getting sign"
-@bind h5t_get_size(dtype_id::Hid)::Csize_t "Error getting size"
-@bind h5t_get_strpad(dtype_id::Hid)::Cint "Error getting string padding"
-@bind h5t_get_super(dtype_id::Hid)::Hid "Error getting super type"
-@bind h5t_insert(dtype_id::Hid, fieldname::Ptr{UInt8}, offset::Csize_t, field_id::Hid)::Herr error("Error adding field ", fieldname, " to compound datatype")
-@bind h5t_is_variable_str(type_id::Hid)::Htri "Error determining whether string is of variable length"
-@bind h5t_open(loc_id::Hid, name::Ptr{UInt8}, tapl_id::Hid)::Hid error("Error opening type ", h5i_get_name(loc_id), "/", name)
-@bind h5t_set_cset(dtype_id::Hid, cset::Cint)::Herr "Error setting character set in datatype"
-@bind h5t_set_precision(dtype_id::Hid, sz::Csize_t)::Herr "Error setting precision of datatype"
-@bind h5t_set_size(dtype_id::Hid, sz::Csize_t)::Herr "Error setting size of datatype"
-@bind h5t_set_strpad(dtype_id::Hid, sz::Cint)::Herr "Error setting size of datatype"
-@bind h5t_vlen_create(base_type_id::Hid)::Hid "Error creating vlen type"
+@bind h5t_array_create(basetype_id::hid_t, ndims::Cuint, sz::Ptr{hsize_t })::hid_t error("Error creating H5T_ARRAY of id ", basetype_id, " and size ", sz)
+@bind h5t_close(dtype_id::hid_t)::herr_t "Error closing datatype"
+@bind h5t_committed(dtype_id::hid_t)::htri_t error("Error determining whether datatype is committed")
+@bind h5t_commit(loc_id::hid_t, name::Ptr{UInt8}, dtype_id::hid_t, lcpl_id::hid_t, tcpl_id::hid_t, tapl_id::hid_t)::herr_t "Error committing type"
+@bind h5t_copy(dtype_id::hid_t)::hid_t "Error copying datatype"
+@bind h5t_create(class_id::Cint, sz::Csize_t)::hid_t error("Error creating datatype of id ", class_id)
+@bind h5t_equal(dtype_id1::hid_t, dtype_id2::hid_t)::hid_t "Error checking datatype equality"
+@bind h5t_get_array_dims(dtype_id::hid_t, dims::Ptr{hsize_t })::Cint "Error getting dimensions of array"
+@bind h5t_get_array_ndims(dtype_id::hid_t)::Cint "Error getting ndims of array"
+@bind h5t_get_class(dtype_id::hid_t)::Cint "Error getting class"
+@bind h5t_get_cset(dtype_id::hid_t)::Cint "Error getting character set encoding"
+@bind h5t_get_member_class(dtype_id::hid_t, index::Cuint)::Cint error("Error getting class of compound datatype member #", index)
+@bind h5t_get_member_index(dtype_id::hid_t, membername::Ptr{UInt8})::Cint error("Error getting index of compound datatype member \"", membername, "\"")
+@bind h5t_get_member_offset(dtype_id::hid_t, index::Cuint)::Csize_t # does not error
+@bind h5t_get_member_type(dtype_id::hid_t, index::Cuint)::hid_t error("Error getting type of compound datatype member #", index)
+@bind h5t_get_native_type(dtype_id::hid_t, direction::Cint)::hid_t "Error getting native type"
+@bind h5t_get_nmembers(dtype_id::hid_t)::Cint "Error getting the number of members"
+@bind h5t_get_sign(dtype_id::hid_t)::Cint "Error getting sign"
+@bind h5t_get_size(dtype_id::hid_t)::Csize_t "Error getting size"
+@bind h5t_get_strpad(dtype_id::hid_t)::Cint "Error getting string padding"
+@bind h5t_get_super(dtype_id::hid_t)::hid_t "Error getting super type"
+@bind h5t_insert(dtype_id::hid_t, fieldname::Ptr{UInt8}, offset::Csize_t, field_id::hid_t)::herr_t error("Error adding field ", fieldname, " to compound datatype")
+@bind h5t_is_variable_str(type_id::hid_t)::htri_t "Error determining whether string is of variable length"
+@bind h5t_open(loc_id::hid_t, name::Ptr{UInt8}, tapl_id::hid_t)::hid_t error("Error opening type ", h5i_get_name(loc_id), "/", name)
+@bind h5t_set_cset(dtype_id::hid_t, cset::Cint)::herr_t "Error setting character set in datatype"
+@bind h5t_set_precision(dtype_id::hid_t, sz::Csize_t)::herr_t "Error setting precision of datatype"
+@bind h5t_set_size(dtype_id::hid_t, sz::Csize_t)::herr_t "Error setting size of datatype"
+@bind h5t_set_strpad(dtype_id::hid_t, sz::Cint)::herr_t "Error setting size of datatype"
+@bind h5t_vlen_create(base_type_id::hid_t)::hid_t "Error creating vlen type"
 # The following are not autoatically wrapped since they have requirements about freeing
 # the memory that is returned from the calls.
-#@bind h5t_get_member_name(dtype_id::Hid, index::Cuint)::Cstring error("Error getting name of compound datatype member #", index)
-#@bind h5t_get_tag(type_id::Hid)::Cstring "Error getting datatype opaque tag"
+#@bind h5t_get_member_name(dtype_id::hid_t, index::Cuint)::Cstring error("Error getting name of compound datatype member #", index)
+#@bind h5t_get_tag(type_id::hid_t)::Cstring "Error getting datatype opaque tag"
 
 ###
 ### Optimized Functions Interface
 ###
 
-@bind h5do_append(dset_id::Hid, dxpl_id::Hid, index::Cuint, num_elem::Hsize, memtype::Hid, buffer::Ptr{Cvoid})::Herr "error appending"
-@bind h5do_write_chunk(dset_id::Hid, dxpl_id::Hid, filter_mask::Int32, offset::Ptr{Hsize}, bufsize::Csize_t, buf::Ptr{Cvoid})::Herr "Error writing chunk"
+@bind h5do_append(dset_id::hid_t, dxpl_id::hid_t, index::Cuint, num_elem::hsize_t , memtype::hid_t, buffer::Ptr{Cvoid})::herr_t "error appending"
+@bind h5do_write_chunk(dset_id::hid_t, dxpl_id::hid_t, filter_mask::Int32, offset::Ptr{hsize_t }, bufsize::Csize_t, buf::Ptr{Cvoid})::herr_t "Error writing chunk"
 
 ###
 ### HDF5 Lite Interface
 ###
 
-@bind h5lt_dtype_to_text(datatype::Hid, str::Ptr{UInt8}, lang_type::Cint, len::Ref{Csize_t})::Herr "Error getting datatype text representation"
+@bind h5lt_dtype_to_text(datatype::hid_t, str::Ptr{UInt8}, lang_type::Cint, len::Ref{Csize_t})::herr_t "Error getting datatype text representation"
 
 ###
 ### Table Interface
 ###
 
-@bind h5tb_get_field_info(loc_id::Hid, table_name::Ptr{UInt8}, field_names::Ptr{Ptr{UInt8}}, field_sizes::Ptr{UInt8}, field_offsets::Ptr{UInt8}, type_size::Ptr{UInt8})::Herr "Error getting field information"
+@bind h5tb_get_field_info(loc_id::hid_t, table_name::Ptr{UInt8}, field_names::Ptr{Ptr{UInt8}}, field_sizes::Ptr{UInt8}, field_offsets::Ptr{UInt8}, type_size::Ptr{UInt8})::herr_t "Error getting field information"
 
 ###
 ### Filter Interface
 ###
 
-@bind h5z_register(filter_class::Ref{H5Z_class_t})::Herr "Unable to register new filter"
+@bind h5z_register(filter_class::Ref{H5Z_class_t})::herr_t "Unable to register new filter"

--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -34,13 +34,13 @@
 @bind h5a_create(loc_id::hid_t, pathname::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t)::hid_t error("Error creating attribute ", h5a_get_name(loc_id), "/", pathname)
 @bind h5a_create_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t, lapl_id::hid_t)::hid_t error("Error creating attribute ", attr_name, " for object ", obj_name)
 @bind h5a_delete(loc_id::hid_t, attr_name::Ptr{UInt8})::herr_t error("Error deleting attribute ", attr_name)
-@bind h5a_delete_by_idx(loc_id::hid_t, obj_name::Ptr{UInt8}, idx_type::Cint, order::Cint, n::hsize_t , lapl_id::hid_t)::herr_t error("Error deleting attribute ", n, " from object ", obj_name)
+@bind h5a_delete_by_idx(loc_id::hid_t, obj_name::Ptr{UInt8}, idx_type::Cint, order::Cint, n::hsize_t, lapl_id::hid_t)::herr_t error("Error deleting attribute ", n, " from object ", obj_name)
 @bind h5a_delete_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, lapl_id::hid_t)::herr_t error("Error removing attribute ", attr_name, " from object ", obj_name)
 @bind h5a_exists(obj_id::hid_t, attr_name::Ptr{UInt8})::htri_t error("Error checking whether attribute ", attr_name, " exists")
 @bind h5a_exists_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, lapl_id::hid_t)::htri_t error("Error checking whether object ", obj_name, " has attribute ", attr_name)
 @bind h5a_get_create_plist(attr_id::hid_t)::hid_t error("Cannot get creation property list")
 @bind h5a_get_name(attr_id::hid_t, buf_size::Csize_t, buf::Ptr{UInt8})::Cssize_t "Error getting attribute name"
-@bind h5a_get_name_by_idx(loc_id::hid_t, obj_name::Ptr{UInt8}, index_type::Cint, order::Cint, idx::hsize_t , name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t)::Cssize_t error("Error getting attribute name")
+@bind h5a_get_name_by_idx(loc_id::hid_t, obj_name::Ptr{UInt8}, index_type::Cint, order::Cint, idx::hsize_t, name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t)::Cssize_t error("Error getting attribute name")
 @bind h5a_get_space(attr_id::hid_t)::hid_t "Error getting attribute dataspace"
 @bind h5a_get_type(attr_id::hid_t)::hid_t "Error getting attribute type"
 @bind h5a_open(obj_id::hid_t, pathname::Ptr{UInt8}, aapl_id::hid_t)::hid_t error("Error opening attribute ", h5i_get_name(obj_id), "/", pathname)
@@ -62,8 +62,8 @@
 @bind h5d_open(loc_id::hid_t, pathname::Ptr{UInt8}, dapl_id::hid_t)::hid_t error("Error opening dataset ", h5i_get_name(loc_id), "/", pathname)
 @bind h5d_read(dataset_id::hid_t, mem_type_id::hid_t, mem_space_id::hid_t, file_space_id::hid_t, xfer_plist_id::hid_t, buf::Ptr{Cvoid})::herr_t error("Error reading dataset ", h5i_get_name(dataset_id))
 @bind h5d_refresh(dataset_id::hid_t)::herr_t "Error refreshing dataset"
-@bind h5d_set_extent(dataset_id::hid_t, new_dims::Ptr{hsize_t })::herr_t "Error extending dataset dimensions"
-@bind h5d_vlen_get_buf_size(dset_id::hid_t, type_id::hid_t, space_id::hid_t, buf::Ptr{hsize_t })::herr_t "Error getting vlen buffer size"
+@bind h5d_set_extent(dataset_id::hid_t, new_dims::Ptr{hsize_t})::herr_t "Error extending dataset dimensions"
+@bind h5d_vlen_get_buf_size(dset_id::hid_t, type_id::hid_t, space_id::hid_t, buf::Ptr{hsize_t})::herr_t "Error getting vlen buffer size"
 @bind h5d_vlen_reclaim(type_id::hid_t, space_id::hid_t, plist_id::hid_t, buf::Ptr{Cvoid})::herr_t "Error reclaiming vlen buffer"
 @bind h5d_write(dataset_id::hid_t, mem_type_id::hid_t, mem_space_id::hid_t, file_space_id::hid_t, xfer_plist_id::hid_t, buf::Ptr{Cvoid})::herr_t "Error writing dataset"
 
@@ -100,8 +100,8 @@
 @bind h5g_create(loc_id::hid_t, pathname::Ptr{UInt8}, lcpl_id::hid_t, gcpl_id::hid_t, gapl_id::hid_t)::hid_t error("Error creating group ", h5i_get_name(loc_id), "/", pathname)
 @bind h5g_get_create_plist(group_id::hid_t)::hid_t "Error getting group create property list"
 @bind h5g_get_info(group_id::hid_t, buf::Ptr{H5Ginfo})::herr_t "Error getting group info"
-@bind h5g_get_num_objs(loc_id::hid_t, num_obj::Ptr{hsize_t })::hid_t "Error getting group length"
-@bind h5g_get_objname_by_idx(loc_id::hid_t, idx::hsize_t , pathname::Ptr{UInt8}, size::Csize_t)::Cssize_t error("Error getting group object name ", h5i_get_name(loc_id), "/", pathname)
+@bind h5g_get_num_objs(loc_id::hid_t, num_obj::Ptr{hsize_t})::hid_t "Error getting group length"
+@bind h5g_get_objname_by_idx(loc_id::hid_t, idx::hsize_t, pathname::Ptr{UInt8}, size::Csize_t)::Cssize_t error("Error getting group object name ", h5i_get_name(loc_id), "/", pathname)
 @bind h5g_open(loc_id::hid_t, pathname::Ptr{UInt8}, gapl_id::hid_t)::hid_t error("Error opening group ", h5i_get_name(loc_id), "/", pathname)
 
 ###
@@ -125,7 +125,7 @@
 @bind h5l_delete(obj_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t)::herr_t error("Error deleting ", h5i_get_name(obj_id), "/", pathname)
 @bind h5l_exists(loc_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t)::htri_t error("Cannot determine whether ", pathname, " exists")
 @bind h5l_get_info(link_loc_id::hid_t, link_name::Ptr{UInt8}, link_buf::Ptr{H5LInfo}, lapl_id::hid_t)::herr_t error("Error getting info for link ", link_name)
-@bind h5l_get_name_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_field::Cint, order::Cint, n::hsize_t , name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t)::Cssize_t "Error getting object name"
+@bind h5l_get_name_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_field::Cint, order::Cint, n::hsize_t, name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t)::Cssize_t "Error getting object name"
 
 ###
 ### Object Interface
@@ -136,7 +136,7 @@
 @bind h5o_get_info(object_id::hid_t, buf::Ptr{H5Oinfo})::herr_t "Error getting object info"
 @bind h5o_open(loc_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t)::hid_t error("Error opening object ", h5i_get_name(loc_id), "/", pathname)
 @bind h5o_open_by_addr(loc_id::hid_t, addr::haddr_t)::hid_t error("Error opening object by address")
-@bind h5o_open_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_type::Cint, order::Cint, n::hsize_t , lapl_id::hid_t)::hid_t error("Error opening object of index ", n)
+@bind h5o_open_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_type::Cint, order::Cint, n::hsize_t, lapl_id::hid_t)::hid_t error("Error opening object of index ", n)
 
 ###
 ### Property Interface
@@ -144,9 +144,9 @@
 
 @bind h5p_close(id::hid_t)::herr_t "Error closing property list"
 @bind h5p_create(cls_id::hid_t)::hid_t "Error creating property list"
-@bind h5p_get_alignment(plist_id::hid_t, threshold::Ptr{hsize_t }, alignment::Ptr{hsize_t })::herr_t "Error getting alignment"
+@bind h5p_get_alignment(plist_id::hid_t, threshold::Ptr{hsize_t}, alignment::Ptr{hsize_t})::herr_t "Error getting alignment"
 @bind h5p_get_alloc_time(plist_id::hid_t, alloc_time::Ptr{Cint})::herr_t "Error getting allocation timing"
-@bind h5p_get_chunk(plist_id::hid_t, n_dims::Cint, dims::Ptr{hsize_t })::Cint error("Error getting chunk size")
+@bind h5p_get_chunk(plist_id::hid_t, n_dims::Cint, dims::Ptr{hsize_t})::Cint error("Error getting chunk size")
 @bind h5p_get_driver(plist_id::hid_t)::hid_t "Error getting driver identifier"
 @bind h5p_get_driver_info(plist_id::hid_t)::Ptr{Cvoid} # does not error
 @bind h5p_get_dxpl_mpio(dxpl_id::hid_t, xfer_mode::Ptr{Cint})::herr_t "Error getting MPIO transfer mode"
@@ -155,12 +155,12 @@
 @bind h5p_get_fclose_degree(plist_id::hid_t, fc_degree::Ptr{Cint})::herr_t "Error getting close degree"
 @bind h5p_get_filter_by_id(plist_id::hid_t, filter_id::H5Z_filter_t, flags::Ref{Cuint}, cd_nelmts::Ref{Csize_t}, cd_values::Ptr{Cuint}, namelen::Csize_t, name::Ptr{UInt8}, filter_config::Ptr{Cuint})::herr_t "Error getting filter ID"
 @bind h5p_get_layout(plist_id::hid_t)::Cint error("Error getting layout")
-@bind h5p_get_userblock(plist_id::hid_t, len::Ptr{hsize_t })::herr_t "Error getting userblock"
+@bind h5p_get_userblock(plist_id::hid_t, len::Ptr{hsize_t})::herr_t "Error getting userblock"
 @bind h5p_modify_filter(plist_id::hid_t, filter_id::H5Z_filter_t, flags::Cuint, cd_nelmts::Csize_t, cd_values::Ptr{Cuint})::herr_t "Error modifying filter"
-@bind h5p_set_alignment(plist_id::hid_t, threshold::hsize_t , alignment::hsize_t )::herr_t "Error setting alignment"
+@bind h5p_set_alignment(plist_id::hid_t, threshold::hsize_t, alignment::hsize_t)::herr_t "Error setting alignment"
 @bind h5p_set_alloc_time(plist_id::hid_t, alloc_time::Cint)::herr_t "Error setting allocation timing"
 @bind h5p_set_char_encoding(plist_id::hid_t, encoding::Cint)::herr_t "Error setting char encoding"
-@bind h5p_set_chunk(plist_id::hid_t, ndims::Cint, dims::Ptr{hsize_t })::herr_t "Error setting chunk size"
+@bind h5p_set_chunk(plist_id::hid_t, ndims::Cint, dims::Ptr{hsize_t})::herr_t "Error setting chunk size"
 @bind h5p_set_chunk_cache(dapl_id::hid_t, rdcc_nslots::Csize_t, rdcc_nbytes::Csize_t, rdcc_w0::Cdouble)::herr_t "Error setting chunk cache"
 @bind h5p_set_create_intermediate_group(plist_id::hid_t, setting::Cuint)::herr_t "Error setting create intermediate group"
 @bind h5p_set_deflate(plist_id::hid_t, setting::Cuint)::herr_t "Error setting compression method and level (deflate)"
@@ -175,7 +175,7 @@
 @bind h5p_set_local_heap_size_hint(fapl_id::hid_t, size_hint::Cuint)::herr_t "Error setting local heap size hint"
 @bind h5p_set_obj_track_times(plist_id::hid_t, track_times::UInt8)::herr_t "Error setting object time tracking"
 @bind h5p_set_shuffle(plist_id::hid_t)::herr_t "Error enabling shuffle filter"
-@bind h5p_set_userblock(plist_id::hid_t, len::hsize_t )::herr_t "Error setting userblock"
+@bind h5p_set_userblock(plist_id::hid_t, len::hsize_t)::herr_t "Error setting userblock"
 @bind h5p_set_virtual(dcpl_id::hid_t, vspace_id::hid_t, src_file_name::Ptr{UInt8}, src_dset_name::Ptr{UInt8}, src_space_id::hid_t)::herr_t "Error setting virtual"
 
 ###
@@ -194,25 +194,25 @@
 @bind h5s_close(space_id::hid_t)::herr_t "Error closing dataspace"
 @bind h5s_copy(space_id::hid_t)::hid_t "Error copying dataspace"
 @bind h5s_create(class::Cint)::hid_t "Error creating dataspace"
-@bind h5s_create_simple(rank::Cint, current_dims::Ptr{hsize_t }, maximum_dims::Ptr{hsize_t })::hid_t "Error creating simple dataspace"
-@bind h5s_get_simple_extent_dims(space_id::hid_t, dims::Ptr{hsize_t }, maxdims::Ptr{hsize_t })::Cint "Error getting the dimensions for a dataspace"
+@bind h5s_create_simple(rank::Cint, current_dims::Ptr{hsize_t}, maximum_dims::Ptr{hsize_t})::hid_t "Error creating simple dataspace"
+@bind h5s_get_simple_extent_dims(space_id::hid_t, dims::Ptr{hsize_t}, maxdims::Ptr{hsize_t})::Cint "Error getting the dimensions for a dataspace"
 @bind h5s_get_simple_extent_ndims(space_id::hid_t)::Cint "Error getting the number of dimensions for a dataspace"
 @bind h5s_get_simple_extent_type(space_id::hid_t)::Cint "Error getting the dataspace type"
 @bind h5s_is_simple(space_id::hid_t)::htri_t "Error determining whether dataspace is simple"
-@bind h5s_select_hyperslab(dspace_id::hid_t, seloper::Cint, start::Ptr{hsize_t }, stride::Ptr{hsize_t }, count::Ptr{hsize_t }, block::Ptr{hsize_t })::herr_t "Error selecting hyperslab"
+@bind h5s_select_hyperslab(dspace_id::hid_t, seloper::Cint, start::Ptr{hsize_t}, stride::Ptr{hsize_t}, count::Ptr{hsize_t}, block::Ptr{hsize_t})::herr_t "Error selecting hyperslab"
 
 ###
 ### Datatype Interface
 ###
 
-@bind h5t_array_create(basetype_id::hid_t, ndims::Cuint, sz::Ptr{hsize_t })::hid_t error("Error creating H5T_ARRAY of id ", basetype_id, " and size ", sz)
+@bind h5t_array_create(basetype_id::hid_t, ndims::Cuint, sz::Ptr{hsize_t})::hid_t error("Error creating H5T_ARRAY of id ", basetype_id, " and size ", sz)
 @bind h5t_close(dtype_id::hid_t)::herr_t "Error closing datatype"
 @bind h5t_committed(dtype_id::hid_t)::htri_t error("Error determining whether datatype is committed")
 @bind h5t_commit(loc_id::hid_t, name::Ptr{UInt8}, dtype_id::hid_t, lcpl_id::hid_t, tcpl_id::hid_t, tapl_id::hid_t)::herr_t "Error committing type"
 @bind h5t_copy(dtype_id::hid_t)::hid_t "Error copying datatype"
 @bind h5t_create(class_id::Cint, sz::Csize_t)::hid_t error("Error creating datatype of id ", class_id)
 @bind h5t_equal(dtype_id1::hid_t, dtype_id2::hid_t)::hid_t "Error checking datatype equality"
-@bind h5t_get_array_dims(dtype_id::hid_t, dims::Ptr{hsize_t })::Cint "Error getting dimensions of array"
+@bind h5t_get_array_dims(dtype_id::hid_t, dims::Ptr{hsize_t})::Cint "Error getting dimensions of array"
 @bind h5t_get_array_ndims(dtype_id::hid_t)::Cint "Error getting ndims of array"
 @bind h5t_get_class(dtype_id::hid_t)::Cint "Error getting class"
 @bind h5t_get_cset(dtype_id::hid_t)::Cint "Error getting character set encoding"
@@ -243,8 +243,8 @@
 ### Optimized Functions Interface
 ###
 
-@bind h5do_append(dset_id::hid_t, dxpl_id::hid_t, index::Cuint, num_elem::hsize_t , memtype::hid_t, buffer::Ptr{Cvoid})::herr_t "error appending"
-@bind h5do_write_chunk(dset_id::hid_t, dxpl_id::hid_t, filter_mask::Int32, offset::Ptr{hsize_t }, bufsize::Csize_t, buf::Ptr{Cvoid})::herr_t "Error writing chunk"
+@bind h5do_append(dset_id::hid_t, dxpl_id::hid_t, index::Cuint, num_elem::hsize_t, memtype::hid_t, buffer::Ptr{Cvoid})::herr_t "error appending"
+@bind h5do_write_chunk(dset_id::hid_t, dxpl_id::hid_t, filter_mask::Int32, offset::Ptr{hsize_t}, bufsize::Csize_t, buf::Ptr{Cvoid})::herr_t "Error writing chunk"
 
 ###
 ### HDF5 Lite Interface

--- a/gen/bind_generator.jl
+++ b/gen/bind_generator.jl
@@ -46,10 +46,10 @@ expression may refer to any arguments by name.
 The declared return type in the function-like signature must be the return type of the C
 function, and the Julia return type is inferred as one of the following possibilities:
 
-1. If `ReturnType === :Herr`, the Julia function returns `nothing` and the C return is
+1. If `ReturnType === :herr_t`, the Julia function returns `nothing` and the C return is
    used only in error checking.
 
-2. If `ReturnType === :Htri`, the Julia function returns a boolean indicating whether
+2. If `ReturnType === :htri_t`, the Julia function returns a boolean indicating whether
    the return value of the C function was zero (`false`) or positive (`true`).
 
 3. Otherwise, the C function return value is returned from the Julia function.
@@ -57,11 +57,11 @@ function, and the Julia return type is inferred as one of the following possibil
 Furthermore, the C return value is interpreted to automatically generate error checks
 (only when `ErrorStringOrExpression` is provided):
 
-1. If `ReturnType === :Herr` or `ReturnType === :Htri`, an error is raised when the return
+1. If `ReturnType === :herr_t` or `ReturnType === :htri_t`, an error is raised when the return
    value is negative.
 
-2. If `ReturnType === :Haddr` or `ReturnType === :Hsize`, an error is raised when the
-   return value is equivalent to `-1 % Haddr` and `-1 % Hsize`, respectively.
+2. If `ReturnType === :haddr_t` or `ReturnType === :hsize_t `, an error is raised when the
+   return value is equivalent to `-1 % haddr_t` and `-1 % hsize_t `, respectively.
 
 3. If `ReturnType` is a `Ptr` expression, an error is raised when the return value is
    equal to `C_NULL`.
@@ -120,7 +120,7 @@ macro bind(sig::Expr, err::Union{String,Expr,Nothing} = nothing)
     errexpr = err isa String ? :(error($err)) : err
     if errexpr === nothing
         # pass through
-    elseif rettype === :Haddr || rettype === :Hsize
+    elseif rettype === :haddr_t|| rettype === :hsize_t
         # Error typically indicated by negative values, but some return types are unsigned
         # integers. From `H5public.h`:
         #   ADDR_UNDEF => (haddr_t)(-1)
@@ -134,10 +134,10 @@ macro bind(sig::Expr, err::Union{String,Expr,Nothing} = nothing)
     end
 
     # Three cases for handling the return type
-    if rettype === :Htri
+    if rettype === :htri_t
         # Returns a Boolean on non-error
         returnexpr = :(return $statsym > 0)
-    elseif rettype === :Herr
+    elseif rettype === :herr_t
         # Only used to indicate error status
         returnexpr = :(return nothing)
     else

--- a/gen/bind_generator.jl
+++ b/gen/bind_generator.jl
@@ -60,8 +60,8 @@ Furthermore, the C return value is interpreted to automatically generate error c
 1. If `ReturnType === :herr_t` or `ReturnType === :htri_t`, an error is raised when the return
    value is negative.
 
-2. If `ReturnType === :haddr_t` or `ReturnType === :hsize_t `, an error is raised when the
-   return value is equivalent to `-1 % haddr_t` and `-1 % hsize_t `, respectively.
+2. If `ReturnType === :haddr_t` or `ReturnType === :hsize_t`, an error is raised when the
+   return value is equivalent to `-1 % haddr_t` and `-1 % hsize_t`, respectively.
 
 3. If `ReturnType` is a `Ptr` expression, an error is raised when the return value is
    equal to `C_NULL`.

--- a/src/api.jl
+++ b/src/api.jl
@@ -4,966 +4,965 @@
 # `gen/gen_wrappers.jl`, and commit the updated `src/api.jl`.
 
 function h5_close()
-    var"#status#" = ccall((:H5close, libhdf5), Herr, ())
+    var"#status#" = ccall((:H5close, libhdf5), herr_t, ())
     var"#status#" < 0 && error("Error closing the HDF5 resources")
     return nothing
 end
 
 function h5_dont_atexit()
-    var"#status#" = ccall((:H5dont_atexit, libhdf5), Herr, ())
+    var"#status#" = ccall((:H5dont_atexit, libhdf5), herr_t, ())
     var"#status#" < 0 && error("Error calling dont_atexit")
     return nothing
 end
 
 function h5_free_memory(buf)
-    var"#status#" = ccall((:H5free_memory, libhdf5), Herr, (Ptr{Cvoid},), buf)
+    var"#status#" = ccall((:H5free_memory, libhdf5), herr_t, (Ptr{Cvoid},), buf)
     var"#status#" < 0 && error("Error freeing memory")
     return nothing
 end
 
 function h5_garbage_collect()
-    var"#status#" = ccall((:H5garbage_collect, libhdf5), Herr, ())
+    var"#status#" = ccall((:H5garbage_collect, libhdf5), herr_t, ())
     var"#status#" < 0 && error("Error on garbage collect")
     return nothing
 end
 
 function h5_get_libversion(majnum, minnum, relnum)
-    var"#status#" = ccall((:H5get_libversion, libhdf5), Herr, (Ref{Cuint}, Ref{Cuint}, Ref{Cuint}), majnum, minnum, relnum)
+    var"#status#" = ccall((:H5get_libversion, libhdf5), herr_t, (Ref{Cuint}, Ref{Cuint}, Ref{Cuint}), majnum, minnum, relnum)
     var"#status#" < 0 && error("Error getting HDF5 library version")
     return nothing
 end
 
 function h5_open()
-    var"#status#" = ccall((:H5open, libhdf5), Herr, ())
+    var"#status#" = ccall((:H5open, libhdf5), herr_t, ())
     var"#status#" < 0 && error("Error initializing the HDF5 library")
     return nothing
 end
 
 function h5_set_free_list_limits(reg_global_lim, reg_list_lim, arr_global_lim, arr_list_lim, blk_global_lim, blk_list_lim)
-    var"#status#" = ccall((:H5set_free_list_limits, libhdf5), Herr, (Cint, Cint, Cint, Cint, Cint, Cint), reg_global_lim, reg_list_lim, arr_global_lim, arr_list_lim, blk_global_lim, blk_list_lim)
+    var"#status#" = ccall((:H5set_free_list_limits, libhdf5), herr_t, (Cint, Cint, Cint, Cint, Cint, Cint), reg_global_lim, reg_list_lim, arr_global_lim, arr_list_lim, blk_global_lim, blk_list_lim)
     var"#status#" < 0 && error("Error setting limits on free lists")
     return nothing
 end
 
 function h5a_close(id)
-    var"#status#" = ccall((:H5Aclose, libhdf5), Herr, (Hid,), id)
+    var"#status#" = ccall((:H5Aclose, libhdf5), herr_t, (hid_t,), id)
     var"#status#" < 0 && error("Error closing attribute")
     return nothing
 end
 
 function h5a_create(loc_id, pathname, type_id, space_id, acpl_id, aapl_id)
-    var"#status#" = ccall((:H5Acreate2, libhdf5), Hid, (Hid, Ptr{UInt8}, Hid, Hid, Hid, Hid), loc_id, pathname, type_id, space_id, acpl_id, aapl_id)
+    var"#status#" = ccall((:H5Acreate2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t, hid_t, hid_t, hid_t), loc_id, pathname, type_id, space_id, acpl_id, aapl_id)
     var"#status#" < 0 && error("Error creating attribute ", h5a_get_name(loc_id), "/", pathname)
     return var"#status#"
 end
 
 function h5a_create_by_name(loc_id, obj_name, attr_name, type_id, space_id, acpl_id, aapl_id, lapl_id)
-    var"#status#" = ccall((:H5Acreate_by_name, libhdf5), Hid, (Hid, Ptr{UInt8}, Ptr{UInt8}, Hid, Hid, Hid, Hid, Hid), loc_id, obj_name, attr_name, type_id, space_id, acpl_id, aapl_id, lapl_id)
+    var"#status#" = ccall((:H5Acreate_by_name, libhdf5), hid_t, (hid_t, Ptr{UInt8}, Ptr{UInt8}, hid_t, hid_t, hid_t, hid_t, hid_t), loc_id, obj_name, attr_name, type_id, space_id, acpl_id, aapl_id, lapl_id)
     var"#status#" < 0 && error("Error creating attribute ", attr_name, " for object ", obj_name)
     return var"#status#"
 end
 
 function h5a_delete(loc_id, attr_name)
-    var"#status#" = ccall((:H5Adelete, libhdf5), Herr, (Hid, Ptr{UInt8}), loc_id, attr_name)
+    var"#status#" = ccall((:H5Adelete, libhdf5), herr_t, (hid_t, Ptr{UInt8}), loc_id, attr_name)
     var"#status#" < 0 && error("Error deleting attribute ", attr_name)
     return nothing
 end
 
 function h5a_delete_by_idx(loc_id, obj_name, idx_type, order, n, lapl_id)
-    var"#status#" = ccall((:H5Adelete_by_idx, libhdf5), Herr, (Hid, Ptr{UInt8}, Cint, Cint, Hsize, Hid), loc_id, obj_name, idx_type, order, n, lapl_id)
+    var"#status#" = ccall((:H5Adelete_by_idx, libhdf5), herr_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t , hid_t), loc_id, obj_name, idx_type, order, n, lapl_id)
     var"#status#" < 0 && error("Error deleting attribute ", n, " from object ", obj_name)
     return nothing
 end
 
 function h5a_delete_by_name(loc_id, obj_name, attr_name, lapl_id)
-    var"#status#" = ccall((:H5Adelete_by_name, libhdf5), Herr, (Hid, Ptr{UInt8}, Ptr{UInt8}, Hid), loc_id, obj_name, attr_name, lapl_id)
+    var"#status#" = ccall((:H5Adelete_by_name, libhdf5), herr_t, (hid_t, Ptr{UInt8}, Ptr{UInt8}, hid_t), loc_id, obj_name, attr_name, lapl_id)
     var"#status#" < 0 && error("Error removing attribute ", attr_name, " from object ", obj_name)
     return nothing
 end
 
 function h5a_exists(obj_id, attr_name)
-    var"#status#" = ccall((:H5Aexists, libhdf5), Htri, (Hid, Ptr{UInt8}), obj_id, attr_name)
+    var"#status#" = ccall((:H5Aexists, libhdf5), htri_t, (hid_t, Ptr{UInt8}), obj_id, attr_name)
     var"#status#" < 0 && error("Error checking whether attribute ", attr_name, " exists")
     return var"#status#" > 0
 end
 
 function h5a_exists_by_name(loc_id, obj_name, attr_name, lapl_id)
-    var"#status#" = ccall((:H5Aexists_by_name, libhdf5), Htri, (Hid, Ptr{UInt8}, Ptr{UInt8}, Hid), loc_id, obj_name, attr_name, lapl_id)
+    var"#status#" = ccall((:H5Aexists_by_name, libhdf5), htri_t, (hid_t, Ptr{UInt8}, Ptr{UInt8}, hid_t), loc_id, obj_name, attr_name, lapl_id)
     var"#status#" < 0 && error("Error checking whether object ", obj_name, " has attribute ", attr_name)
     return var"#status#" > 0
 end
 
 function h5a_get_create_plist(attr_id)
-    var"#status#" = ccall((:H5Aget_create_plist, libhdf5), Hid, (Hid,), attr_id)
+    var"#status#" = ccall((:H5Aget_create_plist, libhdf5), hid_t, (hid_t,), attr_id)
     var"#status#" < 0 && error("Cannot get creation property list")
     return var"#status#"
 end
 
 function h5a_get_name(attr_id, buf_size, buf)
-    var"#status#" = ccall((:H5Aget_name, libhdf5), Cssize_t, (Hid, Csize_t, Ptr{UInt8}), attr_id, buf_size, buf)
+    var"#status#" = ccall((:H5Aget_name, libhdf5), Cssize_t, (hid_t, Csize_t, Ptr{UInt8}), attr_id, buf_size, buf)
     var"#status#" < 0 && error("Error getting attribute name")
     return var"#status#"
 end
 
 function h5a_get_name_by_idx(loc_id, obj_name, index_type, order, idx, name, size, lapl_id)
-    var"#status#" = ccall((:H5Aget_name_by_idx, libhdf5), Cssize_t, (Hid, Ptr{UInt8}, Cint, Cint, Hsize, Ptr{UInt8}, Csize_t, Hid), loc_id, obj_name, index_type, order, idx, name, size, lapl_id)
+    var"#status#" = ccall((:H5Aget_name_by_idx, libhdf5), Cssize_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t , Ptr{UInt8}, Csize_t, hid_t), loc_id, obj_name, index_type, order, idx, name, size, lapl_id)
     var"#status#" < 0 && error("Error getting attribute name")
     return var"#status#"
 end
 
 function h5a_get_space(attr_id)
-    var"#status#" = ccall((:H5Aget_space, libhdf5), Hid, (Hid,), attr_id)
+    var"#status#" = ccall((:H5Aget_space, libhdf5), hid_t, (hid_t,), attr_id)
     var"#status#" < 0 && error("Error getting attribute dataspace")
     return var"#status#"
 end
 
 function h5a_get_type(attr_id)
-    var"#status#" = ccall((:H5Aget_type, libhdf5), Hid, (Hid,), attr_id)
+    var"#status#" = ccall((:H5Aget_type, libhdf5), hid_t, (hid_t,), attr_id)
     var"#status#" < 0 && error("Error getting attribute type")
     return var"#status#"
 end
 
 function h5a_open(obj_id, pathname, aapl_id)
-    var"#status#" = ccall((:H5Aopen, libhdf5), Hid, (Hid, Ptr{UInt8}, Hid), obj_id, pathname, aapl_id)
+    var"#status#" = ccall((:H5Aopen, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t), obj_id, pathname, aapl_id)
     var"#status#" < 0 && error("Error opening attribute ", h5i_get_name(obj_id), "/", pathname)
     return var"#status#"
 end
 
 function h5a_read(attr_id, mem_type_id, buf)
-    var"#status#" = ccall((:H5Aread, libhdf5), Herr, (Hid, Hid, Ptr{Cvoid}), attr_id, mem_type_id, buf)
+    var"#status#" = ccall((:H5Aread, libhdf5), herr_t, (hid_t, hid_t, Ptr{Cvoid}), attr_id, mem_type_id, buf)
     var"#status#" < 0 && error("Error reading attribute ", h5a_get_name(attr_id))
     return nothing
 end
 
 function h5a_write(attr_hid, mem_type_id, buf)
-    var"#status#" = ccall((:H5Awrite, libhdf5), Herr, (Hid, Hid, Ptr{Cvoid}), attr_hid, mem_type_id, buf)
+    var"#status#" = ccall((:H5Awrite, libhdf5), herr_t, (hid_t, hid_t, Ptr{Cvoid}), attr_hid, mem_type_id, buf)
     var"#status#" < 0 && error("Error writing attribute data")
     return nothing
 end
 
 function h5d_close(dataset_id)
-    var"#status#" = ccall((:H5Dclose, libhdf5), Herr, (Hid,), dataset_id)
+    var"#status#" = ccall((:H5Dclose, libhdf5), herr_t, (hid_t,), dataset_id)
     var"#status#" < 0 && error("Error closing dataset")
     return nothing
 end
 
 function h5d_create(loc_id, pathname, dtype_id, space_id, lcpl_id, dcpl_id, dapl_id)
-    var"#status#" = ccall((:H5Dcreate2, libhdf5), Hid, (Hid, Ptr{UInt8}, Hid, Hid, Hid, Hid, Hid), loc_id, pathname, dtype_id, space_id, lcpl_id, dcpl_id, dapl_id)
+    var"#status#" = ccall((:H5Dcreate2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t, hid_t, hid_t, hid_t, hid_t), loc_id, pathname, dtype_id, space_id, lcpl_id, dcpl_id, dapl_id)
     var"#status#" < 0 && error("Error creating dataset ", h5i_get_name(loc_id), "/", pathname)
     return var"#status#"
 end
 
 function h5d_flush(dataset_id)
-    var"#status#" = ccall((:H5Dflush, libhdf5), Herr, (Hid,), dataset_id)
+    var"#status#" = ccall((:H5Dflush, libhdf5), herr_t, (hid_t,), dataset_id)
     var"#status#" < 0 && error("Error flushing dataset")
     return nothing
 end
 
 function h5d_get_access_plist(dataset_id)
-    var"#status#" = ccall((:H5Dget_access_plist, libhdf5), Hid, (Hid,), dataset_id)
+    var"#status#" = ccall((:H5Dget_access_plist, libhdf5), hid_t, (hid_t,), dataset_id)
     var"#status#" < 0 && error("Error getting dataset access property list")
     return var"#status#"
 end
 
 function h5d_get_create_plist(dataset_id)
-    var"#status#" = ccall((:H5Dget_create_plist, libhdf5), Hid, (Hid,), dataset_id)
+    var"#status#" = ccall((:H5Dget_create_plist, libhdf5), hid_t, (hid_t,), dataset_id)
     var"#status#" < 0 && error("Error getting dataset create property list")
     return var"#status#"
 end
 
 function h5d_get_offset(dataset_id)
-    var"#status#" = ccall((:H5Dget_offset, libhdf5), Haddr, (Hid,), dataset_id)
-    var"#status#" == -1 % Haddr && error("Error getting offset")
+    var"#status#" = ccall((:H5Dget_offset, libhdf5), haddr_t, (hid_t,), dataset_id)
+    var"#status#" == -1 % haddr_t&& error("Error getting offset")
     return var"#status#"
 end
 
 function h5d_get_space(dataset_id)
-    var"#status#" = ccall((:H5Dget_space, libhdf5), Hid, (Hid,), dataset_id)
+    var"#status#" = ccall((:H5Dget_space, libhdf5), hid_t, (hid_t,), dataset_id)
     var"#status#" < 0 && error("Error getting dataspace")
     return var"#status#"
 end
 
 function h5d_get_type(dataset_id)
-    var"#status#" = ccall((:H5Dget_type, libhdf5), Hid, (Hid,), dataset_id)
+    var"#status#" = ccall((:H5Dget_type, libhdf5), hid_t, (hid_t,), dataset_id)
     var"#status#" < 0 && error("Error getting dataspace type")
     return var"#status#"
 end
 
 function h5d_open(loc_id, pathname, dapl_id)
-    var"#status#" = ccall((:H5Dopen2, libhdf5), Hid, (Hid, Ptr{UInt8}, Hid), loc_id, pathname, dapl_id)
+    var"#status#" = ccall((:H5Dopen2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t), loc_id, pathname, dapl_id)
     var"#status#" < 0 && error("Error opening dataset ", h5i_get_name(loc_id), "/", pathname)
     return var"#status#"
 end
 
 function h5d_read(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf)
-    var"#status#" = ccall((:H5Dread, libhdf5), Herr, (Hid, Hid, Hid, Hid, Hid, Ptr{Cvoid}), dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf)
+    var"#status#" = ccall((:H5Dread, libhdf5), herr_t, (hid_t, hid_t, hid_t, hid_t, hid_t, Ptr{Cvoid}), dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf)
     var"#status#" < 0 && error("Error reading dataset ", h5i_get_name(dataset_id))
     return nothing
 end
 
 function h5d_refresh(dataset_id)
-    var"#status#" = ccall((:H5Drefresh, libhdf5), Herr, (Hid,), dataset_id)
+    var"#status#" = ccall((:H5Drefresh, libhdf5), herr_t, (hid_t,), dataset_id)
     var"#status#" < 0 && error("Error refreshing dataset")
     return nothing
 end
 
 function h5d_set_extent(dataset_id, new_dims)
-    var"#status#" = ccall((:H5Dset_extent, libhdf5), Herr, (Hid, Ptr{Hsize}), dataset_id, new_dims)
+    var"#status#" = ccall((:H5Dset_extent, libhdf5), herr_t, (hid_t, Ptr{hsize_t }), dataset_id, new_dims)
     var"#status#" < 0 && error("Error extending dataset dimensions")
     return nothing
 end
 
 function h5d_vlen_get_buf_size(dset_id, type_id, space_id, buf)
-    var"#status#" = ccall((:H5Dvlen_get_buf_size, libhdf5), Herr, (Hid, Hid, Hid, Ptr{Hsize}), dset_id, type_id, space_id, buf)
+    var"#status#" = ccall((:H5Dvlen_get_buf_size, libhdf5), herr_t, (hid_t, hid_t, hid_t, Ptr{hsize_t }), dset_id, type_id, space_id, buf)
     var"#status#" < 0 && error("Error getting vlen buffer size")
     return nothing
 end
 
 function h5d_vlen_reclaim(type_id, space_id, plist_id, buf)
-    var"#status#" = ccall((:H5Dvlen_reclaim, libhdf5), Herr, (Hid, Hid, Hid, Ptr{Cvoid}), type_id, space_id, plist_id, buf)
+    var"#status#" = ccall((:H5Dvlen_reclaim, libhdf5), herr_t, (hid_t, hid_t, hid_t, Ptr{Cvoid}), type_id, space_id, plist_id, buf)
     var"#status#" < 0 && error("Error reclaiming vlen buffer")
     return nothing
 end
 
 function h5d_write(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf)
-    var"#status#" = ccall((:H5Dwrite, libhdf5), Herr, (Hid, Hid, Hid, Hid, Hid, Ptr{Cvoid}), dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf)
+    var"#status#" = ccall((:H5Dwrite, libhdf5), herr_t, (hid_t, hid_t, hid_t, hid_t, hid_t, Ptr{Cvoid}), dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf)
     var"#status#" < 0 && error("Error writing dataset")
     return nothing
 end
 
 function h5e_get_auto(estack_id, func, client_data)
-    var"#status#" = ccall((:H5Eget_auto2, libhdf5), Herr, (Hid, Ref{Ptr{Cvoid}}, Ref{Ptr{Cvoid}}), estack_id, func, client_data)
+    var"#status#" = ccall((:H5Eget_auto2, libhdf5), herr_t, (hid_t, Ref{Ptr{Cvoid}}, Ref{Ptr{Cvoid}}), estack_id, func, client_data)
     var"#status#" < 0 && error("Error getting error reporting behavior")
     return nothing
 end
 
 function h5e_set_auto(estack_id, func, client_data)
-    var"#status#" = ccall((:H5Eset_auto2, libhdf5), Herr, (Hid, Ptr{Cvoid}, Ptr{Cvoid}), estack_id, func, client_data)
+    var"#status#" = ccall((:H5Eset_auto2, libhdf5), herr_t, (hid_t, Ptr{Cvoid}, Ptr{Cvoid}), estack_id, func, client_data)
     var"#status#" < 0 && error("Error setting error reporting behavior")
     return nothing
 end
 
 function h5f_close(file_id)
-    var"#status#" = ccall((:H5Fclose, libhdf5), Herr, (Hid,), file_id)
+    var"#status#" = ccall((:H5Fclose, libhdf5), herr_t, (hid_t,), file_id)
     var"#status#" < 0 && error("Error closing file")
     return nothing
 end
 
 function h5f_create(pathname, flags, fcpl_id, fapl_id)
-    var"#status#" = ccall((:H5Fcreate, libhdf5), Hid, (Ptr{UInt8}, Cuint, Hid, Hid), pathname, flags, fcpl_id, fapl_id)
+    var"#status#" = ccall((:H5Fcreate, libhdf5), hid_t, (Ptr{UInt8}, Cuint, hid_t, hid_t), pathname, flags, fcpl_id, fapl_id)
     var"#status#" < 0 && error("Error creating file ", pathname)
     return var"#status#"
 end
 
 function h5f_flush(object_id, scope)
-    var"#status#" = ccall((:H5Fflush, libhdf5), Herr, (Hid, Cint), object_id, scope)
+    var"#status#" = ccall((:H5Fflush, libhdf5), herr_t, (hid_t, Cint), object_id, scope)
     var"#status#" < 0 && error("Error flushing object to file")
     return nothing
 end
 
 function h5f_get_access_plist(file_id)
-    var"#status#" = ccall((:H5Fget_access_plist, libhdf5), Hid, (Hid,), file_id)
+    var"#status#" = ccall((:H5Fget_access_plist, libhdf5), hid_t, (hid_t,), file_id)
     var"#status#" < 0 && error("Error getting file access property list")
     return var"#status#"
 end
 
 function h5f_get_create_plist(file_id)
-    var"#status#" = ccall((:H5Fget_create_plist, libhdf5), Hid, (Hid,), file_id)
+    var"#status#" = ccall((:H5Fget_create_plist, libhdf5), hid_t, (hid_t,), file_id)
     var"#status#" < 0 && error("Error getting file create property list")
     return var"#status#"
 end
 
 function h5f_get_intent(file_id, intent)
-    var"#status#" = ccall((:H5Fget_intent, libhdf5), Herr, (Hid, Ptr{Cuint}), file_id, intent)
+    var"#status#" = ccall((:H5Fget_intent, libhdf5), herr_t, (hid_t, Ptr{Cuint}), file_id, intent)
     var"#status#" < 0 && error("Error getting file intent")
     return nothing
 end
 
 function h5f_get_name(obj_id, buf, buf_size)
-    var"#status#" = ccall((:H5Fget_name, libhdf5), Cssize_t, (Hid, Ptr{UInt8}, Csize_t), obj_id, buf, buf_size)
+    var"#status#" = ccall((:H5Fget_name, libhdf5), Cssize_t, (hid_t, Ptr{UInt8}, Csize_t), obj_id, buf, buf_size)
     var"#status#" < 0 && error("Error getting file name")
     return var"#status#"
 end
 
 function h5f_get_obj_count(file_id, types)
-    var"#status#" = ccall((:H5Fget_obj_count, libhdf5), Cssize_t, (Hid, Cuint), file_id, types)
+    var"#status#" = ccall((:H5Fget_obj_count, libhdf5), Cssize_t, (hid_t, Cuint), file_id, types)
     var"#status#" < 0 && error("Error getting object count")
     return var"#status#"
 end
 
 function h5f_get_obj_ids(file_id, types, max_objs, obj_id_list)
-    var"#status#" = ccall((:H5Fget_obj_ids, libhdf5), Cssize_t, (Hid, Cuint, Csize_t, Ptr{Hid}), file_id, types, max_objs, obj_id_list)
+    var"#status#" = ccall((:H5Fget_obj_ids, libhdf5), Cssize_t, (hid_t, Cuint, Csize_t, Ptr{hid_t}), file_id, types, max_objs, obj_id_list)
     var"#status#" < 0 && error("Error getting objects")
     return var"#status#"
 end
 
 function h5f_get_vfd_handle(file_id, fapl_id, file_handle)
-    var"#status#" = ccall((:H5Fget_vfd_handle, libhdf5), Herr, (Hid, Hid, Ptr{Ptr{Cint}}), file_id, fapl_id, file_handle)
+    var"#status#" = ccall((:H5Fget_vfd_handle, libhdf5), herr_t, (hid_t, hid_t, Ptr{Ptr{Cint}}), file_id, fapl_id, file_handle)
     var"#status#" < 0 && error("Error getting VFD handle")
     return nothing
 end
 
 function h5f_is_hdf5(pathname)
-    var"#status#" = ccall((:H5Fis_hdf5, libhdf5), Htri, (Cstring,), pathname)
+    var"#status#" = ccall((:H5Fis_hdf5, libhdf5), htri_t, (Cstring,), pathname)
     var"#status#" < 0 && error("Cannot access file ", pathname)
     return var"#status#" > 0
 end
 
 function h5f_open(pathname, flags, fapl_id)
-    var"#status#" = ccall((:H5Fopen, libhdf5), Hid, (Cstring, Cuint, Hid), pathname, flags, fapl_id)
+    var"#status#" = ccall((:H5Fopen, libhdf5), hid_t, (Cstring, Cuint, hid_t), pathname, flags, fapl_id)
     var"#status#" < 0 && error("Error opening file ", pathname)
     return var"#status#"
 end
 
 function h5f_start_swmr_write(id)
-    var"#status#" = ccall((:H5Fstart_swmr_write, libhdf5), Herr, (Hid,), id)
+    var"#status#" = ccall((:H5Fstart_swmr_write, libhdf5), herr_t, (hid_t,), id)
     var"#status#" < 0 && error("Error starting SWMR write")
     return nothing
 end
 
 function h5g_close(group_id)
-    var"#status#" = ccall((:H5Gclose, libhdf5), Herr, (Hid,), group_id)
+    var"#status#" = ccall((:H5Gclose, libhdf5), herr_t, (hid_t,), group_id)
     var"#status#" < 0 && error("Error closing group")
     return nothing
 end
 
 function h5g_create(loc_id, pathname, lcpl_id, gcpl_id, gapl_id)
-    var"#status#" = ccall((:H5Gcreate2, libhdf5), Hid, (Hid, Ptr{UInt8}, Hid, Hid, Hid), loc_id, pathname, lcpl_id, gcpl_id, gapl_id)
+    var"#status#" = ccall((:H5Gcreate2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t, hid_t, hid_t), loc_id, pathname, lcpl_id, gcpl_id, gapl_id)
     var"#status#" < 0 && error("Error creating group ", h5i_get_name(loc_id), "/", pathname)
     return var"#status#"
 end
 
 function h5g_get_create_plist(group_id)
-    var"#status#" = ccall((:H5Gget_create_plist, libhdf5), Hid, (Hid,), group_id)
+    var"#status#" = ccall((:H5Gget_create_plist, libhdf5), hid_t, (hid_t,), group_id)
     var"#status#" < 0 && error("Error getting group create property list")
     return var"#status#"
 end
 
 function h5g_get_info(group_id, buf)
-    var"#status#" = ccall((:H5Gget_info, libhdf5), Herr, (Hid, Ptr{H5Ginfo}), group_id, buf)
+    var"#status#" = ccall((:H5Gget_info, libhdf5), herr_t, (hid_t, Ptr{H5Ginfo}), group_id, buf)
     var"#status#" < 0 && error("Error getting group info")
     return nothing
 end
 
 function h5g_get_num_objs(loc_id, num_obj)
-    var"#status#" = ccall((:H5Gget_num_objs, libhdf5), Hid, (Hid, Ptr{Hsize}), loc_id, num_obj)
+    var"#status#" = ccall((:H5Gget_num_objs, libhdf5), hid_t, (hid_t, Ptr{hsize_t }), loc_id, num_obj)
     var"#status#" < 0 && error("Error getting group length")
     return var"#status#"
 end
 
 function h5g_get_objname_by_idx(loc_id, idx, pathname, size)
-    var"#status#" = ccall((:H5Gget_objname_by_idx, libhdf5), Cssize_t, (Hid, Hsize, Ptr{UInt8}, Csize_t), loc_id, idx, pathname, size)
+    var"#status#" = ccall((:H5Gget_objname_by_idx, libhdf5), Cssize_t, (hid_t, hsize_t , Ptr{UInt8}, Csize_t), loc_id, idx, pathname, size)
     var"#status#" < 0 && error("Error getting group object name ", h5i_get_name(loc_id), "/", pathname)
     return var"#status#"
 end
 
 function h5g_open(loc_id, pathname, gapl_id)
-    var"#status#" = ccall((:H5Gopen2, libhdf5), Hid, (Hid, Ptr{UInt8}, Hid), loc_id, pathname, gapl_id)
+    var"#status#" = ccall((:H5Gopen2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t), loc_id, pathname, gapl_id)
     var"#status#" < 0 && error("Error opening group ", h5i_get_name(loc_id), "/", pathname)
     return var"#status#"
 end
 
 function h5i_dec_ref(obj_id)
-    var"#status#" = ccall((:H5Idec_ref, libhdf5), Cint, (Hid,), obj_id)
+    var"#status#" = ccall((:H5Idec_ref, libhdf5), Cint, (hid_t,), obj_id)
     var"#status#" < 0 && error("Error decementing reference")
     return var"#status#"
 end
 
 function h5i_get_file_id(obj_id)
-    var"#status#" = ccall((:H5Iget_file_id, libhdf5), Hid, (Hid,), obj_id)
+    var"#status#" = ccall((:H5Iget_file_id, libhdf5), hid_t, (hid_t,), obj_id)
     var"#status#" < 0 && error("Error getting file identifier")
     return var"#status#"
 end
 
 function h5i_get_name(obj_id, buf, buf_size)
-    var"#status#" = ccall((:H5Iget_name, libhdf5), Cssize_t, (Hid, Ptr{UInt8}, Csize_t), obj_id, buf, buf_size)
+    var"#status#" = ccall((:H5Iget_name, libhdf5), Cssize_t, (hid_t, Ptr{UInt8}, Csize_t), obj_id, buf, buf_size)
     var"#status#" < 0 && error("Error getting object name")
     return var"#status#"
 end
 
 function h5i_get_ref(obj_id)
-    var"#status#" = ccall((:H5Iget_ref, libhdf5), Cint, (Hid,), obj_id)
+    var"#status#" = ccall((:H5Iget_ref, libhdf5), Cint, (hid_t,), obj_id)
     var"#status#" < 0 && error("Error getting reference count")
     return var"#status#"
 end
 
 function h5i_get_type(obj_id)
-    var"#status#" = ccall((:H5Iget_type, libhdf5), Cint, (Hid,), obj_id)
+    var"#status#" = ccall((:H5Iget_type, libhdf5), Cint, (hid_t,), obj_id)
     var"#status#" < 0 && error("Error getting type")
     return var"#status#"
 end
 
 function h5i_is_valid(obj_id)
-    var"#status#" = ccall((:H5Iis_valid, libhdf5), Htri, (Hid,), obj_id)
+    var"#status#" = ccall((:H5Iis_valid, libhdf5), htri_t, (hid_t,), obj_id)
     var"#status#" < 0 && error("Cannot determine whether object is valid")
     return var"#status#" > 0
 end
 
 function h5l_create_external(target_file_name, target_obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
-    var"#status#" = ccall((:H5Lcreate_external, libhdf5), Herr, (Ptr{UInt8}, Ptr{UInt8}, Hid, Ptr{UInt8}, Hid, Hid), target_file_name, target_obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
+    var"#status#" = ccall((:H5Lcreate_external, libhdf5), herr_t, (Ptr{UInt8}, Ptr{UInt8}, hid_t, Ptr{UInt8}, hid_t, hid_t), target_file_name, target_obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
     var"#status#" < 0 && error("Error creating external link ", link_name, " pointing to ", target_obj_name, " in file ", target_file_name)
     return nothing
 end
 
 function h5l_create_hard(obj_loc_id, obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
-    var"#status#" = ccall((:H5Lcreate_hard, libhdf5), Herr, (Hid, Ptr{UInt8}, Hid, Ptr{UInt8}, Hid, Hid), obj_loc_id, obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
+    var"#status#" = ccall((:H5Lcreate_hard, libhdf5), herr_t, (hid_t, Ptr{UInt8}, hid_t, Ptr{UInt8}, hid_t, hid_t), obj_loc_id, obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
     var"#status#" < 0 && error("Error creating hard link ", link_name, " pointing to ", obj_name)
     return nothing
 end
 
 function h5l_create_soft(target_path, link_loc_id, link_name, lcpl_id, lapl_id)
-    var"#status#" = ccall((:H5Lcreate_soft, libhdf5), Herr, (Ptr{UInt8}, Hid, Ptr{UInt8}, Hid, Hid), target_path, link_loc_id, link_name, lcpl_id, lapl_id)
+    var"#status#" = ccall((:H5Lcreate_soft, libhdf5), herr_t, (Ptr{UInt8}, hid_t, Ptr{UInt8}, hid_t, hid_t), target_path, link_loc_id, link_name, lcpl_id, lapl_id)
     var"#status#" < 0 && error("Error creating soft link ", link_name, " pointing to ", target_path)
     return nothing
 end
 
 function h5l_delete(obj_id, pathname, lapl_id)
-    var"#status#" = ccall((:H5Ldelete, libhdf5), Herr, (Hid, Ptr{UInt8}, Hid), obj_id, pathname, lapl_id)
+    var"#status#" = ccall((:H5Ldelete, libhdf5), herr_t, (hid_t, Ptr{UInt8}, hid_t), obj_id, pathname, lapl_id)
     var"#status#" < 0 && error("Error deleting ", h5i_get_name(obj_id), "/", pathname)
     return nothing
 end
 
 function h5l_exists(loc_id, pathname, lapl_id)
-    var"#status#" = ccall((:H5Lexists, libhdf5), Htri, (Hid, Ptr{UInt8}, Hid), loc_id, pathname, lapl_id)
+    var"#status#" = ccall((:H5Lexists, libhdf5), htri_t, (hid_t, Ptr{UInt8}, hid_t), loc_id, pathname, lapl_id)
     var"#status#" < 0 && error("Cannot determine whether ", pathname, " exists")
     return var"#status#" > 0
 end
 
 function h5l_get_info(link_loc_id, link_name, link_buf, lapl_id)
-    var"#status#" = ccall((:H5Lget_info, libhdf5), Herr, (Hid, Ptr{UInt8}, Ptr{H5LInfo}, Hid), link_loc_id, link_name, link_buf, lapl_id)
+    var"#status#" = ccall((:H5Lget_info, libhdf5), herr_t, (hid_t, Ptr{UInt8}, Ptr{H5LInfo}, hid_t), link_loc_id, link_name, link_buf, lapl_id)
     var"#status#" < 0 && error("Error getting info for link ", link_name)
     return nothing
 end
 
 function h5l_get_name_by_idx(loc_id, group_name, index_field, order, n, name, size, lapl_id)
-    var"#status#" = ccall((:H5Lget_name_by_idx, libhdf5), Cssize_t, (Hid, Ptr{UInt8}, Cint, Cint, Hsize, Ptr{UInt8}, Csize_t, Hid), loc_id, group_name, index_field, order, n, name, size, lapl_id)
+    var"#status#" = ccall((:H5Lget_name_by_idx, libhdf5), Cssize_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t , Ptr{UInt8}, Csize_t, hid_t), loc_id, group_name, index_field, order, n, name, size, lapl_id)
     var"#status#" < 0 && error("Error getting object name")
     return var"#status#"
 end
 
 function h5o_close(object_id)
-    var"#status#" = ccall((:H5Oclose, libhdf5), Herr, (Hid,), object_id)
+    var"#status#" = ccall((:H5Oclose, libhdf5), herr_t, (hid_t,), object_id)
     var"#status#" < 0 && error("Error closing object")
     return nothing
 end
 
 function h5o_copy(src_loc_id, src_name, dst_loc_id, dst_name, ocpypl_id, lcpl_id)
-    var"#status#" = ccall((:H5Ocopy, libhdf5), Herr, (Hid, Ptr{UInt8}, Hid, Ptr{UInt8}, Hid, Hid), src_loc_id, src_name, dst_loc_id, dst_name, ocpypl_id, lcpl_id)
+    var"#status#" = ccall((:H5Ocopy, libhdf5), herr_t, (hid_t, Ptr{UInt8}, hid_t, Ptr{UInt8}, hid_t, hid_t), src_loc_id, src_name, dst_loc_id, dst_name, ocpypl_id, lcpl_id)
     var"#status#" < 0 && error("Error copying object ", h5i_get_name(src_loc_id), "/", src_name, " to ", h5i_get_name(dst_loc_id), "/", dst_name)
     return nothing
 end
 
 function h5o_get_info(object_id, buf)
-    var"#status#" = ccall((:H5Oget_info1, libhdf5), Herr, (Hid, Ptr{H5Oinfo}), object_id, buf)
+    var"#status#" = ccall((:H5Oget_info1, libhdf5), herr_t, (hid_t, Ptr{H5Oinfo}), object_id, buf)
     var"#status#" < 0 && error("Error getting object info")
     return nothing
 end
 
 function h5o_open(loc_id, pathname, lapl_id)
-    var"#status#" = ccall((:H5Oopen, libhdf5), Hid, (Hid, Ptr{UInt8}, Hid), loc_id, pathname, lapl_id)
+    var"#status#" = ccall((:H5Oopen, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t), loc_id, pathname, lapl_id)
     var"#status#" < 0 && error("Error opening object ", h5i_get_name(loc_id), "/", pathname)
     return var"#status#"
 end
 
 function h5o_open_by_addr(loc_id, addr)
-    var"#status#" = ccall((:H5Oopen_by_addr, libhdf5), Hid, (Hid, Haddr), loc_id, addr)
+    var"#status#" = ccall((:H5Oopen_by_addr, libhdf5), hid_t, (hid_t, haddr_t), loc_id, addr)
     var"#status#" < 0 && error("Error opening object by address")
     return var"#status#"
 end
 
 function h5o_open_by_idx(loc_id, group_name, index_type, order, n, lapl_id)
-    var"#status#" = ccall((:H5Oopen_by_idx, libhdf5), Hid, (Hid, Ptr{UInt8}, Cint, Cint, Hsize, Hid), loc_id, group_name, index_type, order, n, lapl_id)
+    var"#status#" = ccall((:H5Oopen_by_idx, libhdf5), hid_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t , hid_t), loc_id, group_name, index_type, order, n, lapl_id)
     var"#status#" < 0 && error("Error opening object of index ", n)
     return var"#status#"
 end
 
 function h5p_close(id)
-    var"#status#" = ccall((:H5Pclose, libhdf5), Herr, (Hid,), id)
+    var"#status#" = ccall((:H5Pclose, libhdf5), herr_t, (hid_t,), id)
     var"#status#" < 0 && error("Error closing property list")
     return nothing
 end
 
 function h5p_create(cls_id)
-    var"#status#" = ccall((:H5Pcreate, libhdf5), Hid, (Hid,), cls_id)
+    var"#status#" = ccall((:H5Pcreate, libhdf5), hid_t, (hid_t,), cls_id)
     var"#status#" < 0 && error("Error creating property list")
     return var"#status#"
 end
 
 function h5p_get_alignment(plist_id, threshold, alignment)
-    var"#status#" = ccall((:H5Pget_alignment, libhdf5), Herr, (Hid, Ptr{Hsize}, Ptr{Hsize}), plist_id, threshold, alignment)
+    var"#status#" = ccall((:H5Pget_alignment, libhdf5), herr_t, (hid_t, Ptr{hsize_t }, Ptr{hsize_t }), plist_id, threshold, alignment)
     var"#status#" < 0 && error("Error getting alignment")
     return nothing
 end
 
 function h5p_get_alloc_time(plist_id, alloc_time)
-    var"#status#" = ccall((:H5Pget_alloc_time, libhdf5), Herr, (Hid, Ptr{Cint}), plist_id, alloc_time)
+    var"#status#" = ccall((:H5Pget_alloc_time, libhdf5), herr_t, (hid_t, Ptr{Cint}), plist_id, alloc_time)
     var"#status#" < 0 && error("Error getting allocation timing")
     return nothing
 end
 
 function h5p_get_chunk(plist_id, n_dims, dims)
-    var"#status#" = ccall((:H5Pget_chunk, libhdf5), Cint, (Hid, Cint, Ptr{Hsize}), plist_id, n_dims, dims)
+    var"#status#" = ccall((:H5Pget_chunk, libhdf5), Cint, (hid_t, Cint, Ptr{hsize_t }), plist_id, n_dims, dims)
     var"#status#" < 0 && error("Error getting chunk size")
     return var"#status#"
 end
 
 function h5p_get_driver(plist_id)
-    var"#status#" = ccall((:H5Pget_driver, libhdf5), Hid, (Hid,), plist_id)
+    var"#status#" = ccall((:H5Pget_driver, libhdf5), hid_t, (hid_t,), plist_id)
     var"#status#" < 0 && error("Error getting driver identifier")
     return var"#status#"
 end
 
 function h5p_get_driver_info(plist_id)
-    var"#status#" = ccall((:H5Pget_driver_info, libhdf5), Ptr{Cvoid}, (Hid,), plist_id)
+    var"#status#" = ccall((:H5Pget_driver_info, libhdf5), Ptr{Cvoid}, (hid_t,), plist_id)
     return var"#status#"
 end
 
 function h5p_get_dxpl_mpio(dxpl_id, xfer_mode)
-    var"#status#" = ccall((:H5Pget_dxpl_mpio, libhdf5), Herr, (Hid, Ptr{Cint}), dxpl_id, xfer_mode)
+    var"#status#" = ccall((:H5Pget_dxpl_mpio, libhdf5), herr_t, (hid_t, Ptr{Cint}), dxpl_id, xfer_mode)
     var"#status#" < 0 && error("Error getting MPIO transfer mode")
     return nothing
 end
 
 function h5p_get_fapl_mpio32(fapl_id, comm, info)
-    var"#status#" = ccall((:H5Pget_fapl_mpio, libhdf5), Herr, (Hid, Ptr{Hmpih32}, Ptr{Hmpih32}), fapl_id, comm, info)
+    var"#status#" = ccall((:H5Pget_fapl_mpio, libhdf5), herr_t, (hid_t, Ptr{Hmpih32}, Ptr{Hmpih32}), fapl_id, comm, info)
     var"#status#" < 0 && error("Error getting MPIO properties")
     return nothing
 end
 
 function h5p_get_fapl_mpio64(fapl_id, comm, info)
-    var"#status#" = ccall((:H5Pget_fapl_mpio, libhdf5), Herr, (Hid, Ptr{Hmpih64}, Ptr{Hmpih64}), fapl_id, comm, info)
+    var"#status#" = ccall((:H5Pget_fapl_mpio, libhdf5), herr_t, (hid_t, Ptr{Hmpih64}, Ptr{Hmpih64}), fapl_id, comm, info)
     var"#status#" < 0 && error("Error getting MPIO properties")
     return nothing
 end
 
 function h5p_get_fclose_degree(plist_id, fc_degree)
-    var"#status#" = ccall((:H5Pget_fclose_degree, libhdf5), Herr, (Hid, Ptr{Cint}), plist_id, fc_degree)
+    var"#status#" = ccall((:H5Pget_fclose_degree, libhdf5), herr_t, (hid_t, Ptr{Cint}), plist_id, fc_degree)
     var"#status#" < 0 && error("Error getting close degree")
     return nothing
 end
 
 function h5p_get_filter_by_id(plist_id, filter_id, flags, cd_nelmts, cd_values, namelen, name, filter_config)
-    var"#status#" = ccall((:H5Pget_filter_by_id2, libhdf5), Herr, (Hid, H5Z_filter_t, Ref{Cuint}, Ref{Csize_t}, Ptr{Cuint}, Csize_t, Ptr{UInt8}, Ptr{Cuint}), plist_id, filter_id, flags, cd_nelmts, cd_values, namelen, name, filter_config)
+    var"#status#" = ccall((:H5Pget_filter_by_id2, libhdf5), herr_t, (hid_t, H5Z_filter_t, Ref{Cuint}, Ref{Csize_t}, Ptr{Cuint}, Csize_t, Ptr{UInt8}, Ptr{Cuint}), plist_id, filter_id, flags, cd_nelmts, cd_values, namelen, name, filter_config)
     var"#status#" < 0 && error("Error getting filter ID")
     return nothing
 end
 
 function h5p_get_layout(plist_id)
-    var"#status#" = ccall((:H5Pget_layout, libhdf5), Cint, (Hid,), plist_id)
+    var"#status#" = ccall((:H5Pget_layout, libhdf5), Cint, (hid_t,), plist_id)
     var"#status#" < 0 && error("Error getting layout")
     return var"#status#"
 end
 
 function h5p_get_userblock(plist_id, len)
-    var"#status#" = ccall((:H5Pget_userblock, libhdf5), Herr, (Hid, Ptr{Hsize}), plist_id, len)
+    var"#status#" = ccall((:H5Pget_userblock, libhdf5), herr_t, (hid_t, Ptr{hsize_t }), plist_id, len)
     var"#status#" < 0 && error("Error getting userblock")
     return nothing
 end
 
 function h5p_modify_filter(plist_id, filter_id, flags, cd_nelmts, cd_values)
-    var"#status#" = ccall((:H5Pmodify_filter, libhdf5), Herr, (Hid, H5Z_filter_t, Cuint, Csize_t, Ptr{Cuint}), plist_id, filter_id, flags, cd_nelmts, cd_values)
+    var"#status#" = ccall((:H5Pmodify_filter, libhdf5), herr_t, (hid_t, H5Z_filter_t, Cuint, Csize_t, Ptr{Cuint}), plist_id, filter_id, flags, cd_nelmts, cd_values)
     var"#status#" < 0 && error("Error modifying filter")
     return nothing
 end
 
 function h5p_set_alignment(plist_id, threshold, alignment)
-    var"#status#" = ccall((:H5Pset_alignment, libhdf5), Herr, (Hid, Hsize, Hsize), plist_id, threshold, alignment)
+    var"#status#" = ccall((:H5Pset_alignment, libhdf5), herr_t, (hid_t, hsize_t , hsize_t ), plist_id, threshold, alignment)
     var"#status#" < 0 && error("Error setting alignment")
     return nothing
 end
 
 function h5p_set_alloc_time(plist_id, alloc_time)
-    var"#status#" = ccall((:H5Pset_alloc_time, libhdf5), Herr, (Hid, Cint), plist_id, alloc_time)
+    var"#status#" = ccall((:H5Pset_alloc_time, libhdf5), herr_t, (hid_t, Cint), plist_id, alloc_time)
     var"#status#" < 0 && error("Error setting allocation timing")
     return nothing
 end
 
 function h5p_set_char_encoding(plist_id, encoding)
-    var"#status#" = ccall((:H5Pset_char_encoding, libhdf5), Herr, (Hid, Cint), plist_id, encoding)
+    var"#status#" = ccall((:H5Pset_char_encoding, libhdf5), herr_t, (hid_t, Cint), plist_id, encoding)
     var"#status#" < 0 && error("Error setting char encoding")
     return nothing
 end
 
 function h5p_set_chunk(plist_id, ndims, dims)
-    var"#status#" = ccall((:H5Pset_chunk, libhdf5), Herr, (Hid, Cint, Ptr{Hsize}), plist_id, ndims, dims)
+    var"#status#" = ccall((:H5Pset_chunk, libhdf5), herr_t, (hid_t, Cint, Ptr{hsize_t }), plist_id, ndims, dims)
     var"#status#" < 0 && error("Error setting chunk size")
     return nothing
 end
 
 function h5p_set_chunk_cache(dapl_id, rdcc_nslots, rdcc_nbytes, rdcc_w0)
-    var"#status#" = ccall((:H5Pset_chunk_cache, libhdf5), Herr, (Hid, Csize_t, Csize_t, Cdouble), dapl_id, rdcc_nslots, rdcc_nbytes, rdcc_w0)
+    var"#status#" = ccall((:H5Pset_chunk_cache, libhdf5), herr_t, (hid_t, Csize_t, Csize_t, Cdouble), dapl_id, rdcc_nslots, rdcc_nbytes, rdcc_w0)
     var"#status#" < 0 && error("Error setting chunk cache")
     return nothing
 end
 
 function h5p_set_create_intermediate_group(plist_id, setting)
-    var"#status#" = ccall((:H5Pset_create_intermediate_group, libhdf5), Herr, (Hid, Cuint), plist_id, setting)
+    var"#status#" = ccall((:H5Pset_create_intermediate_group, libhdf5), herr_t, (hid_t, Cuint), plist_id, setting)
     var"#status#" < 0 && error("Error setting create intermediate group")
     return nothing
 end
 
 function h5p_set_deflate(plist_id, setting)
-    var"#status#" = ccall((:H5Pset_deflate, libhdf5), Herr, (Hid, Cuint), plist_id, setting)
+    var"#status#" = ccall((:H5Pset_deflate, libhdf5), herr_t, (hid_t, Cuint), plist_id, setting)
     var"#status#" < 0 && error("Error setting compression method and level (deflate)")
     return nothing
 end
 
 function h5p_set_dxpl_mpio(dxpl_id, xfer_mode)
-    var"#status#" = ccall((:H5Pset_dxpl_mpio, libhdf5), Herr, (Hid, Cint), dxpl_id, xfer_mode)
+    var"#status#" = ccall((:H5Pset_dxpl_mpio, libhdf5), herr_t, (hid_t, Cint), dxpl_id, xfer_mode)
     var"#status#" < 0 && error("Error setting MPIO transfer mode")
     return nothing
 end
 
 function h5p_set_external(plist_id, name, offset, size)
-    var"#status#" = ccall((:H5Pset_external, libhdf5), Herr, (Hid, Ptr{UInt8}, Int, Csize_t), plist_id, name, offset, size)
+    var"#status#" = ccall((:H5Pset_external, libhdf5), herr_t, (hid_t, Ptr{UInt8}, Int, Csize_t), plist_id, name, offset, size)
     var"#status#" < 0 && error("Error setting external property")
     return nothing
 end
 
 function h5p_set_fapl_mpio32(fapl_id, comm, info)
-    var"#status#" = ccall((:H5Pset_fapl_mpio, libhdf5), Herr, (Hid, Hmpih32, Hmpih32), fapl_id, comm, info)
+    var"#status#" = ccall((:H5Pset_fapl_mpio, libhdf5), herr_t, (hid_t, Hmpih32, Hmpih32), fapl_id, comm, info)
     var"#status#" < 0 && error("Error setting MPIO properties")
     return nothing
 end
 
 function h5p_set_fapl_mpio64(fapl_id, comm, info)
-    var"#status#" = ccall((:H5Pset_fapl_mpio, libhdf5), Herr, (Hid, Hmpih64, Hmpih64), fapl_id, comm, info)
+    var"#status#" = ccall((:H5Pset_fapl_mpio, libhdf5), herr_t, (hid_t, Hmpih64, Hmpih64), fapl_id, comm, info)
     var"#status#" < 0 && error("Error setting MPIO properties")
     return nothing
 end
 
 function h5p_set_fclose_degree(plist_id, fc_degree)
-    var"#status#" = ccall((:H5Pset_fclose_degree, libhdf5), Herr, (Hid, Cint), plist_id, fc_degree)
+    var"#status#" = ccall((:H5Pset_fclose_degree, libhdf5), herr_t, (hid_t, Cint), plist_id, fc_degree)
     var"#status#" < 0 && error("Error setting close degree")
     return nothing
 end
 
 function h5p_set_filter(plist_id, filter_id, flags, cd_nelmts, cd_values)
-    var"#status#" = ccall((:H5Pset_filter, libhdf5), Herr, (Hid, H5Z_filter_t, Cuint, Csize_t, Ptr{Cuint}), plist_id, filter_id, flags, cd_nelmts, cd_values)
+    var"#status#" = ccall((:H5Pset_filter, libhdf5), herr_t, (hid_t, H5Z_filter_t, Cuint, Csize_t, Ptr{Cuint}), plist_id, filter_id, flags, cd_nelmts, cd_values)
     var"#status#" < 0 && error("Error setting filter")
     return nothing
 end
 
 function h5p_set_layout(plist_id, setting)
-    var"#status#" = ccall((:H5Pset_layout, libhdf5), Herr, (Hid, Cint), plist_id, setting)
+    var"#status#" = ccall((:H5Pset_layout, libhdf5), herr_t, (hid_t, Cint), plist_id, setting)
     var"#status#" < 0 && error("Error setting layout")
     return nothing
 end
 
 function h5p_set_libver_bounds(fapl_id, libver_low, libver_high)
-    var"#status#" = ccall((:H5Pset_libver_bounds, libhdf5), Herr, (Hid, Cint, Cint), fapl_id, libver_low, libver_high)
+    var"#status#" = ccall((:H5Pset_libver_bounds, libhdf5), herr_t, (hid_t, Cint, Cint), fapl_id, libver_low, libver_high)
     var"#status#" < 0 && error("Error setting library version bounds")
     return nothing
 end
 
 function h5p_set_local_heap_size_hint(fapl_id, size_hint)
-    var"#status#" = ccall((:H5Pset_local_heap_size_hint, libhdf5), Herr, (Hid, Cuint), fapl_id, size_hint)
+    var"#status#" = ccall((:H5Pset_local_heap_size_hint, libhdf5), herr_t, (hid_t, Cuint), fapl_id, size_hint)
     var"#status#" < 0 && error("Error setting local heap size hint")
     return nothing
 end
 
 function h5p_set_obj_track_times(plist_id, track_times)
-    var"#status#" = ccall((:H5Pset_obj_track_times, libhdf5), Herr, (Hid, UInt8), plist_id, track_times)
+    var"#status#" = ccall((:H5Pset_obj_track_times, libhdf5), herr_t, (hid_t, UInt8), plist_id, track_times)
     var"#status#" < 0 && error("Error setting object time tracking")
     return nothing
 end
 
 function h5p_set_shuffle(plist_id)
-    var"#status#" = ccall((:H5Pset_shuffle, libhdf5), Herr, (Hid,), plist_id)
+    var"#status#" = ccall((:H5Pset_shuffle, libhdf5), herr_t, (hid_t,), plist_id)
     var"#status#" < 0 && error("Error enabling shuffle filter")
     return nothing
 end
 
 function h5p_set_userblock(plist_id, len)
-    var"#status#" = ccall((:H5Pset_userblock, libhdf5), Herr, (Hid, Hsize), plist_id, len)
+    var"#status#" = ccall((:H5Pset_userblock, libhdf5), herr_t, (hid_t, hsize_t ), plist_id, len)
     var"#status#" < 0 && error("Error setting userblock")
     return nothing
 end
 
 function h5p_set_virtual(dcpl_id, vspace_id, src_file_name, src_dset_name, src_space_id)
-    var"#status#" = ccall((:H5Pset_virtual, libhdf5), Herr, (Hid, Hid, Ptr{UInt8}, Ptr{UInt8}, Hid), dcpl_id, vspace_id, src_file_name, src_dset_name, src_space_id)
+    var"#status#" = ccall((:H5Pset_virtual, libhdf5), herr_t, (hid_t, hid_t, Ptr{UInt8}, Ptr{UInt8}, hid_t), dcpl_id, vspace_id, src_file_name, src_dset_name, src_space_id)
     var"#status#" < 0 && error("Error setting virtual")
     return nothing
 end
 
 function h5r_create(ref, loc_id, pathname, ref_type, space_id)
-    var"#status#" = ccall((:H5Rcreate, libhdf5), Herr, (Ptr{HDF5ReferenceObj}, Hid, Ptr{UInt8}, Cint, Hid), ref, loc_id, pathname, ref_type, space_id)
+    var"#status#" = ccall((:H5Rcreate, libhdf5), herr_t, (Ptr{HDF5ReferenceObj}, hid_t, Ptr{UInt8}, Cint, hid_t), ref, loc_id, pathname, ref_type, space_id)
     var"#status#" < 0 && error("Error creating reference to object ", hi5_get_name(loc_id), "/", pathname)
     return nothing
 end
 
 function h5r_dereference(obj_id, ref_type, ref)
-    var"#status#" = ccall((:H5Rdereference1, libhdf5), Hid, (Hid, Cint, Ref{HDF5ReferenceObj}), obj_id, ref_type, ref)
+    var"#status#" = ccall((:H5Rdereference1, libhdf5), hid_t, (hid_t, Cint, Ref{HDF5ReferenceObj}), obj_id, ref_type, ref)
     var"#status#" < 0 && error("Error dereferencing object")
     return var"#status#"
 end
 
 function h5r_get_obj_type(loc_id, ref_type, ref, obj_type)
-    var"#status#" = ccall((:H5Rget_obj_type2, libhdf5), Herr, (Hid, Cint, Ptr{Cvoid}, Ptr{Cint}), loc_id, ref_type, ref, obj_type)
+    var"#status#" = ccall((:H5Rget_obj_type2, libhdf5), herr_t, (hid_t, Cint, Ptr{Cvoid}, Ptr{Cint}), loc_id, ref_type, ref, obj_type)
     var"#status#" < 0 && error("Error getting object type")
     return nothing
 end
 
 function h5r_get_region(loc_id, ref_type, ref)
-    var"#status#" = ccall((:H5Rget_region, libhdf5), Hid, (Hid, Cint, Ptr{Cvoid}), loc_id, ref_type, ref)
+    var"#status#" = ccall((:H5Rget_region, libhdf5), hid_t, (hid_t, Cint, Ptr{Cvoid}), loc_id, ref_type, ref)
     var"#status#" < 0 && error("Error getting region from reference")
     return var"#status#"
 end
 
 function h5s_close(space_id)
-    var"#status#" = ccall((:H5Sclose, libhdf5), Herr, (Hid,), space_id)
+    var"#status#" = ccall((:H5Sclose, libhdf5), herr_t, (hid_t,), space_id)
     var"#status#" < 0 && error("Error closing dataspace")
     return nothing
 end
 
 function h5s_copy(space_id)
-    var"#status#" = ccall((:H5Scopy, libhdf5), Hid, (Hid,), space_id)
+    var"#status#" = ccall((:H5Scopy, libhdf5), hid_t, (hid_t,), space_id)
     var"#status#" < 0 && error("Error copying dataspace")
     return var"#status#"
 end
 
 function h5s_create(class)
-    var"#status#" = ccall((:H5Screate, libhdf5), Hid, (Cint,), class)
+    var"#status#" = ccall((:H5Screate, libhdf5), hid_t, (Cint,), class)
     var"#status#" < 0 && error("Error creating dataspace")
     return var"#status#"
 end
 
 function h5s_create_simple(rank, current_dims, maximum_dims)
-    var"#status#" = ccall((:H5Screate_simple, libhdf5), Hid, (Cint, Ptr{Hsize}, Ptr{Hsize}), rank, current_dims, maximum_dims)
+    var"#status#" = ccall((:H5Screate_simple, libhdf5), hid_t, (Cint, Ptr{hsize_t }, Ptr{hsize_t }), rank, current_dims, maximum_dims)
     var"#status#" < 0 && error("Error creating simple dataspace")
     return var"#status#"
 end
 
 function h5s_get_simple_extent_dims(space_id, dims, maxdims)
-    var"#status#" = ccall((:H5Sget_simple_extent_dims, libhdf5), Cint, (Hid, Ptr{Hsize}, Ptr{Hsize}), space_id, dims, maxdims)
+    var"#status#" = ccall((:H5Sget_simple_extent_dims, libhdf5), Cint, (hid_t, Ptr{hsize_t }, Ptr{hsize_t }), space_id, dims, maxdims)
     var"#status#" < 0 && error("Error getting the dimensions for a dataspace")
     return var"#status#"
 end
 
 function h5s_get_simple_extent_ndims(space_id)
-    var"#status#" = ccall((:H5Sget_simple_extent_ndims, libhdf5), Cint, (Hid,), space_id)
+    var"#status#" = ccall((:H5Sget_simple_extent_ndims, libhdf5), Cint, (hid_t,), space_id)
     var"#status#" < 0 && error("Error getting the number of dimensions for a dataspace")
     return var"#status#"
 end
 
 function h5s_get_simple_extent_type(space_id)
-    var"#status#" = ccall((:H5Sget_simple_extent_type, libhdf5), Cint, (Hid,), space_id)
+    var"#status#" = ccall((:H5Sget_simple_extent_type, libhdf5), Cint, (hid_t,), space_id)
     var"#status#" < 0 && error("Error getting the dataspace type")
     return var"#status#"
 end
 
 function h5s_is_simple(space_id)
-    var"#status#" = ccall((:H5Sis_simple, libhdf5), Htri, (Hid,), space_id)
+    var"#status#" = ccall((:H5Sis_simple, libhdf5), htri_t, (hid_t,), space_id)
     var"#status#" < 0 && error("Error determining whether dataspace is simple")
     return var"#status#" > 0
 end
 
 function h5s_select_hyperslab(dspace_id, seloper, start, stride, count, block)
-    var"#status#" = ccall((:H5Sselect_hyperslab, libhdf5), Herr, (Hid, Cint, Ptr{Hsize}, Ptr{Hsize}, Ptr{Hsize}, Ptr{Hsize}), dspace_id, seloper, start, stride, count, block)
+    var"#status#" = ccall((:H5Sselect_hyperslab, libhdf5), herr_t, (hid_t, Cint, Ptr{hsize_t }, Ptr{hsize_t }, Ptr{hsize_t }, Ptr{hsize_t }), dspace_id, seloper, start, stride, count, block)
     var"#status#" < 0 && error("Error selecting hyperslab")
     return nothing
 end
 
 function h5t_array_create(basetype_id, ndims, sz)
-    var"#status#" = ccall((:H5Tarray_create2, libhdf5), Hid, (Hid, Cuint, Ptr{Hsize}), basetype_id, ndims, sz)
+    var"#status#" = ccall((:H5Tarray_create2, libhdf5), hid_t, (hid_t, Cuint, Ptr{hsize_t }), basetype_id, ndims, sz)
     var"#status#" < 0 && error("Error creating H5T_ARRAY of id ", basetype_id, " and size ", sz)
     return var"#status#"
 end
 
 function h5t_close(dtype_id)
-    var"#status#" = ccall((:H5Tclose, libhdf5), Herr, (Hid,), dtype_id)
+    var"#status#" = ccall((:H5Tclose, libhdf5), herr_t, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error closing datatype")
     return nothing
 end
 
 function h5t_committed(dtype_id)
-    var"#status#" = ccall((:H5Tcommitted, libhdf5), Htri, (Hid,), dtype_id)
+    var"#status#" = ccall((:H5Tcommitted, libhdf5), htri_t, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error determining whether datatype is committed")
     return var"#status#" > 0
 end
 
 function h5t_commit(loc_id, name, dtype_id, lcpl_id, tcpl_id, tapl_id)
-    var"#status#" = ccall((:H5Tcommit2, libhdf5), Herr, (Hid, Ptr{UInt8}, Hid, Hid, Hid, Hid), loc_id, name, dtype_id, lcpl_id, tcpl_id, tapl_id)
+    var"#status#" = ccall((:H5Tcommit2, libhdf5), herr_t, (hid_t, Ptr{UInt8}, hid_t, hid_t, hid_t, hid_t), loc_id, name, dtype_id, lcpl_id, tcpl_id, tapl_id)
     var"#status#" < 0 && error("Error committing type")
     return nothing
 end
 
 function h5t_copy(dtype_id)
-    var"#status#" = ccall((:H5Tcopy, libhdf5), Hid, (Hid,), dtype_id)
+    var"#status#" = ccall((:H5Tcopy, libhdf5), hid_t, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error copying datatype")
     return var"#status#"
 end
 
 function h5t_create(class_id, sz)
-    var"#status#" = ccall((:H5Tcreate, libhdf5), Hid, (Cint, Csize_t), class_id, sz)
+    var"#status#" = ccall((:H5Tcreate, libhdf5), hid_t, (Cint, Csize_t), class_id, sz)
     var"#status#" < 0 && error("Error creating datatype of id ", class_id)
     return var"#status#"
 end
 
 function h5t_equal(dtype_id1, dtype_id2)
-    var"#status#" = ccall((:H5Tequal, libhdf5), Hid, (Hid, Hid), dtype_id1, dtype_id2)
+    var"#status#" = ccall((:H5Tequal, libhdf5), hid_t, (hid_t, hid_t), dtype_id1, dtype_id2)
     var"#status#" < 0 && error("Error checking datatype equality")
     return var"#status#"
 end
 
 function h5t_get_array_dims(dtype_id, dims)
-    var"#status#" = ccall((:H5Tget_array_dims2, libhdf5), Cint, (Hid, Ptr{Hsize}), dtype_id, dims)
+    var"#status#" = ccall((:H5Tget_array_dims2, libhdf5), Cint, (hid_t, Ptr{hsize_t }), dtype_id, dims)
     var"#status#" < 0 && error("Error getting dimensions of array")
     return var"#status#"
 end
 
 function h5t_get_array_ndims(dtype_id)
-    var"#status#" = ccall((:H5Tget_array_ndims, libhdf5), Cint, (Hid,), dtype_id)
+    var"#status#" = ccall((:H5Tget_array_ndims, libhdf5), Cint, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting ndims of array")
     return var"#status#"
 end
 
 function h5t_get_class(dtype_id)
-    var"#status#" = ccall((:H5Tget_class, libhdf5), Cint, (Hid,), dtype_id)
+    var"#status#" = ccall((:H5Tget_class, libhdf5), Cint, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting class")
     return var"#status#"
 end
 
 function h5t_get_cset(dtype_id)
-    var"#status#" = ccall((:H5Tget_cset, libhdf5), Cint, (Hid,), dtype_id)
+    var"#status#" = ccall((:H5Tget_cset, libhdf5), Cint, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting character set encoding")
     return var"#status#"
 end
 
 function h5t_get_member_class(dtype_id, index)
-    var"#status#" = ccall((:H5Tget_member_class, libhdf5), Cint, (Hid, Cuint), dtype_id, index)
+    var"#status#" = ccall((:H5Tget_member_class, libhdf5), Cint, (hid_t, Cuint), dtype_id, index)
     var"#status#" < 0 && error("Error getting class of compound datatype member #", index)
     return var"#status#"
 end
 
 function h5t_get_member_index(dtype_id, membername)
-    var"#status#" = ccall((:H5Tget_member_index, libhdf5), Cint, (Hid, Ptr{UInt8}), dtype_id, membername)
+    var"#status#" = ccall((:H5Tget_member_index, libhdf5), Cint, (hid_t, Ptr{UInt8}), dtype_id, membername)
     var"#status#" < 0 && error("Error getting index of compound datatype member \"", membername, "\"")
     return var"#status#"
 end
 
 function h5t_get_member_offset(dtype_id, index)
-    var"#status#" = ccall((:H5Tget_member_offset, libhdf5), Csize_t, (Hid, Cuint), dtype_id, index)
+    var"#status#" = ccall((:H5Tget_member_offset, libhdf5), Csize_t, (hid_t, Cuint), dtype_id, index)
     return var"#status#"
 end
 
 function h5t_get_member_type(dtype_id, index)
-    var"#status#" = ccall((:H5Tget_member_type, libhdf5), Hid, (Hid, Cuint), dtype_id, index)
+    var"#status#" = ccall((:H5Tget_member_type, libhdf5), hid_t, (hid_t, Cuint), dtype_id, index)
     var"#status#" < 0 && error("Error getting type of compound datatype member #", index)
     return var"#status#"
 end
 
 function h5t_get_native_type(dtype_id, direction)
-    var"#status#" = ccall((:H5Tget_native_type, libhdf5), Hid, (Hid, Cint), dtype_id, direction)
+    var"#status#" = ccall((:H5Tget_native_type, libhdf5), hid_t, (hid_t, Cint), dtype_id, direction)
     var"#status#" < 0 && error("Error getting native type")
     return var"#status#"
 end
 
 function h5t_get_nmembers(dtype_id)
-    var"#status#" = ccall((:H5Tget_nmembers, libhdf5), Cint, (Hid,), dtype_id)
+    var"#status#" = ccall((:H5Tget_nmembers, libhdf5), Cint, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting the number of members")
     return var"#status#"
 end
 
 function h5t_get_sign(dtype_id)
-    var"#status#" = ccall((:H5Tget_sign, libhdf5), Cint, (Hid,), dtype_id)
+    var"#status#" = ccall((:H5Tget_sign, libhdf5), Cint, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting sign")
     return var"#status#"
 end
 
 function h5t_get_size(dtype_id)
-    var"#status#" = ccall((:H5Tget_size, libhdf5), Csize_t, (Hid,), dtype_id)
+    var"#status#" = ccall((:H5Tget_size, libhdf5), Csize_t, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting size")
     return var"#status#"
 end
 
 function h5t_get_strpad(dtype_id)
-    var"#status#" = ccall((:H5Tget_strpad, libhdf5), Cint, (Hid,), dtype_id)
+    var"#status#" = ccall((:H5Tget_strpad, libhdf5), Cint, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting string padding")
     return var"#status#"
 end
 
 function h5t_get_super(dtype_id)
-    var"#status#" = ccall((:H5Tget_super, libhdf5), Hid, (Hid,), dtype_id)
+    var"#status#" = ccall((:H5Tget_super, libhdf5), hid_t, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting super type")
     return var"#status#"
 end
 
 function h5t_insert(dtype_id, fieldname, offset, field_id)
-    var"#status#" = ccall((:H5Tinsert, libhdf5), Herr, (Hid, Ptr{UInt8}, Csize_t, Hid), dtype_id, fieldname, offset, field_id)
+    var"#status#" = ccall((:H5Tinsert, libhdf5), herr_t, (hid_t, Ptr{UInt8}, Csize_t, hid_t), dtype_id, fieldname, offset, field_id)
     var"#status#" < 0 && error("Error adding field ", fieldname, " to compound datatype")
     return nothing
 end
 
 function h5t_is_variable_str(type_id)
-    var"#status#" = ccall((:H5Tis_variable_str, libhdf5), Htri, (Hid,), type_id)
+    var"#status#" = ccall((:H5Tis_variable_str, libhdf5), htri_t, (hid_t,), type_id)
     var"#status#" < 0 && error("Error determining whether string is of variable length")
     return var"#status#" > 0
 end
 
 function h5t_open(loc_id, name, tapl_id)
-    var"#status#" = ccall((:H5Topen2, libhdf5), Hid, (Hid, Ptr{UInt8}, Hid), loc_id, name, tapl_id)
+    var"#status#" = ccall((:H5Topen2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t), loc_id, name, tapl_id)
     var"#status#" < 0 && error("Error opening type ", h5i_get_name(loc_id), "/", name)
     return var"#status#"
 end
 
 function h5t_set_cset(dtype_id, cset)
-    var"#status#" = ccall((:H5Tset_cset, libhdf5), Herr, (Hid, Cint), dtype_id, cset)
+    var"#status#" = ccall((:H5Tset_cset, libhdf5), herr_t, (hid_t, Cint), dtype_id, cset)
     var"#status#" < 0 && error("Error setting character set in datatype")
     return nothing
 end
 
 function h5t_set_precision(dtype_id, sz)
-    var"#status#" = ccall((:H5Tset_precision, libhdf5), Herr, (Hid, Csize_t), dtype_id, sz)
+    var"#status#" = ccall((:H5Tset_precision, libhdf5), herr_t, (hid_t, Csize_t), dtype_id, sz)
     var"#status#" < 0 && error("Error setting precision of datatype")
     return nothing
 end
 
 function h5t_set_size(dtype_id, sz)
-    var"#status#" = ccall((:H5Tset_size, libhdf5), Herr, (Hid, Csize_t), dtype_id, sz)
+    var"#status#" = ccall((:H5Tset_size, libhdf5), herr_t, (hid_t, Csize_t), dtype_id, sz)
     var"#status#" < 0 && error("Error setting size of datatype")
     return nothing
 end
 
 function h5t_set_strpad(dtype_id, sz)
-    var"#status#" = ccall((:H5Tset_strpad, libhdf5), Herr, (Hid, Cint), dtype_id, sz)
+    var"#status#" = ccall((:H5Tset_strpad, libhdf5), herr_t, (hid_t, Cint), dtype_id, sz)
     var"#status#" < 0 && error("Error setting size of datatype")
     return nothing
 end
 
 function h5t_vlen_create(base_type_id)
-    var"#status#" = ccall((:H5Tvlen_create, libhdf5), Hid, (Hid,), base_type_id)
+    var"#status#" = ccall((:H5Tvlen_create, libhdf5), hid_t, (hid_t,), base_type_id)
     var"#status#" < 0 && error("Error creating vlen type")
     return var"#status#"
 end
 
 function h5do_append(dset_id, dxpl_id, index, num_elem, memtype, buffer)
-    var"#status#" = ccall((:H5DOappend, libhdf5_hl), Herr, (Hid, Hid, Cuint, Hsize, Hid, Ptr{Cvoid}), dset_id, dxpl_id, index, num_elem, memtype, buffer)
+    var"#status#" = ccall((:H5DOappend, libhdf5_hl), herr_t, (hid_t, hid_t, Cuint, hsize_t , hid_t, Ptr{Cvoid}), dset_id, dxpl_id, index, num_elem, memtype, buffer)
     var"#status#" < 0 && error("error appending")
     return nothing
 end
 
 function h5do_write_chunk(dset_id, dxpl_id, filter_mask, offset, bufsize, buf)
-    var"#status#" = ccall((:H5DOwrite_chunk, libhdf5_hl), Herr, (Hid, Hid, Int32, Ptr{Hsize}, Csize_t, Ptr{Cvoid}), dset_id, dxpl_id, filter_mask, offset, bufsize, buf)
+    var"#status#" = ccall((:H5DOwrite_chunk, libhdf5_hl), herr_t, (hid_t, hid_t, Int32, Ptr{hsize_t }, Csize_t, Ptr{Cvoid}), dset_id, dxpl_id, filter_mask, offset, bufsize, buf)
     var"#status#" < 0 && error("Error writing chunk")
     return nothing
 end
 
 function h5lt_dtype_to_text(datatype, str, lang_type, len)
-    var"#status#" = ccall((:H5LTdtype_to_text, libhdf5_hl), Herr, (Hid, Ptr{UInt8}, Cint, Ref{Csize_t}), datatype, str, lang_type, len)
+    var"#status#" = ccall((:H5LTdtype_to_text, libhdf5_hl), herr_t, (hid_t, Ptr{UInt8}, Cint, Ref{Csize_t}), datatype, str, lang_type, len)
     var"#status#" < 0 && error("Error getting datatype text representation")
     return nothing
 end
 
 function h5tb_get_field_info(loc_id, table_name, field_names, field_sizes, field_offsets, type_size)
-    var"#status#" = ccall((:H5TBget_field_info, libhdf5_hl), Herr, (Hid, Ptr{UInt8}, Ptr{Ptr{UInt8}}, Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}), loc_id, table_name, field_names, field_sizes, field_offsets, type_size)
+    var"#status#" = ccall((:H5TBget_field_info, libhdf5_hl), herr_t, (hid_t, Ptr{UInt8}, Ptr{Ptr{UInt8}}, Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}), loc_id, table_name, field_names, field_sizes, field_offsets, type_size)
     var"#status#" < 0 && error("Error getting field information")
     return nothing
 end
 
 function h5z_register(filter_class)
-    var"#status#" = ccall((:H5Zregister, libhdf5), Herr, (Ref{H5Z_class_t},), filter_class)
+    var"#status#" = ccall((:H5Zregister, libhdf5), herr_t, (Ref{H5Z_class_t},), filter_class)
     var"#status#" < 0 && error("Unable to register new filter")
     return nothing
 end
-

--- a/src/api.jl
+++ b/src/api.jl
@@ -70,7 +70,7 @@ function h5a_delete(loc_id, attr_name)
 end
 
 function h5a_delete_by_idx(loc_id, obj_name, idx_type, order, n, lapl_id)
-    var"#status#" = ccall((:H5Adelete_by_idx, libhdf5), herr_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t , hid_t), loc_id, obj_name, idx_type, order, n, lapl_id)
+    var"#status#" = ccall((:H5Adelete_by_idx, libhdf5), herr_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t, hid_t), loc_id, obj_name, idx_type, order, n, lapl_id)
     var"#status#" < 0 && error("Error deleting attribute ", n, " from object ", obj_name)
     return nothing
 end
@@ -106,7 +106,7 @@ function h5a_get_name(attr_id, buf_size, buf)
 end
 
 function h5a_get_name_by_idx(loc_id, obj_name, index_type, order, idx, name, size, lapl_id)
-    var"#status#" = ccall((:H5Aget_name_by_idx, libhdf5), Cssize_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t , Ptr{UInt8}, Csize_t, hid_t), loc_id, obj_name, index_type, order, idx, name, size, lapl_id)
+    var"#status#" = ccall((:H5Aget_name_by_idx, libhdf5), Cssize_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t, Ptr{UInt8}, Csize_t, hid_t), loc_id, obj_name, index_type, order, idx, name, size, lapl_id)
     var"#status#" < 0 && error("Error getting attribute name")
     return var"#status#"
 end
@@ -208,13 +208,13 @@ function h5d_refresh(dataset_id)
 end
 
 function h5d_set_extent(dataset_id, new_dims)
-    var"#status#" = ccall((:H5Dset_extent, libhdf5), herr_t, (hid_t, Ptr{hsize_t }), dataset_id, new_dims)
+    var"#status#" = ccall((:H5Dset_extent, libhdf5), herr_t, (hid_t, Ptr{hsize_t}), dataset_id, new_dims)
     var"#status#" < 0 && error("Error extending dataset dimensions")
     return nothing
 end
 
 function h5d_vlen_get_buf_size(dset_id, type_id, space_id, buf)
-    var"#status#" = ccall((:H5Dvlen_get_buf_size, libhdf5), herr_t, (hid_t, hid_t, hid_t, Ptr{hsize_t }), dset_id, type_id, space_id, buf)
+    var"#status#" = ccall((:H5Dvlen_get_buf_size, libhdf5), herr_t, (hid_t, hid_t, hid_t, Ptr{hsize_t}), dset_id, type_id, space_id, buf)
     var"#status#" < 0 && error("Error getting vlen buffer size")
     return nothing
 end
@@ -346,13 +346,13 @@ function h5g_get_info(group_id, buf)
 end
 
 function h5g_get_num_objs(loc_id, num_obj)
-    var"#status#" = ccall((:H5Gget_num_objs, libhdf5), hid_t, (hid_t, Ptr{hsize_t }), loc_id, num_obj)
+    var"#status#" = ccall((:H5Gget_num_objs, libhdf5), hid_t, (hid_t, Ptr{hsize_t}), loc_id, num_obj)
     var"#status#" < 0 && error("Error getting group length")
     return var"#status#"
 end
 
 function h5g_get_objname_by_idx(loc_id, idx, pathname, size)
-    var"#status#" = ccall((:H5Gget_objname_by_idx, libhdf5), Cssize_t, (hid_t, hsize_t , Ptr{UInt8}, Csize_t), loc_id, idx, pathname, size)
+    var"#status#" = ccall((:H5Gget_objname_by_idx, libhdf5), Cssize_t, (hid_t, hsize_t, Ptr{UInt8}, Csize_t), loc_id, idx, pathname, size)
     var"#status#" < 0 && error("Error getting group object name ", h5i_get_name(loc_id), "/", pathname)
     return var"#status#"
 end
@@ -436,7 +436,7 @@ function h5l_get_info(link_loc_id, link_name, link_buf, lapl_id)
 end
 
 function h5l_get_name_by_idx(loc_id, group_name, index_field, order, n, name, size, lapl_id)
-    var"#status#" = ccall((:H5Lget_name_by_idx, libhdf5), Cssize_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t , Ptr{UInt8}, Csize_t, hid_t), loc_id, group_name, index_field, order, n, name, size, lapl_id)
+    var"#status#" = ccall((:H5Lget_name_by_idx, libhdf5), Cssize_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t, Ptr{UInt8}, Csize_t, hid_t), loc_id, group_name, index_field, order, n, name, size, lapl_id)
     var"#status#" < 0 && error("Error getting object name")
     return var"#status#"
 end
@@ -472,7 +472,7 @@ function h5o_open_by_addr(loc_id, addr)
 end
 
 function h5o_open_by_idx(loc_id, group_name, index_type, order, n, lapl_id)
-    var"#status#" = ccall((:H5Oopen_by_idx, libhdf5), hid_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t , hid_t), loc_id, group_name, index_type, order, n, lapl_id)
+    var"#status#" = ccall((:H5Oopen_by_idx, libhdf5), hid_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t, hid_t), loc_id, group_name, index_type, order, n, lapl_id)
     var"#status#" < 0 && error("Error opening object of index ", n)
     return var"#status#"
 end
@@ -490,7 +490,7 @@ function h5p_create(cls_id)
 end
 
 function h5p_get_alignment(plist_id, threshold, alignment)
-    var"#status#" = ccall((:H5Pget_alignment, libhdf5), herr_t, (hid_t, Ptr{hsize_t }, Ptr{hsize_t }), plist_id, threshold, alignment)
+    var"#status#" = ccall((:H5Pget_alignment, libhdf5), herr_t, (hid_t, Ptr{hsize_t}, Ptr{hsize_t}), plist_id, threshold, alignment)
     var"#status#" < 0 && error("Error getting alignment")
     return nothing
 end
@@ -502,7 +502,7 @@ function h5p_get_alloc_time(plist_id, alloc_time)
 end
 
 function h5p_get_chunk(plist_id, n_dims, dims)
-    var"#status#" = ccall((:H5Pget_chunk, libhdf5), Cint, (hid_t, Cint, Ptr{hsize_t }), plist_id, n_dims, dims)
+    var"#status#" = ccall((:H5Pget_chunk, libhdf5), Cint, (hid_t, Cint, Ptr{hsize_t}), plist_id, n_dims, dims)
     var"#status#" < 0 && error("Error getting chunk size")
     return var"#status#"
 end
@@ -555,7 +555,7 @@ function h5p_get_layout(plist_id)
 end
 
 function h5p_get_userblock(plist_id, len)
-    var"#status#" = ccall((:H5Pget_userblock, libhdf5), herr_t, (hid_t, Ptr{hsize_t }), plist_id, len)
+    var"#status#" = ccall((:H5Pget_userblock, libhdf5), herr_t, (hid_t, Ptr{hsize_t}), plist_id, len)
     var"#status#" < 0 && error("Error getting userblock")
     return nothing
 end
@@ -567,7 +567,7 @@ function h5p_modify_filter(plist_id, filter_id, flags, cd_nelmts, cd_values)
 end
 
 function h5p_set_alignment(plist_id, threshold, alignment)
-    var"#status#" = ccall((:H5Pset_alignment, libhdf5), herr_t, (hid_t, hsize_t , hsize_t ), plist_id, threshold, alignment)
+    var"#status#" = ccall((:H5Pset_alignment, libhdf5), herr_t, (hid_t, hsize_t, hsize_t), plist_id, threshold, alignment)
     var"#status#" < 0 && error("Error setting alignment")
     return nothing
 end
@@ -585,7 +585,7 @@ function h5p_set_char_encoding(plist_id, encoding)
 end
 
 function h5p_set_chunk(plist_id, ndims, dims)
-    var"#status#" = ccall((:H5Pset_chunk, libhdf5), herr_t, (hid_t, Cint, Ptr{hsize_t }), plist_id, ndims, dims)
+    var"#status#" = ccall((:H5Pset_chunk, libhdf5), herr_t, (hid_t, Cint, Ptr{hsize_t}), plist_id, ndims, dims)
     var"#status#" < 0 && error("Error setting chunk size")
     return nothing
 end
@@ -675,7 +675,7 @@ function h5p_set_shuffle(plist_id)
 end
 
 function h5p_set_userblock(plist_id, len)
-    var"#status#" = ccall((:H5Pset_userblock, libhdf5), herr_t, (hid_t, hsize_t ), plist_id, len)
+    var"#status#" = ccall((:H5Pset_userblock, libhdf5), herr_t, (hid_t, hsize_t), plist_id, len)
     var"#status#" < 0 && error("Error setting userblock")
     return nothing
 end
@@ -729,13 +729,13 @@ function h5s_create(class)
 end
 
 function h5s_create_simple(rank, current_dims, maximum_dims)
-    var"#status#" = ccall((:H5Screate_simple, libhdf5), hid_t, (Cint, Ptr{hsize_t }, Ptr{hsize_t }), rank, current_dims, maximum_dims)
+    var"#status#" = ccall((:H5Screate_simple, libhdf5), hid_t, (Cint, Ptr{hsize_t}, Ptr{hsize_t}), rank, current_dims, maximum_dims)
     var"#status#" < 0 && error("Error creating simple dataspace")
     return var"#status#"
 end
 
 function h5s_get_simple_extent_dims(space_id, dims, maxdims)
-    var"#status#" = ccall((:H5Sget_simple_extent_dims, libhdf5), Cint, (hid_t, Ptr{hsize_t }, Ptr{hsize_t }), space_id, dims, maxdims)
+    var"#status#" = ccall((:H5Sget_simple_extent_dims, libhdf5), Cint, (hid_t, Ptr{hsize_t}, Ptr{hsize_t}), space_id, dims, maxdims)
     var"#status#" < 0 && error("Error getting the dimensions for a dataspace")
     return var"#status#"
 end
@@ -759,13 +759,13 @@ function h5s_is_simple(space_id)
 end
 
 function h5s_select_hyperslab(dspace_id, seloper, start, stride, count, block)
-    var"#status#" = ccall((:H5Sselect_hyperslab, libhdf5), herr_t, (hid_t, Cint, Ptr{hsize_t }, Ptr{hsize_t }, Ptr{hsize_t }, Ptr{hsize_t }), dspace_id, seloper, start, stride, count, block)
+    var"#status#" = ccall((:H5Sselect_hyperslab, libhdf5), herr_t, (hid_t, Cint, Ptr{hsize_t}, Ptr{hsize_t}, Ptr{hsize_t}, Ptr{hsize_t}), dspace_id, seloper, start, stride, count, block)
     var"#status#" < 0 && error("Error selecting hyperslab")
     return nothing
 end
 
 function h5t_array_create(basetype_id, ndims, sz)
-    var"#status#" = ccall((:H5Tarray_create2, libhdf5), hid_t, (hid_t, Cuint, Ptr{hsize_t }), basetype_id, ndims, sz)
+    var"#status#" = ccall((:H5Tarray_create2, libhdf5), hid_t, (hid_t, Cuint, Ptr{hsize_t}), basetype_id, ndims, sz)
     var"#status#" < 0 && error("Error creating H5T_ARRAY of id ", basetype_id, " and size ", sz)
     return var"#status#"
 end
@@ -807,7 +807,7 @@ function h5t_equal(dtype_id1, dtype_id2)
 end
 
 function h5t_get_array_dims(dtype_id, dims)
-    var"#status#" = ccall((:H5Tget_array_dims2, libhdf5), Cint, (hid_t, Ptr{hsize_t }), dtype_id, dims)
+    var"#status#" = ccall((:H5Tget_array_dims2, libhdf5), Cint, (hid_t, Ptr{hsize_t}), dtype_id, dims)
     var"#status#" < 0 && error("Error getting dimensions of array")
     return var"#status#"
 end
@@ -938,13 +938,13 @@ function h5t_vlen_create(base_type_id)
 end
 
 function h5do_append(dset_id, dxpl_id, index, num_elem, memtype, buffer)
-    var"#status#" = ccall((:H5DOappend, libhdf5_hl), herr_t, (hid_t, hid_t, Cuint, hsize_t , hid_t, Ptr{Cvoid}), dset_id, dxpl_id, index, num_elem, memtype, buffer)
+    var"#status#" = ccall((:H5DOappend, libhdf5_hl), herr_t, (hid_t, hid_t, Cuint, hsize_t, hid_t, Ptr{Cvoid}), dset_id, dxpl_id, index, num_elem, memtype, buffer)
     var"#status#" < 0 && error("error appending")
     return nothing
 end
 
 function h5do_write_chunk(dset_id, dxpl_id, filter_mask, offset, bufsize, buf)
-    var"#status#" = ccall((:H5DOwrite_chunk, libhdf5_hl), herr_t, (hid_t, hid_t, Int32, Ptr{hsize_t }, Csize_t, Ptr{Cvoid}), dset_id, dxpl_id, filter_mask, offset, bufsize, buf)
+    var"#status#" = ccall((:H5DOwrite_chunk, libhdf5_hl), herr_t, (hid_t, hid_t, Int32, Ptr{hsize_t}, Csize_t, Ptr{Cvoid}), dset_id, dxpl_id, filter_mask, offset, bufsize, buf)
     var"#status#" < 0 && error("Error writing chunk")
     return nothing
 end

--- a/src/blosc_filter.jl
+++ b/src/blosc_filter.jl
@@ -29,9 +29,9 @@ const blosc_name = "blosc"
 const blosc_flags = Ref{Cuint}()
 const blosc_values = Vector{Cuint}(undef,8)
 const blosc_nelements = Ref{Csize_t}(length(blosc_values))
-const blosc_chunkdims = Vector{Hsize}(undef,32)
+const blosc_chunkdims = Vector{hsize_t }(undef,32)
 
-function blosc_set_local(dcpl::Hid, htype::Hid, space::Hid)
+function blosc_set_local(dcpl::hid_t, htype::hid_t, space::hid_t)
     h5p_get_filter_by_id(dcpl, FILTER_BLOSC, blosc_flags, blosc_nelements, blosc_values, 0, C_NULL, C_NULL)
     flags = blosc_flags[]
 
@@ -44,7 +44,7 @@ function blosc_set_local(dcpl::Hid, htype::Hid, space::Hid)
     ndims = h5p_get_chunk(dcpl, 32, blosc_chunkdims)
     chunksize = prod(resize!(blosc_chunkdims, ndims))
     if ndims < 0 || ndims > 32 || chunksize > Blosc.MAX_BUFFERSIZE
-        return Herr(-1)
+        return herr_t(-1)
     end
 
     htypesize = h5t_get_size(htype)
@@ -67,7 +67,7 @@ function blosc_set_local(dcpl::Hid, htype::Hid, space::Hid)
 
     h5p_modify_filter(dcpl, FILTER_BLOSC, flags, nelements, blosc_values)
 
-    return Herr(1)
+    return herr_t(1)
 end
 
 function blosc_filter(flags::Cuint, cd_nelmts::Csize_t,
@@ -116,7 +116,7 @@ end
 
 # register the Blosc filter function with HDF5
 function register_blosc()
-    c_blosc_set_local = @cfunction(blosc_set_local, Herr, (Hid,Hid,Hid))
+    c_blosc_set_local = @cfunction(blosc_set_local, herr_t, (hid_t,hid_t,hid_t))
     c_blosc_filter = @cfunction(blosc_filter, Csize_t,
                                 (Cuint, Csize_t, Ptr{Cuint}, Csize_t,
                                  Ptr{Csize_t}, Ptr{Ptr{Cvoid}}))

--- a/src/blosc_filter.jl
+++ b/src/blosc_filter.jl
@@ -29,7 +29,7 @@ const blosc_name = "blosc"
 const blosc_flags = Ref{Cuint}()
 const blosc_values = Vector{Cuint}(undef,8)
 const blosc_nelements = Ref{Csize_t}(length(blosc_values))
-const blosc_chunkdims = Vector{hsize_t }(undef,32)
+const blosc_chunkdims = Vector{hsize_t}(undef,32)
 
 function blosc_set_local(dcpl::hid_t, htype::hid_t, space::hid_t)
     h5p_get_filter_by_id(dcpl, FILTER_BLOSC, blosc_flags, blosc_nelements, blosc_values, 0, C_NULL, C_NULL)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,13 +1,13 @@
 import Base: @deprecate, @deprecate_binding, depwarn
 
 ### Changed in PR#629
-# - HDF5Dataset.xfer from ::Hid to ::HDF5Properties
-@deprecate h5d_read(dataset_id::Hid, memtype_id::Hid, buf::AbstractArray, xfer::HDF5Properties) h5d_read(dataset_id, memtype_id, buf, xfer.id)
-@deprecate h5d_write(dataset_id::Hid, memtype_id::Hid, buf::AbstractArray, xfer::HDF5Properties) h5d_write(dataset_id, memtype_id, buf, xfer.id)
-@deprecate h5d_write(dataset_id::Hid, memtype_id::Hid, str::String, xfer::HDF5Properties) h5d_write(dataset_id, memtype_id, str, xfer.id)
-@deprecate h5d_write(dataset_id::Hid, memtype_id::Hid, x::T, xfer::HDF5Properties) where {T<:Union{HDF5Scalar, Complex{<:HDF5Scalar}}} h5d_write(dataset_id, memtype_id, x, xfer.id)
-@deprecate h5d_write(dataset_id::Hid, memtype_id::Hid, strs::Array{S}, xfer::HDF5Properties) where {S<:String} h5d_write(dataset_id, memtype_id, strs, xfer.id)
-@deprecate h5d_write(dataset_id::Hid, memtype_id::Hid, v::HDF5Vlen{T}, xfer::HDF5Properties) where {T<:Union{HDF5Scalar,CharType}} h5d_write(dataset_id, memtype_id, v, xfer.id)
+# - HDF5Dataset.xfer from ::hid_t to ::HDF5Properties
+@deprecate h5d_read(dataset_id::hid_t, memtype_id::hid_t, buf::AbstractArray, xfer::HDF5Properties) h5d_read(dataset_id, memtype_id, buf, xfer.id)
+@deprecate h5d_write(dataset_id::hid_t, memtype_id::hid_t, buf::AbstractArray, xfer::HDF5Properties) h5d_write(dataset_id, memtype_id, buf, xfer.id)
+@deprecate h5d_write(dataset_id::hid_t, memtype_id::hid_t, str::String, xfer::HDF5Properties) h5d_write(dataset_id, memtype_id, str, xfer.id)
+@deprecate h5d_write(dataset_id::hid_t, memtype_id::hid_t, x::T, xfer::HDF5Properties) where {T<:Union{HDF5Scalar, Complex{<:HDF5Scalar}}} h5d_write(dataset_id, memtype_id, x, xfer.id)
+@deprecate h5d_write(dataset_id::hid_t, memtype_id::hid_t, strs::Array{S}, xfer::HDF5Properties) where {S<:String} h5d_write(dataset_id, memtype_id, strs, xfer.id)
+@deprecate h5d_write(dataset_id::hid_t, memtype_id::hid_t, v::HDF5Vlen{T}, xfer::HDF5Properties) where {T<:Union{HDF5Scalar,CharType}} h5d_write(dataset_id, memtype_id, v, xfer.id)
 # - p_create lost toclose argument
 @deprecate p_create(class, toclose::Bool, pv...) p_create(class, pv...)
 
@@ -172,3 +172,13 @@ end
 @deprecate_binding h5f_get_intend h5f_get_intent
 @deprecate_binding hf5start_swmr_write h5f_start_swmr_write
 @deprecate_binding h5d_oappend h5do_append
+
+### Changed in PR#678
+# - normalized constants names to C definitions
+@deprecate_binding Haddr haddr_t
+@deprecate_binding Herr herr_t
+@deprecate_binding Hid hid_t
+@deprecate_binding Hsize hsize_t
+@deprecate_binding Hssize hssize_t
+@deprecate_binding Htri htri_t
+@deprecate_binding Hvl_t hvl_t

--- a/test/compound.jl
+++ b/test/compound.jl
@@ -44,7 +44,7 @@ function datatype(::Type{foo_hdf5})
   HDF5.h5t_set_strpad(fixedstr_dtype, HDF5.H5T_STR_NULLPAD)
   HDF5.h5t_insert(dtype, "c", fieldoffset(foo_hdf5, 3), fixedstr_dtype)
 
-  hsz = HDF5.hsize_t [3,3]
+  hsz = HDF5.hsize_t[3,3]
   array_dtype = HDF5.h5t_array_create(datatype(ComplexF64).id, 2, hsz)
   HDF5.h5t_insert(dtype, "d", fieldoffset(foo_hdf5, 4), array_dtype)
 
@@ -69,7 +69,7 @@ function datatype(::Type{bar_hdf5})
   HDF5.h5t_set_size(fixedstr_dtype, 20 * sizeof(UInt8))
   HDF5.h5t_set_cset(fixedstr_dtype, HDF5.H5T_CSET_UTF8)
 
-  hsz = HDF5.hsize_t [2]
+  hsz = HDF5.hsize_t[2]
   array_dtype = HDF5.h5t_array_create(fixedstr_dtype, 1, hsz)
 
   HDF5.h5t_insert(dtype, "a", fieldoffset(bar_hdf5, 1), array_dtype)

--- a/test/compound.jl
+++ b/test/compound.jl
@@ -17,7 +17,7 @@ struct foo_hdf5
   b::Cstring
   c::NTuple{20, UInt8}
   d::NTuple{9, ComplexF64}
-  e::HDF5.Hvl_t
+  e::HDF5.hvl_t
 end
 
 function unsafe_convert(::Type{foo_hdf5}, x::foo)
@@ -25,7 +25,7 @@ function unsafe_convert(::Type{foo_hdf5}, x::foo)
            Base.unsafe_convert(Cstring, x.b),
            ntuple(i -> i <= ncodeunits(x.c) ? codeunit(x.c, i) : '\0', 20),
            ntuple(i -> x.d[i], length(x.d)),
-           HDF5.Hvl_t(length(x.e), pointer(x.e))
+           HDF5.hvl_t(length(x.e), pointer(x.e))
           )
 end
 
@@ -44,7 +44,7 @@ function datatype(::Type{foo_hdf5})
   HDF5.h5t_set_strpad(fixedstr_dtype, HDF5.H5T_STR_NULLPAD)
   HDF5.h5t_insert(dtype, "c", fieldoffset(foo_hdf5, 3), fixedstr_dtype)
 
-  hsz = HDF5.Hsize[3,3]
+  hsz = HDF5.hsize_t [3,3]
   array_dtype = HDF5.h5t_array_create(datatype(ComplexF64).id, 2, hsz)
   HDF5.h5t_insert(dtype, "d", fieldoffset(foo_hdf5, 4), array_dtype)
 
@@ -69,7 +69,7 @@ function datatype(::Type{bar_hdf5})
   HDF5.h5t_set_size(fixedstr_dtype, 20 * sizeof(UInt8))
   HDF5.h5t_set_cset(fixedstr_dtype, HDF5.H5T_CSET_UTF8)
 
-  hsz = HDF5.Hsize[2]
+  hsz = HDF5.hsize_t [2]
   array_dtype = HDF5.h5t_array_create(fixedstr_dtype, 1, hsz)
 
   HDF5.h5t_insert(dtype, "a", fieldoffset(bar_hdf5, 1), array_dtype)

--- a/test/extend_test.jl
+++ b/test/extend_test.jl
@@ -40,7 +40,7 @@ set_dims!(d, (1, 5))
 Array(d) == [1.1231 1.313 5.123 2.231 4.1231]
 
 #println("d is size current $(map(int,HDF5.get_dims(d)[1])) max $(map(int,HDF5.get_dims(d)[2]))")
-b = d_create(fid, "b", Int, ((1000,), (-1,)), chunk=(100,)) #-1 is equivalent to typemax(hsize_t ) as far as I can tell
+b = d_create(fid, "b", Int, ((1000,), (-1,)), chunk=(100,)) #-1 is equivalent to typemax(hsize_t) as far as I can tell
 #println("b is size current $(map(int,HDF5.get_dims(b)[1])) max $(map(int,HDF5.get_dims(b)[2]))")
 b[1:200] = ones(200)
 dims, max_dims = HDF5.get_dims(b)

--- a/test/extend_test.jl
+++ b/test/extend_test.jl
@@ -40,7 +40,7 @@ set_dims!(d, (1, 5))
 Array(d) == [1.1231 1.313 5.123 2.231 4.1231]
 
 #println("d is size current $(map(int,HDF5.get_dims(d)[1])) max $(map(int,HDF5.get_dims(d)[2]))")
-b = d_create(fid, "b", Int, ((1000,), (-1,)), chunk=(100,)) #-1 is equivalent to typemax(Hsize) as far as I can tell
+b = d_create(fid, "b", Int, ((1000,), (-1,)), chunk=(100,)) #-1 is equivalent to typemax(hsize_t ) as far as I can tell
 #println("b is size current $(map(int,HDF5.get_dims(b)[1])) max $(map(int,HDF5.get_dims(b)[2]))")
 b[1:200] = ones(200)
 dims, max_dims = HDF5.get_dims(b)


### PR DESCRIPTION
I'm not sure what others think about this, but I thought I'd open up a PR anyways. I never understood the previous convention for these types, which is to capitalize the constant and remove the `_t` postfix. I think `Clang.jl` directly translates the names, so I'm hoping this is at least consistent with that. In any case, we don't apply any special name normalization to other API constants, so I don't see why we should treat these any differently.