### PR TITLE
Re-add `read(dset, String)` form

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1435,6 +1435,18 @@ function read(obj::DatasetOrAttribute, ::Type{T}, I...) where T
         return out
     end
 end
+# `Type{String}` does not have a definite size, so the previous method does not accept
+# it even though it will return a `String`. This explicit overload allows that usage.
+function read(obj::DatasetOrAttribute, ::Type{String}, I...)
+    dtype = datatype(obj)
+    try
+        T = get_jl_type(dtype)
+        T <: Union{Cstring, FixedString} || error(name(obj), " cannot be read as type `String`")
+        return read(obj, T, I...)
+    finally
+        close(dtype)
+    end
+end
 
 # Read OPAQUE datasets and attributes
 function read(obj::DatasetOrAttribute, ::Type{HDF5Opaque})


### PR DESCRIPTION
This would close #669. Adds a method overload for the generic `read()` function introduced in #652 that specializes on the `String` type to make reading as a specific type easier for the string case. As I suggested in https://github.com/JuliaIO/HDF5.jl/issues/669#issuecomment-698022510, the idea is that the type argument is a natural way to specify particular deserializations of datasets, and the HDF5 string types are deserialized to Julia `Strings`.

In the course of testing, I found that there's actually a way to manually specify the underlying `Cstring` or `FixedString` types on the generic read that caused it to read "junk" values by [forcibly] misinterpreting the returned data during normalization. I've added a check that prevents that from being possible.