### PR TITLE
Add default null reference constructor

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -48,6 +48,7 @@ include("api_helpers.jl")
 struct Reference
     r::hobj_ref_t
 end
+Reference() = Reference(HOBJ_REF_T_NULL) # NULL reference to compare to
 Base.cconvert(::Type{Ptr{T}}, ref::Reference) where {T<:Union{Reference,hobj_ref_t,Cvoid}} = Ref(ref)
 
 # Single character types
@@ -1262,7 +1263,7 @@ unpad(s, pad::Integer) = unpad(String(s), pad)
 
 # Dereference
 function getindex(parent::Union{File, Group, Dataset}, r::Reference)
-    r.r == HOBJ_REF_T_NULL && error("Reference is null")
+    r == Reference() && error("Reference is null")
     obj_id = h5r_dereference(checkvalid(parent).id, H5P_DEFAULT, H5R_OBJECT, r)
     h5object(obj_id, parent)
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -191,10 +191,9 @@ end
 
 ### Changed in PR#689
 # - switch from H5Rdereference1 to H5Rdereference2
-@deprecate_binding HDF5ReferenceObj_NULL Reference(HOBJ_REF_T_NULL)
 @deprecate h5r_dereference(obj_id, ref_type, ref) h5r_dereference(obj_id, H5P_DEFAULT, ref_type, ref)
 
-### Changed in PR#689
+### Changed in PR#690
 # - rename exported bindings
 # - remove exports in > v0.14
 export HDF5Attribute, HDF5File, HDF5Group, HDF5Dataset, HDF5Datatype,
@@ -210,3 +209,7 @@ export HDF5Attribute, HDF5File, HDF5Group, HDF5Dataset, HDF5Datatype,
 @deprecate_binding HDF5Vlen HDF5.VLen
 @deprecate_binding HDF5ChunkStorage HDF5.ChunkStorage
 @deprecate_binding HDF5ReferenceObj HDF5.Reference
+
+### Changed in PR#691
+# - Make Reference() construct a null reference
+@deprecate_binding HDF5ReferenceObj_NULL HDF5.Reference()


### PR DESCRIPTION
I think this is a better solution for providing a null reference that can be compared against — trying to fix deprecations in JLD and MAT showed that something like this would be useful.

I know this will have to be rebased after #690 is merged.