### PR TITLE
Fix #705, distinguishing 0-size and null arrays

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -218,6 +218,29 @@ By default `Complex` numbers are stored as compound types with `r` and `i` field
 When reading data, compound types with matching field names will be loaded as the corresponding `Complex` julia type.
 These field names are configurable with the `HDF5.set_complex_field_names(real::AbstractString, imag::AbstractString)` function and complex support can be completely enabled/disabled with `HDF5.enable/disable_complex_support()`.
 
+For `Array`s, note that the array dimensionality is preserved, including 0-length
+dimensions:
+```julia
+fid["zero_vector"] = zeros(0)
+fid["zero_matrix"] = zeros(0, 0)
+size(fid["zero_vector"]) # == (0,)
+size(fid["zero_matrix"]) # == (0, 0)
+```
+An _exception_ to this rule is Julia's 0-dimensional `Array`, which is stored as an HDF5
+scalar because there is a value to be preserved:
+```julia
+fid["zero_dim_value"] = fill(1.0π)
+read(fid["zero_dim_value"]) # == 3.141592653589793, != [3.141592653589793]
+```
+HDF5 also has the concept of a null array which contains a type but has neither size nor
+contents, which is represented by the type `HDF5.EmptyArray`:
+```julia
+fid["empty_array"] = HDF5.EmptyArray{Float32}()
+HDF5.isnull(fid["empty_array"]) # == true
+size(fid["empty_array"]) # == ()
+eltype(fid["empty_array"]) # == Float32
+```
+
 This module also supports HDF5's VLEN, OPAQUE, and REFERENCE types, which can be used to encode more complex types. In general, you need to specify how you want to combine these more advanced facilities to represent more complex data types. For many of the data types in Julia, the JLD module implements support. You can likewise define your own file format if, for example, you need to interact with some external program that has explicit formatting requirements.
 
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -317,6 +317,10 @@ Base.length(::EmptyArray) = 0
 # Required to avoid indexing during printing
 Base.show(io::IO, E::EmptyArray) = print(io, typeof(E), "()")
 Base.show(io::IO, ::MIME"text/plain", E::EmptyArray) = show(io, E)
+# FIXME: Concatenation doesn't work for this type (it's treated as a length-1 array like
+# Base's 0-dimensional arrays), so just forceably abort.
+Base.cat_size(::EmptyArray) = error("concatenation of HDF5.EmptyArray is unsupported")
+Base.cat_size(::EmptyArray, d) = error("concatenation of HDF5.EmptyArray is unsupported")
 
 # Stub types to encode fixed-size arrays for H5T_ARRAY
 struct FixedArray{T,D,L}

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -590,6 +590,12 @@ azeromat2 = dzeromat2["attr"]
 @test !HDF5.isnull(azerodim)
 @test read(azerodim) == 1.0ℯ
 
+# Concatenation of EmptyArrays is not supported
+x = HDF5.EmptyArray{Float64}()
+@test_throws ErrorException [x x]
+@test_throws ErrorException [x; x]
+@test_throws ErrorException [x x; x x]
+
 close(hfile)
 rm(fn)
 

--- a/test/readremote.jl
+++ b/test/readremote.jl
@@ -112,7 +112,7 @@ g = fid[a[1]]
 @test isa(g, HDF5.Group)
 ds2 = fid[a[2]]
 ds2v = read(ds2)
-@test isa(ds2v, Array{Int32})
+@test isa(ds2v, HDF5.EmptyArray{Int32})
 @test isempty(ds2v)
 close(fid)
 
@@ -123,7 +123,7 @@ g = fid[d[1]]
 @test isa(g, HDF5.Group)
 ds2 = fid[d[2]]
 ds2v = read(ds2)
-@test isa(ds2v, Array{Int32})
+@test isa(ds2v, HDF5.EmptyArray{Int32})
 @test isempty(ds2v)
 close(fid)
 


### PR DESCRIPTION
HDF5 has the concept of NULL arrays which are distinct from 0-size arrays. As shown in #705, writing any 0-size array was being translated to the NULL object during writing, but having 0-length axes is also perfectly valid. This PR preserves 0-sizes when writing arrays.

To represent the HDF5 NULL object, there was already the `HDF5.EmptyArray` type defined, but it appears to have been used only for internal dispatch on the generic read (which then returns a 0-length vector for NULL objects).

This PR reuses `HDF5.EmptyArray` and elevates it to a full subtype of `AbstractArray`, which then becomes the returned object for any NULL datasets/attributes which are read in. This array type carries an element type but has no contents. This is distinct from Julia's `Array{T,0}` 0-dimensional arrays because the latter _does_ have a single element. (I tried just doing duck typing instead of actually making it a subtype of `AbstractArray`, but you end up playing whack-a-mole with enough new method definitions that you might as well just implement the `AbstractArray` interface and take advantage of its fallbacks once the few methods are defined.)

Surprisingly, both MAT and JLD don't require any changes to handle this PR (beyond the deprecation-fixing private branches I've been maintaining...), so it appears this case is generally unused — only a couple of test cases in this package required fixes.

(One oddity is that Julia's 0-dimensional `Arrays` are turned into HDF5 scalars and will not be read back in as a 0-dimensional array, but (a) that is the existing behavior, and (b) I haven't thought of any other way to handle the case.)