### PR TITLE
Rename public functions and stop exporting several public API methods

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,23 @@
 ## v0.14
 
+### Breaking Changes
+
+* The following functions have been unexported and do not have an automatic deprecation warning. Please use the `HDF5` module prefix to call these functions:
+  - `file`
+  - `filename`
+  - `name`
+  - `get_chunk`
+  - `get_datasets`
+  - `iscontiguous`
+  - `ishdf5`
+  - `ismmappable`
+  - `root`
+  - `readmmap`
+  - `set_dims!`
+  - `get_access_properties`
+  - `get_create_properties`
+  - `create_external_dataset`
+
 * Properties are now set using keyword arguments instead of by pairs of string and value positional arguments.
   For example `dset = d_create(h5f, "A", datatype(Int64), dataspace(10,10), "chunk", (3,3))` is now written as
   `dset = d_create(h5f, "A", datatype(Int64), dataspace(10,10), chunk=(3,3))`. Additionally the key type used for

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ read by numerous [programming
 languages](https://en.wikipedia.org/wiki/Hierarchical_Data_Format#Interfaces).  This package
 provides an interface to the HDF5 library for the Julia language.
 
+## Changelog
+
+Please see the [HISTORY.jl](HISTORY.md) file for the changelog. Most changes have deprecation warnings and thus may not be listed under the changelog, but for the changes that don't please refer to the [HISTORY.jl](HISTORY.md).
+
 ## Installation
 
 ```julia
@@ -122,4 +126,3 @@ demonstrate usage.
   improving the handling of HDF5's constants
 
 - Thanks also to the users who have reported bugs and tested fixes
-

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ provides an interface to the HDF5 library for the Julia language.
 
 ## Changelog
 
-Please see the [HISTORY.jl](HISTORY.md) file for the changelog. Most changes have deprecation warnings and thus may not be listed under the changelog, but for the changes that don't please refer to the [HISTORY.jl](HISTORY.md).
+Please see [HISTORY.jl](HISTORY.md) for the changelog. Most changes have deprecation warnings and thus may not be listed under here, but for those that don't please refer to this file.
 
 ## Installation
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,7 @@
-using MPI  # needed to generate docs for parallel HDF5 API
-using HDF5
 using Documenter
+using HDF5
+using MPI  # needed to generate docs for parallel HDF5 API
+
 
 makedocs(;
     modules=[HDF5],
@@ -19,5 +20,6 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/JuliaIO/HDF5.jl",
+    repo="github.com/JuliaIO/HDF5.jl.git",
+    push_preview=true,
 )

--- a/src/show.jl
+++ b/src/show.jl
@@ -122,8 +122,8 @@ function _tree_children(parent::Union{File, Group}, attributes::Bool)
     names = keys(parent)
     objs  = Union{Object, Attribute}[parent[n] for n in names]
     if attributes
-        attrn = keys(attrs(parent))
-        attro = Union{Object, Attribute}[attrs(parent)[n] for n in attrn]
+        attrn = keys(HDF5.attributes(parent))
+        attro = Union{Object, Attribute}[HDF5.attributes(parent)[n] for n in attrn]
         names = append!(attrn, names)
         objs  = append!(attro, objs)
     end
@@ -133,8 +133,8 @@ function _tree_children(parent::Dataset, attributes::Bool)
     names = String[]
     objs = Union{Object, Attribute}[parent[n] for n in names]
     if attributes
-        attrn = keys(attrs(parent))
-        attro = Union{Object, Attribute}[attrs(parent)[n] for n in attrn]
+        attrn = keys(HDF5.attributes(parent))
+        attro = Union{Object, Attribute}[HDF5.attributes(parent)[n] for n in attrn]
         names = append!(attrn, names)
         objs  = append!(attro, objs)
     end
@@ -151,7 +151,7 @@ function _tree_children(parent::Union{Attribute, Datatype}, attributes::Bool)
 end
 
 function _show_tree(io::IO, obj::Union{File,Group,Dataset,Datatype,Attributes,Attribute}, indent::String="";
-                   attributes::Bool = true)
+                    attributes::Bool = true)
     isempty(indent) && _tree_head(io, obj)
     !isvalid(obj) && return
 

--- a/test/compound.jl
+++ b/test/compound.jl
@@ -1,5 +1,6 @@
 using Random, Test, HDF5
 
+import HDF5.datatype
 import Base.convert
 import Base.unsafe_convert
 
@@ -28,7 +29,7 @@ function unsafe_convert(::Type{foo_hdf5}, x::foo)
             )
 end
 
-function HDF5.datatype(::Type{foo_hdf5})
+function datatype(::Type{foo_hdf5})
     dtype = HDF5.h5t_create(HDF5.H5T_COMPOUND, sizeof(foo_hdf5))
     HDF5.h5t_insert(dtype, "a", fieldoffset(foo_hdf5, 1), datatype(Float64))
 
@@ -61,7 +62,7 @@ struct bar_hdf5
     a::NTuple{2, NTuple{20, UInt8}}
 end
 
-function HDF5.datatype(::Type{bar_hdf5})
+function datatype(::Type{bar_hdf5})
     dtype = HDF5.h5t_create(HDF5.H5T_COMPOUND, sizeof(bar_hdf5))
 
     fixedstr_dtype = HDF5.h5t_copy(HDF5.H5T_C_S1)

--- a/test/compound.jl
+++ b/test/compound.jl
@@ -1,6 +1,5 @@
 using Random, Test, HDF5
 
-import HDF5.datatype
 import Base.convert
 import Base.unsafe_convert
 
@@ -29,7 +28,7 @@ function unsafe_convert(::Type{foo_hdf5}, x::foo)
             )
 end
 
-function datatype(::Type{foo_hdf5})
+function HDF5.datatype(::Type{foo_hdf5})
     dtype = HDF5.h5t_create(HDF5.H5T_COMPOUND, sizeof(foo_hdf5))
     HDF5.h5t_insert(dtype, "a", fieldoffset(foo_hdf5, 1), datatype(Float64))
 
@@ -62,7 +61,7 @@ struct bar_hdf5
     a::NTuple{2, NTuple{20, UInt8}}
 end
 
-function datatype(::Type{bar_hdf5})
+function HDF5.datatype(::Type{bar_hdf5})
     dtype = HDF5.h5t_create(HDF5.H5T_COMPOUND, sizeof(bar_hdf5))
 
     fixedstr_dtype = HDF5.h5t_copy(HDF5.H5T_C_S1)
@@ -107,13 +106,13 @@ end
     h5open(fn, "w") do h5f
         foo_dtype = datatype(foo_hdf5)
         foo_space = dataspace(v_write)
-        foo_dset = d_create(h5f, "foo", foo_dtype, foo_space)
-        d_write(foo_dset, foo_dtype, v_write)
+        foo_dset = create_dataset(h5f, "foo", foo_dtype, foo_space)
+        write_dataset(foo_dset, foo_dtype, v_write)
 
         bar_dtype = datatype(bar_hdf5)
         bar_space = dataspace(w_write)
-        bar_dset = d_create(h5f, "bar", bar_dtype, bar_space)
-        d_write(bar_dset, bar_dtype, w_write)
+        bar_dset = create_dataset(h5f, "bar", bar_dtype, bar_space)
+        write_dataset(bar_dset, bar_dtype, w_write)
     end
 
     v_read = h5read(fn, "foo")

--- a/test/custom.jl
+++ b/test/custom.jl
@@ -1,6 +1,6 @@
 using Random, Test, HDF5
 
-import HDF5: datatype
+import HDF5.datatype
 
 struct Simple
     a::Float64

--- a/test/custom.jl
+++ b/test/custom.jl
@@ -1,6 +1,6 @@
 using Random, Test, HDF5
 
-import HDF5.datatype
+import HDF5: datatype
 
 struct Simple
     a::Float64
@@ -22,8 +22,8 @@ end
     h5open(fn, "w") do h5f
         dtype = datatype(Simple)
         dspace = dataspace(v)
-        dset = d_create(h5f, "data", dtype, dspace)
-        d_write(dset, dtype, v)
+        dset = create_dataset(h5f, "data", dtype, dspace)
+        write_dataset(dset, dtype, v)
     end
 
     h5open(fn, "r") do h5f

--- a/test/extend_test.jl
+++ b/test/extend_test.jl
@@ -6,18 +6,18 @@ using Test
 fn = tempname()
 
 fid = h5open(fn, "w")
-g = g_create(fid, "shoe")
-d = d_create(g, "foo", datatype(Float64), ((10, 20), (100, 200)), chunk=(1, 1))
+g = create_group(fid, "shoe")
+d = create_dataset(g, "foo", datatype(Float64), ((10, 20), (100, 200)), chunk=(1, 1))
 #println("d is size current $(map(int,HDF5.get_dims(d)[1])) max $(map(int,HDF5.get_dims(d)[2]))")
 dims, max_dims = HDF5.get_dims(d)
 @test dims == (UInt64(10), UInt64(20))
 @test max_dims == (UInt64(100), UInt64(200))
-set_dims!(d, (100, 150))
+HDF5.set_dims!(d, (100, 150))
 dims, max_dims = HDF5.get_dims(d)
 @test dims == (UInt64(100), UInt64(150))
 @test max_dims == (UInt64(100), UInt64(200))
 d[1, 1:5] = [1.1231, 1.313, 5.123, 2.231, 4.1231]
-set_dims!(d, (1, 5))
+HDF5.set_dims!(d, (1, 5))
 @test size(d) == (1, 5)
 
 # Indexing returns correct array dimensions
@@ -40,13 +40,13 @@ set_dims!(d, (1, 5))
 Array(d) == [1.1231 1.313 5.123 2.231 4.1231]
 
 #println("d is size current $(map(int,HDF5.get_dims(d)[1])) max $(map(int,HDF5.get_dims(d)[2]))")
-b = d_create(fid, "b", Int, ((1000,), (-1,)), chunk=(100,)) #-1 is equivalent to typemax(hsize_t) as far as I can tell
+b = create_dataset(fid, "b", Int, ((1000,), (-1,)), chunk=(100,)) #-1 is equivalent to typemax(hsize_t) as far as I can tell
 #println("b is size current $(map(int,HDF5.get_dims(b)[1])) max $(map(int,HDF5.get_dims(b)[2]))")
 b[1:200] = ones(200)
 dims, max_dims = HDF5.get_dims(b)
 @test dims == (UInt64(1000),)
 @test max_dims == (HDF5.H5S_UNLIMITED,)
-set_dims!(b, (10000,))
+HDF5.set_dims!(b, (10000,))
 dims, max_dims = HDF5.get_dims(b)
 @test dims == (UInt64(10000),)
 @test max_dims == (HDF5.H5S_UNLIMITED,)

--- a/test/external.jl
+++ b/test/external.jl
@@ -8,9 +8,9 @@ fn1 = tempname()
 fn2 = tempname()
 
 source_file = h5open(fn1, "w")
-agroup = g_create(source_file, "agroup")
+agroup = create_group(source_file, "agroup")
 target_file = h5open(fn2, "w")
-target_group = g_create(target_file, "target_group")
+target_group = create_group(target_file, "target_group")
 target_group["abc"] = "abc"
 target_group["1"] = 1
 target_group["1.1"] = 1.1
@@ -21,7 +21,7 @@ close(target_file)
 HDF5.create_external(source_file, "ext_link", target_file.filename, "target_group")
 HDF5.create_external(agroup, "ext_link", target_file.filename, "target_group")
 # write some things via the external link
-new_group = g_create(source_file["ext_link"], "new_group")
+new_group = create_group(source_file["ext_link"], "new_group")
 new_group["abc"] = "abc"
 new_group["1"] = 1
 new_group["1.1"] = 1.1

--- a/test/gc.jl
+++ b/test/gc.jl
@@ -31,23 +31,23 @@ for i = 1:10
     HDF5.h5t_insert(memtype_id, "real", 0, HDF5.hdf5_type_id(Float64))
     HDF5.h5t_insert(memtype_id, "imag", sizeof(Float64), HDF5.hdf5_type_id(Float64))
     dt = HDF5.Datatype(memtype_id)
-    t_commit(file, "dt", dt)
+    commit_datatype(file, "dt", dt)
     ds = dataspace((2,))
-    d = d_create(file, "d", dt, ds)
-    g = g_create(file, "g")
-    a = a_create(file, "a", dt, ds)
+    d = create_dataset(file, "d", dt, ds)
+    g = create_group(file, "g")
+    a = create_attribute(file, "a", dt, ds)
     @gcvalid dt ds d g a
     close(file)
 
     @closederror read(d)
     for obj in (d, g)
-        @closederror a_read(obj, "a")
-        @closederror a_write(obj, "a", 1)
+        @closederror read_attribute(obj, "a")
+        @closederror write_attribute(obj, "a", 1)
     end
     for obj in (g, file)
-        @closederror d_open(obj, "d")
-        @closederror d_read(obj, "d")
-        @closederror d_write(obj, "d", 1)
+        @closederror open_dataset(obj, "d")
+        @closederror read_dataset(obj, "d")
+        @closederror write_dataset(obj, "d", 1)
         @closederror read(obj, "x")
         @closederror write(obj, "x", "y")
     end
@@ -58,13 +58,13 @@ for i = 1:10
     d = file["d"]
     ds = dataspace(d)
     g = file["g"]
-    a = attrs(file)["a"]
+    a = attributes(file)["a"]
     @gcvalid dt ds d g a
     close(file)
 end
 GC.enable(true)
 
-let plist = p_create(HDF5.H5P_FILE_ACCESS)  # related to issue #620
+let plist = create_property(HDF5.H5P_FILE_ACCESS)  # related to issue #620
     HDF5.h5p_close(plist)
     @test_nowarn finalize(plist)
 end

--- a/test/memtest.jl
+++ b/test/memtest.jl
@@ -14,7 +14,7 @@ macro memtest(ex)
     end
 end
 @memtest h5open("/tmp/memtest.h5", "w") do file
-    dset = d_create(file, "A", datatype(DATA), dataspace(DATA), chunk=(100,))
+    dset = create_dataset(file, "A", datatype(DATA), dataspace(DATA), chunk=(100,))
     dset[:] = DATA[:]
 end
 @memtest h5open("/tmp/memtest.h5", "w") do file

--- a/test/mmap.jl
+++ b/test/mmap.jl
@@ -10,11 +10,11 @@ f = h5open(fn, "w")
 
 # Create two datasets, one with late allocation (the default for contiguous
 # datasets) and the other with explicit early allocation.
-hdf5_A = d_create(f, "A", datatype(Int64), dataspace(3,3))
-hdf5_B = d_create(f, "B", datatype(Float64), dataspace(3,3);
+hdf5_A = create_dataset(f, "A", datatype(Int64), dataspace(3,3))
+hdf5_B = create_dataset(f, "B", datatype(Float64), dataspace(3,3);
                   alloc_time = HDF5.H5D_ALLOC_TIME_EARLY)
 # The late case cannot be mapped yet.
-@test_throws ErrorException("Error getting offset") readmmap(f["A"])
+@test_throws ErrorException("Error getting offset") HDF5.readmmap(f["A"])
 # Then write and fill dataset A, making it mappable. B was filled with 0.0 at
 # creation.
 A = rand(Int64,3,3)
@@ -23,15 +23,15 @@ flush(f)
 close(f)
 # Read HDF5 file & MMAP
 f = h5open(fn,"r")
-A_mmaped = readmmap(f["A"])
+A_mmaped = HDF5.readmmap(f["A"])
 @test all(A .== A_mmaped)
-@test all(iszero, readmmap(f["B"]))
+@test all(iszero, HDF5.readmmap(f["B"]))
 # Check that it is read only
 @test_throws ReadOnlyMemoryError A_mmaped[1,1] = 33
 close(f)
 # Now check if we can write
 f = h5open(fn,"r+")
-A_mmaped = readmmap(f["A"])
+A_mmaped = HDF5.readmmap(f["A"])
 A_mmaped[1,1] = 33
 close(f)
 

--- a/test/mpio.jl
+++ b/test/mpio.jl
@@ -14,7 +14,7 @@ myrank = MPI.Comm_rank(comm)
 
 @test HDF5.has_parallel()
 
-let fileprop = p_create(HDF5.H5P_FILE_ACCESS)
+let fileprop = create_property(HDF5.H5P_FILE_ACCESS)
     HDF5.h5p_set_fapl_mpio(fileprop, comm, info)
     h5comm, h5info = HDF5.h5p_get_fapl_mpio(fileprop)
 
@@ -29,8 +29,8 @@ fn = MPI.bcast(tempname(), 0, comm)
 A = [myrank + i for i = 1:10]
 h5open(fn, "w", comm, info) do f
     @test isopen(f)
-    g = g_create(f, "mygroup")
-    dset = d_create(g, "B", datatype(Int64), dataspace(10, nprocs), chunk=(10, 1), dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
+    g = create_group(f, "mygroup")
+    dset = create_dataset(g, "B", datatype(Int64), dataspace(10, nprocs), chunk=(10, 1), dxpl_mpio=HDF5.H5FD_MPIO_COLLECTIVE)
     dset[:, myrank + 1] = A
 end
 

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -691,10 +691,10 @@ hfile = h5open(fn, "w", swmr = true)
 group = create_group(hfile, "group")
 @test sprint(show, group) == "HDF5.Group: /group (file: $fn)"
 
-dset = create_dataset(group, "dset", HDF5.datatype(Int), HDF5.dataspace((1,)))
+dset = create_dataset(group, "dset", datatype(Int), dataspace((1,)))
 @test sprint(show, dset) == "HDF5.Dataset: /group/dset (file: $fn xfer_mode: 0)"
 
-meta = create_attribute(dset, "meta", HDF5.datatype(Bool), HDF5.dataspace((1,)))
+meta = create_attribute(dset, "meta", datatype(Bool), dataspace((1,)))
 @test sprint(show, meta) == "HDF5.Attribute: meta"
 
 dsetattrs = attributes(dset)
@@ -969,7 +969,7 @@ hfile[GenericString("test")] = 17.2
 memtype_id = HDF5.h5t_copy(HDF5.H5T_NATIVE_DOUBLE)
 dt = HDF5.Datatype(memtype_id)
 @test !HDF5.h5t_committed(dt)
-HDF5.commit_datatype(hfile, GenericString("dt"), dt)
+commit_datatype(hfile, GenericString("dt"), dt)
 @test HDF5.h5t_committed(dt)
 
 dt = datatype(Int)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -44,8 +44,8 @@ let
     dtype = HDF5.Datatype(HDF5.h5t_copy(HDF5.H5T_C_S1))
     HDF5.h5t_set_size(dtype.id, HDF5.H5T_VARIABLE)
     HDF5.h5t_set_cset(dtype.id, HDF5.cset(typeof(salut)))
-    dspace = HDF5.dataspace(salut)
-    dset = HDF5.d_create(f, "salut-vlen", dtype, dspace)
+    dspace = dataspace(salut)
+    dset = create_dataset(f, "salut-vlen", dtype, dspace)
     GC.@preserve salut begin
         HDF5.h5d_write(dset, dtype, HDF5.H5S_ALL, HDF5.H5S_ALL, HDF5.H5P_DEFAULT, [pointer(salut)])
     end
@@ -57,12 +57,12 @@ salut_2d = ["Hi" "there"; "Salut" "friend"]
 write(f, "salut_2d", salut_2d)
 # Arrays of strings as vlen
 vlen = HDF5.VLen(salut_split)
-d_write(f, "salut_vlen", vlen)
+write_dataset(f, "salut_vlen", vlen)
 # Arrays of scalars as vlen
 vlen_int = [[3], [1], [4]]
 vleni = HDF5.VLen(vlen_int)
-d_write(f, "int_vlen", vleni)
-a_write(f["int_vlen"], "vlen_attr", vleni)
+write_dataset(f, "int_vlen", vleni)
+write_attribute(f["int_vlen"], "vlen_attr", vleni)
 # Empty arrays
 empty = UInt32[]
 write(f, "empty", empty)
@@ -75,45 +75,45 @@ write(f, "empty_string_array", empty_string_array)
 # Array of empty string
 empty_array_of_strings = [""]
 write(f, "empty_array_of_strings", empty_array_of_strings)
-# Attributes
+# attributes
 species = [["N", "C"]; ["A", "B"]]
-attrs(f)["species"] = species
+attributes(f)["species"] = species
 C∞ = 42
-attrs(f)["C∞"] = C∞
+attributes(f)["C∞"] = C∞
 dset = f["salut"]
 @test !isempty(dset)
 label = "This is a string"
-attrs(dset)["typeinfo"] = label
+attributes(dset)["typeinfo"] = label
 close(dset)
 # Scalar reference values in attributes
-attrs(f)["ref_test"] = HDF5.Reference(f, "empty_array_of_strings")
-@test read(attrs(f)["ref_test"]) === HDF5.Reference(f, "empty_array_of_strings")
+attributes(f)["ref_test"] = HDF5.Reference(f, "empty_array_of_strings")
+@test read(attributes(f)["ref_test"]) === HDF5.Reference(f, "empty_array_of_strings")
 # Group
-g = g_create(f, "mygroup")
+g = create_group(f, "mygroup")
 # Test dataset with compression
 R = rand(1:20, 20, 40);
 g["CompressedA", chunk=(5, 6), shuffle=(), compress=9] = R
 g["BloscA", chunk=(5, 6), shuffle=(), blosc=9] = R
 close(g)
 # Copy group containing dataset
-o_copy(f, "mygroup", f, "mygroup2")
+copy_object(f, "mygroup", f, "mygroup2")
 # Copy dataset
-g = g_create(f, "mygroup3")
-o_copy(f["mygroup/CompressedA"], g, "CompressedA")
-o_copy(f["mygroup/BloscA"], g, "BloscA")
+g = create_group(f, "mygroup3")
+copy_object(f["mygroup/CompressedA"], g, "CompressedA")
+copy_object(f["mygroup/BloscA"], g, "BloscA")
 close(g)
 # Writing hyperslabs
-dset = d_create(f, "slab", datatype(Float64), dataspace(20, 20, 5), chunk=(5, 5, 1))
+dset = create_dataset(f, "slab", datatype(Float64), dataspace(20, 20, 5), chunk=(5, 5, 1))
 Xslab = randn(20, 20, 5)
 for i = 1:5
     dset[:,:,i] = Xslab[:,:,i]
 end
 # More complex hyperslab and assignment with "incorrect" types (issue #34)
-d = d_create(f, "slab2", datatype(Float64), ((10, 20), (100, 200)), chunk=(1, 1))
+d = create_dataset(f, "slab2", datatype(Float64), ((10, 20), (100, 200)), chunk=(1, 1))
 d[:,:] = 5
 d[1,1] = 4
 # 1d indexing
-d = d_create(f, "slab3", datatype(Int), ((10,), (-1,)), chunk=(5,))
+d = create_dataset(f, "slab3", datatype(Int), ((10,), (-1,)), chunk=(5,))
 @test d[:] == zeros(Int, 10)
 d[3:5] = 3:5
 # Create a dataset designed to be deleted
@@ -201,11 +201,11 @@ Rr5 = read(fr, "mygroup2/BloscA")
 Rr6 = read(fr, "mygroup3/BloscA")
 @test Rr6 == R
 dset = fr["mygroup/CompressedA"]
-@test get_chunk(dset) == (5, 6)
-@test name(dset) == "/mygroup/CompressedA"
+@test HDF5.get_chunk(dset) == (5, 6)
+@test HDF5.name(dset) == "/mygroup/CompressedA"
 dset2 = fr["mygroup/BloscA"]
-@test get_chunk(dset2) == (5, 6)
-@test name(dset2) == "/mygroup/BloscA"
+@test HDF5.get_chunk(dset2) == (5, 6)
+@test HDF5.name(dset2) == "/mygroup/BloscA"
 Xslabr = read(fr, "slab")
 @test Xslabr == Xslab
 Xslabr = h5read(fn, "slab", (:, :, :))  # issue #87
@@ -224,10 +224,10 @@ empty_string_arrayr = read(fr, "empty_string_array")
 @test empty_string_arrayr == empty_string_array
 empty_array_of_stringsr = read(fr, "empty_array_of_strings")
 @test empty_array_of_stringsr == empty_array_of_strings
-@test a_read(fr, "species") == species
-@test a_read(fr, "C∞") == C∞
+@test read_attribute(fr, "species") == species
+@test read_attribute(fr, "C∞") == C∞
 dset = fr["salut"]
-@test a_read(dset, "typeinfo") == label
+@test read_attribute(dset, "typeinfo") == label
 close(dset)
 # Test ref-based reading
 Aref = fr["Afloat64"]
@@ -237,8 +237,8 @@ Asub = Aref[sel...]
 close(Aref)
 # Test iteration, name, and parent
 for obj in fr
-    @test filename(obj) == fn
-    n = name(obj)
+    @test HDF5.filename(obj) == fn
+    n = HDF5.name(obj)
     p = parent(obj)
 end
 # Test reading multiple vars at once
@@ -253,7 +253,7 @@ close(fr)
 # Test object deletion
 fr = h5open(fn, "r+")
 @test haskey(fr, "deleteme")
-o_delete(fr, "deleteme")
+delete_object(fr, "deleteme")
 @test !haskey(fr, "deleteme")
 close(fr)
 
@@ -274,16 +274,16 @@ A = rand(3, 3)'
 @test !haskey(hid, "A")
 @test_throws ArgumentError write(hid, "A", A)
 @test !haskey(hid, "A")
-dset = d_create(hid, "attr", datatype(Int), dataspace(0))
-@test !haskey(attrs(dset), "attr")
+dset = create_dataset(hid, "attr", datatype(Int), dataspace(0))
+@test !haskey(attributes(dset), "attr")
 # broken test - writing attributes does not check that the stride is correct
 @test_skip @test_throws ArgumentError write(dset, "attr", A)
-@test !haskey(attrs(dset), "attr")
+@test !haskey(attributes(dset), "attr")
 close(hid)
 
 # more do syntax
 h5open(fn, "w") do fid
-    g = g_create(fid, "mygroup")
+    g = create_group(fid, "mygroup")
     write(g, "x", 3.2)
 end
 
@@ -301,7 +301,7 @@ outfile = joinpath(tmpdir, "test.h5")
 
 # create a new file
 h5rewrite(outfile) do fid
-    g = g_create(fid, "mygroup")
+    g = create_group(fid, "mygroup")
     write(g, "x", 3.3)
 end
 @test length(readdir(tmpdir)) == 1
@@ -312,7 +312,7 @@ end
 
 # fail to overwrite
 @test_throws ErrorException h5rewrite(outfile) do fid
-    g = g_create(fid, "mygroup")
+    g = create_group(fid, "mygroup")
     write(g, "oops", 3.3)
     error("failed")
 end
@@ -324,7 +324,7 @@ end
 
 # overwrite
 h5rewrite(outfile) do fid
-    g = g_create(fid, "mygroup")
+    g = create_group(fid, "mygroup")
     write(g, "y", 3.3)
 end
 @test length(readdir(tmpdir)) == 1
@@ -343,19 +343,19 @@ d = h5read(joinpath(test_files, "compound.h5"), "/data")
 fn = tempname()
 fd = h5open(fn, "w")
 fd["level_0"] = [1,2,3]
-grp = g_create(fd, "mygroup")
+grp = create_group(fd, "mygroup")
 fd["mygroup/level_1"] = [4, 5]
-grp2 = g_create(grp, "deep_group")
+grp2 = create_group(grp, "deep_group")
 fd["mygroup/deep_group/level_2"] = [6.0, 7.0]
-datasets = get_datasets(fd)
-@test sort(map(name, datasets)) ==  sort(["/level_0", "/mygroup/deep_group/level_2", "/mygroup/level_1"])
+datasets = HDF5.get_datasets(fd)
+@test sort(map(HDF5.name, datasets)) ==  sort(["/level_0", "/mygroup/deep_group/level_2", "/mygroup/level_1"])
 close(fd)
 rm(fn)
 
 # File creation and access property lists
-cpl = p_create(HDF5.H5P_FILE_CREATE)
+cpl = create_property(HDF5.H5P_FILE_CREATE)
 cpl[:userblock] = 1024
-apl = p_create(HDF5.H5P_FILE_ACCESS)
+apl = create_property(HDF5.H5P_FILE_ACCESS)
 apl[:libver_bounds] = (HDF5.H5F_LIBVER_EARLIEST, HDF5.H5F_LIBVER_LATEST)
 fid = HDF5._h5open(fn, false, true, true, true, false, cpl, apl)
 write(fid, "intarray", [1, 2, 3])
@@ -385,7 +385,7 @@ rm(fn)
 if !isempty(HDF5.libhdf5_hl)
     # Test direct chunk writing
     h5open(fn, "w") do f
-      d = d_create(f, "dataset", datatype(Int), dataspace(4, 4), chunk=(2, 2))
+      d = create_dataset(f, "dataset", datatype(Int), dataspace(4, 4), chunk=(2, 2))
       raw = HDF5.ChunkStorage(d)
       raw[1,1] = 0, collect(reinterpret(UInt8, [1,2,5,6]))
       raw[3,1] = 0, collect(reinterpret(UInt8, [3,4,7,8]))
@@ -422,13 +422,13 @@ end # testset plain
   f = h5open(fn, "w")
 
   f["ComplexF64"] = 1.0 + 2.0im
-  attrs(f["ComplexF64"])["ComplexInt64"] = 1im
+  attributes(f["ComplexF64"])["ComplexInt64"] = 1im
 
   Acmplx = rand(ComplexF64, 3, 5)
   write(f, "Acmplx64", convert(Matrix{ComplexF64}, Acmplx))
   write(f, "Acmplx32", convert(Matrix{ComplexF32}, Acmplx))
 
-  dset = d_create(f, "Acmplx64_hyperslab", datatype(Complex{Float64}), dataspace(Acmplx))
+  dset = create_dataset(f, "Acmplx64_hyperslab", datatype(Complex{Float64}), dataspace(Acmplx))
   for i in 1:size(Acmplx, 2)
     dset[:, i] = Acmplx[:,i]
   end
@@ -444,7 +444,7 @@ end # testset plain
   fr = h5open(fn)
   z = read(fr, "ComplexF64")
   @test z == 1.0 + 2.0im && isa(z, ComplexF64)
-  z_attrs = attrs(fr["ComplexF64"])
+  z_attrs = attributes(fr["ComplexF64"])
   @test read(z_attrs["ComplexInt64"]) == 1im
 
   Acmplx32 = read(fr, "Acmplx32")
@@ -633,7 +633,7 @@ write(hfile, "bool_scalar", true)
 fixstring = "fix"
 varstring = "var"
 write(hfile, "fixed_string", fixstring)
-vardset = d_create(hfile, "variable_string", dtype_varstring, dataspace(varstring))
+vardset = create_dataset(hfile, "variable_string", dtype_varstring, dataspace(varstring))
 GC.@preserve varstring begin
     HDF5.h5d_write(vardset, dtype_varstring, HDF5.H5S_ALL, HDF5.H5S_ALL, HDF5.H5P_DEFAULT, [pointer(varstring)])
 end
@@ -688,24 +688,24 @@ fn = tempname()
 hfile = h5open(fn, "w", swmr = true)
 @test sprint(show, hfile) == "HDF5.File: (read-write, swmr) $fn"
 
-group = g_create(hfile, "group")
+group = create_group(hfile, "group")
 @test sprint(show, group) == "HDF5.Group: /group (file: $fn)"
 
-dset = d_create(group, "dset", datatype(Int), dataspace((1,)))
+dset = create_dataset(group, "dset", HDF5.datatype(Int), HDF5.dataspace((1,)))
 @test sprint(show, dset) == "HDF5.Dataset: /group/dset (file: $fn xfer_mode: 0)"
 
-meta = a_create(dset, "meta", datatype(Bool), dataspace((1,)))
+meta = create_attribute(dset, "meta", HDF5.datatype(Bool), HDF5.dataspace((1,)))
 @test sprint(show, meta) == "HDF5.Attribute: meta"
 
-dsetattrs = attrs(dset)
+dsetattrs = attributes(dset)
 @test sprint(show, dsetattrs) == "Attributes of HDF5.Dataset: /group/dset (file: $fn xfer_mode: 0)"
 
-prop = p_create(HDF5.H5P_DATASET_CREATE)
+prop = create_property(HDF5.H5P_DATASET_CREATE)
 @test sprint(show, prop) == "HDF5.Properties: dataset create class"
 
 dtype = HDF5.Datatype(HDF5.h5t_copy(HDF5.H5T_IEEE_F64LE))
 @test sprint(show, dtype) == "HDF5.Datatype: H5T_IEEE_F64LE"
-t_commit(hfile, "type", dtype)
+commit_datatype(hfile, "type", dtype)
 @test sprint(show, dtype) == "HDF5.Datatype: /type H5T_IEEE_F64LE"
 
 dspace = dataspace((1,))
@@ -755,13 +755,13 @@ rm(fn)
 hfile = h5open(fn, "w")
 # file level
 hfile["version"] = 1.0
-attrs(hfile)["creator"] = "HDF5.jl"
+attributes(hfile)["creator"] = "HDF5.jl"
 # group level
-g_create(hfile, "inner")
-attrs(hfile["inner"])["dirty"] = true
+create_group(hfile, "inner")
+attributes(hfile["inner"])["dirty"] = true
 # dataset level
 hfile["inner/data"] = collect(-5:5)
-attrs(hfile["inner/data"])["mode"] = 1
+attributes(hfile["inner/data"])["mode"] = 1
 # non-trivial committed datatype
 # TODO: print more datatype information
 tmeta = HDF5.Datatype(HDF5.h5t_create(HDF5.H5T_COMPOUND, sizeof(Int) + sizeof(Float64)))
@@ -771,7 +771,7 @@ tstr = datatype("fixed")
 t = HDF5.Datatype(HDF5.h5t_create(HDF5.H5T_COMPOUND, sizeof(tmeta) + sizeof(tstr)))
 HDF5.h5t_insert(t, "meta", 0, tmeta)
 HDF5.h5t_insert(t, "type", sizeof(tmeta), tstr)
-HDF5.t_commit(hfile, "dtype", t)
+commit_datatype(hfile, "dtype", t)
 
 buf = IOBuffer()
 show3(io::IO, x) = show(io, MIME"text/plain"(), x)
@@ -797,12 +797,12 @@ HDF5.show_tree(buf, hfile, attributes = false)
 │  └─ 🔢 data
 └─ 🔢 version"""m, String(take!(buf)))
 
-HDF5.show_tree(buf, attrs(hfile))
+HDF5.show_tree(buf, attributes(hfile))
 msg = String(take!(buf))
 @test occursin(r"""
 🗂️ Attributes of HDF5.File: .*$
 └─ 🏷️ creator"""m, msg)
-@test sprint(show3, attrs(hfile)) == msg
+@test sprint(show3, attributes(hfile)) == msg
 
 HDF5.show_tree(buf, hfile["inner"])
 msg = String(take!(buf))
@@ -896,28 +896,28 @@ end # split1 tests
 fn = tempname()
 hfile = h5open(fn, "w")
 
-group1 = g_create(hfile, "group1")
-group2 = g_create(group1, "group2")
+group1 = create_group(hfile, "group1")
+group2 = create_group(group1, "group2")
 
 @test haskey(hfile, GenericString("group1"))
 @test !haskey(hfile, GenericString("groupna"))
 @test haskey(hfile, "group1/group2")
 @test !haskey(hfile, "group1/groupna")
 
-dset1 = d_create(hfile, "dset1", datatype(Int), dataspace((1,)))
-dset2 = d_create(group1, "dset2", datatype(Int), dataspace((1,)))
+dset1 = create_dataset(hfile, "dset1", datatype(Int), dataspace((1,)))
+dset2 = create_dataset(group1, "dset2", datatype(Int), dataspace((1,)))
 
 @test haskey(hfile, "dset1")
 @test !haskey(hfile, "dsetna")
 @test haskey(hfile, "group1/dset2")
 @test !haskey(hfile, "group1/dsetna")
 
-meta1 = a_create(dset1, "meta1", datatype(Bool), dataspace((1,)))
+meta1 = create_attribute(dset1, "meta1", datatype(Bool), dataspace((1,)))
 @test haskey(dset1, "meta1")
 @test !haskey(dset1, "metana")
 
 
-attribs = attrs(hfile)
+attribs = attributes(hfile)
 attribs["test1"] = true
 attribs["test2"] = "foo"
 
@@ -925,7 +925,7 @@ haskey(attribs, "test1")
 haskey(attribs, "test2")
 !haskey(attribs, "testna")
 
-attribs = attrs(dset2)
+attribs = attributes(dset2)
 attribs["attr"] = "foo"
 haskey(attribs, GenericString("attr"))
 
@@ -942,64 +942,64 @@ close(hfile)
 hfile = h5open(fn); close(hfile)
 hfile = h5open(fn, "w")
 
-@test_nowarn g_create(hfile, GenericString("group1"))
-@test_nowarn d_create(hfile, GenericString("dset1"), datatype(Int), dataspace((1,)))
-@test_nowarn d_create(hfile, GenericString("dset2"), 1)
+@test_nowarn create_group(hfile, GenericString("group1"))
+@test_nowarn create_dataset(hfile, GenericString("dset1"), datatype(Int), dataspace((1,)))
+@test_nowarn create_dataset(hfile, GenericString("dset2"), 1)
 
 @test_nowarn hfile[GenericString("group1")]
 @test_nowarn hfile[GenericString("dset1")]
 
 
 dset1 = hfile["dset1"]
-@test_nowarn a_create(dset1, GenericString("meta1"), datatype(Bool), dataspace((1,)))
-@test_nowarn a_create(dset1, GenericString("meta2"), 1)
+@test_nowarn create_attribute(dset1, GenericString("meta1"), datatype(Bool), dataspace((1,)))
+@test_nowarn create_attribute(dset1, GenericString("meta2"), 1)
 @test_nowarn dset1[GenericString("meta1")]
 @test_nowarn dset1[GenericString("x")] = 2
 
 array_of_strings = ["test",]
 write(hfile, "array_of_strings", array_of_strings)
-@test_nowarn attrs(hfile)[GenericString("ref_test")] = HDF5.Reference(hfile, GenericString("array_of_strings"))
-@test read(attrs(hfile)[GenericString("ref_test")]) === HDF5.Reference(hfile, "array_of_strings")
+@test_nowarn attributes(hfile)[GenericString("ref_test")] = HDF5.Reference(hfile, GenericString("array_of_strings"))
+@test read(attributes(hfile)[GenericString("ref_test")]) === HDF5.Reference(hfile, "array_of_strings")
 
 hfile[GenericString("test")] = 17.2
-@test_nowarn o_delete(hfile, GenericString("test"))
-@test_nowarn a_delete(dset1, GenericString("meta1"))
+@test_nowarn delete_object(hfile, GenericString("test"))
+@test_nowarn delete_attribute(dset1, GenericString("meta1"))
 
 # transient types
 memtype_id = HDF5.h5t_copy(HDF5.H5T_NATIVE_DOUBLE)
 dt = HDF5.Datatype(memtype_id)
 @test !HDF5.h5t_committed(dt)
-t_commit(hfile, GenericString("dt"), dt)
+HDF5.commit_datatype(hfile, GenericString("dt"), dt)
 @test HDF5.h5t_committed(dt)
 
 dt = datatype(Int)
 ds = dataspace(0)
-d = d_create(hfile, GenericString("d"), dt, ds)
-g = g_create(hfile, GenericString("g"))
-a = a_create(hfile, GenericString("a"), dt, ds)
+d = create_dataset(hfile, GenericString("d"), dt, ds)
+g = create_group(hfile, GenericString("g"))
+a = create_attribute(hfile, GenericString("a"), dt, ds)
 
 for obj in (d, g)
-   @test_nowarn a_write(obj, GenericString("a"), 1)
-   @test_nowarn a_read(obj, GenericString("a"))
+   @test_nowarn write_attribute(obj, GenericString("a"), 1)
+   @test_nowarn read_attribute(obj, GenericString("a"))
    @test_nowarn write(obj, GenericString("aa"), 1)
-   @test_nowarn attrs(obj)["attr1"] = GenericString("b")
+   @test_nowarn attributes(obj)["attr1"] = GenericString("b")
 end
 @test_nowarn write(d, "attr2", GenericString("c"))
-@test_nowarn d_write(g, GenericString("ag"), GenericString("gg"))
-@test_nowarn d_write(g, GenericString("ag_array"), [GenericString("a1"), GenericString("a2")])
+@test_nowarn write_dataset(g, GenericString("ag"), GenericString("gg"))
+@test_nowarn write_dataset(g, GenericString("ag_array"), [GenericString("a1"), GenericString("a2")])
 
 genstrs = GenericString["fee", "fi", "foo"]
-@test_nowarn a_write(d, GenericString("myattr"), genstrs)
+@test_nowarn write_attribute(d, GenericString("myattr"), genstrs)
 @test genstrs == read(d["myattr"])
 
 for obj in (hfile,)
-    @test_nowarn d_open(obj, GenericString("d"))
-    @test_nowarn d_write(obj, GenericString("dd"), 1)
-    @test_nowarn d_read(obj, GenericString("dd"))
+    @test_nowarn open_dataset(obj, GenericString("d"))
+    @test_nowarn write_dataset(obj, GenericString("dd"), 1)
+    @test_nowarn read_dataset(obj, GenericString("dd"))
     @test_nowarn read(obj, GenericString("dd"))
     @test_nowarn read(obj, GenericString("dd")=>Int)
 end
-read(attrs(hfile), GenericString("a"))
+read(attributes(hfile), GenericString("a"))
 
 write(hfile, GenericString("ASD"), GenericString("Aa"))
 write(g, GenericString("ASD"), GenericString("Aa"))
@@ -1009,10 +1009,10 @@ write(g, GenericString("ASD1"), [GenericString("Aa")])
 @test_nowarn write(hfile, GenericString("a1"), rand(2,2), GenericString("a2"), rand(2,2))
 
 # copy methods
-d1 = d_create(hfile, GenericString("d1"), dt, ds)
+d1 = create_dataset(hfile, GenericString("d1"), dt, ds)
 d1["x"] = 32
-@test_nowarn o_copy(hfile, GenericString("d1"), hfile, GenericString("d1copy1"))
-@test_nowarn o_copy(d1, hfile, GenericString("d1copy2"))
+@test_nowarn copy_object(hfile, GenericString("d1"), hfile, GenericString("d1copy1"))
+@test_nowarn copy_object(d1, hfile, GenericString("d1copy2"))
 
 fn = GenericString(tempname())
 A = Matrix(reshape(1:120, 15, 8))
@@ -1025,11 +1025,11 @@ A = Matrix(reshape(1:120, 15, 8))
 
 
 @test_nowarn h5rewrite(fn) do fid
-    g = g_create(fid, "mygroup")
+    g = create_group(fid, "mygroup")
     write(g, "x", 3.3)
 end
 @test_nowarn h5rewrite(fn) do fid
-    g = g_create(fid, "mygroup")
+    g = create_group(fid, "mygroup")
     write(g, "y", 3.3)
 end
 
@@ -1038,7 +1038,7 @@ end
 @test_nowarn h5readattr(fn, GenericString("W"))
 
 fn_external = GenericString(tempname())
-dset = d_create_external(hfile, "ext", fn_external, Int, (10,20))
+dset = HDF5.create_external_dataset(hfile, "ext", fn_external, Int, (10,20))
 
 end
 

--- a/test/properties.jl
+++ b/test/properties.jl
@@ -10,20 +10,20 @@ h5open(fn, "w";
        libver_bounds = (HDF5.H5F_LIBVER_EARLIEST, HDF5.H5F_LIBVER_LATEST),
       ) do hfile
     # generic
-    g = g_create(hfile, "group")
-    d = d_create(g, "dataset", datatype(Int), dataspace((500,500)),
+    g = create_group(hfile, "group")
+    d = create_dataset(g, "dataset", datatype(Int), dataspace((500,500)),
                  alloc_time = HDF5.H5D_ALLOC_TIME_EARLY,
                  chunk = (5, 10),
                  track_times = false)
-    attrs(d)["metadata"] = "test"
+    attributes(d)["metadata"] = "test"
 
     flush(hfile)
 
-    fcpl = get_create_properties(hfile)
-    fapl = get_access_properties(hfile)
-    gcpl = get_create_properties(hfile["group"])
-    dcpl = get_create_properties(hfile["group/dataset"])
-    acpl = get_create_properties(attrs(hfile["group/dataset"])["metadata"])
+    fcpl = HDF5.get_create_properties(hfile)
+    fapl = HDF5.get_access_properties(hfile)
+    gcpl = HDF5.get_create_properties(hfile["group"])
+    dcpl = HDF5.get_create_properties(hfile["group/dataset"])
+    acpl = HDF5.get_create_properties(attributes(hfile["group/dataset"])["metadata"])
 
     # Retrievability of properties
     @test isvalid(fcpl)

--- a/test/readremote.jl
+++ b/test/readremote.jl
@@ -66,7 +66,7 @@ AA = Array{Int,2}[
 file = joinpath(test_files, "h5ex_t_floatatt.h5")
 fid = h5open(file, "r")
 dset = fid["DS1"]
-a = a_read(dset, "A1")
+a = read_attribute(dset, "A1")
 @test norm(a - fcmp) < 1.5e-5
 close(fid)
 
@@ -79,7 +79,7 @@ close(fid)
 file = joinpath(test_files, "h5ex_t_intatt.h5")
 fid = h5open(file, "r")
 dset = fid["DS1"]
-a = a_read(dset, "A1")
+a = read_attribute(dset, "A1")
 @test a == icmp
 close(fid)
 
@@ -93,7 +93,7 @@ if HDF5.h5_get_libversion() >= v"1.8.11"
   file = joinpath(test_files, "h5ex_t_enumatt.h5")
   fid = h5open(file, "r")
   dset = fid["DS1"]
-  a = a_read(dset, "A1")
+  a = read_attribute(dset, "A1")
   @test a == ecmp
   close(fid)
 
@@ -107,7 +107,7 @@ end
 file = joinpath(test_files, "h5ex_t_objrefatt.h5")
 fid = h5open(file, "r")
 dset = fid["DS1"]
-a = a_read(dset, "A1")
+a = read_attribute(dset, "A1")
 g = fid[a[1]]
 @test isa(g, HDF5.Group)
 ds2 = fid[a[2]]
@@ -130,7 +130,7 @@ close(fid)
 file = joinpath(test_files, "h5ex_t_stringatt.h5")
 fid = h5open(file, "r")
 dset = fid["DS1"]
-a = a_read(dset, "A1")
+a = read_attribute(dset, "A1")
 @test a == scmp
 close(fid)
 
@@ -143,7 +143,7 @@ close(fid)
 file = joinpath(test_files, "h5ex_t_vlenatt.h5")
 fid = h5open(file, "r")
 dset = fid["DS1"]
-a = a_read(dset, "A1")
+a = read_attribute(dset, "A1")
 @test a == vicmp
 close(fid)
 
@@ -156,7 +156,7 @@ close(fid)
 file = joinpath(test_files, "h5ex_t_vlstringatt.h5")
 fid = h5open(file, "r")
 dset = fid["DS1"]
-a = a_read(dset, "A1")
+a = read_attribute(dset, "A1")
 @test a == scmp
 close(fid)
 
@@ -169,7 +169,7 @@ close(fid)
 file = joinpath(test_files, "h5ex_t_opaqueatt.h5")
 fid = h5open(file, "r")
 dset = fid["DS1"]
-a = a_read(dset, "A1")
+a = read_attribute(dset, "A1")
 @test a.tag == "Character array"
 @test a.data == opq
 close(fid)

--- a/test/reference.jl
+++ b/test/reference.jl
@@ -12,7 +12,7 @@ using Random, Test, HDF5
     # reference attached to file
     f["file_ref"] = HDF5.Reference(f, "data")
     # reference attached to group
-    g = g_create(f, "sub")
+    g = create_group(f, "sub")
     g["group_ref"] = HDF5.Reference(f, "group_data")
     # reference attached to dataset
     f["data"]["attr_ref"] = HDF5.Reference(f, "attr_data")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,5 +25,5 @@ try
     include("mpio.jl")
 catch
 end
-    
+
 end

--- a/test/swmr.jl
+++ b/test/swmr.jl
@@ -26,8 +26,8 @@ end
 
 @testset "h5d_oappend" begin
     h5open(fname, "w") do h5
-        g = g_create(h5, "shoe")
-        d = d_create(g, "bar", datatype(Float64), ((1,), (-1,)), chunk=(100,))
+        g = create_group(h5, "shoe")
+        d = create_dataset(g, "bar", datatype(Float64), ((1,), (-1,)), chunk=(100,))
         dxpl_id = HDF5.get_create_properties(d)
         v = [1.0, 2.0]
         memtype = datatype(Float64).id
@@ -38,7 +38,7 @@ end
 function dataset_write(d, ch_written, ch_read)
     for i = 1:10
         @assert take!(ch_read) == true
-        set_dims!(d, (i*10,))
+        HDF5.set_dims!(d, (i*10,))
         inds::UnitRange{Int} = (1:10) .+ (i - 1) * 10
         d[inds] = inds
         flush(d) # flush the dataset
@@ -89,9 +89,9 @@ end
 
 # create datasets and attributes before staring swmr writing
 function prep_h5_file(h5)
-    d = d_create(h5, "foo", datatype(Int), ((1,), (100,)), chunk=(1,))
-    attrs(h5)["bar"] = "bar"
-    g = g_create(h5, "group")
+    d = create_dataset(h5, "foo", datatype(Int), ((1,), (100,)), chunk=(1,))
+    attributes(h5)["bar"] = "bar"
+    g = create_group(h5, "group")
 end
 
 @testset "create by libver, then start_swmr_write" begin


### PR DESCRIPTION
Rename public functions and stop exporting most public API

Open to re-exporting API people think should be exported.