### PR TITLE
Fix the flaky CRC32 test through actually setting the track_times property

### DIFF
--- a/test/plain.jl
+++ b/test/plain.jl
@@ -403,6 +403,7 @@ fn1 = tempname(); fn2 = tempname()
 h5open(fn1, "w") do f
     f["x", track_times=false] = [1, 2, 3]
 end
+sleep(1)
 h5open(fn2, "w") do f
     f["x", track_times=false] = [1, 2, 3]
 end


### PR DESCRIPTION
The CRC32 test was flaky because the test depended on how quickly or
slowly the two files could be written to disk. By inserting a small
sleep, we guarantee that the file-creation times will be different
between the two data sets. This was sufficient to force the test to
fail reliably.

The fix then comes actually setting the track_times property. The
implementation of `p_create()` was skipping over the property because
the `H5P_DATASET_CREATE != H5P_OBJECT_CREATE`. By special-casing the
`H5P_OBJECT_CREATE` value in the dictionary, we can recognize it as
acting upon any of the three file/dataset/group creation property
classes.

An unrelated change is to inline the call to the property setter
function since it avoids repeating the dictionary lookup done by
`setindex!(::HDF5Properties, ...)` when using the `p[k] = v` syntax.