### PR TITLE
Fix deprecation of names()

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -219,7 +219,8 @@ end
 @deprecate_binding HDF5BitsKind BitsType false
 
 ### Changed in PR#695
-@deprecate names(x::Union{Group,File,Attributes}) keys(x)
+import Base: names
+@deprecate names(x::Union{Group,File,Attributes}) keys(x) false
 
 ### Changed in PR#694
 @deprecate has(parent::Union{File,Group,Dataset}, path::String) Base.haskey(parent, path)


### PR DESCRIPTION
In deprecating this function, the import of `Base.names` was removed,
and then this deprecation was exported. That adds a new, independent
function which conflicts with `Base.names`:
```
$ julia-dev --project -e 'using HDF5; @show methods(names)'
WARNING: both HDF5 and Base export "names"; uses of it in module Main must be qualified
ERROR: UndefVarError: names not defined
Stacktrace:
 [1] top-level scope
   @ show.jl:895
```

We therefore must import the binding before deprecating it. With this
commit:
```
$ julia-dev --project --depwarn=yes
...
julia> using HDF5

julia> @show methods(names)
methods(names) = # 2 methods for generic function "names":
[1] names(m::Module; all, imported) in Base at reflection.jl:98
[2] names(x::Union{HDF5.Attributes, HDF5.File, HDF5.Group}) in HDF5 at deprecated.jl:70

julia> fid = h5open("/tmp/test.h5", "w")
HDF5 data file: /tmp/test.h5

julia> names(fid)
┌ Warning: `names(x::Union{Group, File, Attributes})` is deprecated, use `keys(x)` instead.
│   caller = top-level scope at REPL[3]:1
└ @ Core REPL[3]:1
String[]
```