### PR TITLE
Fix #618, treat create-write operation as transaction

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1425,6 +1425,9 @@ function d_write(parent::Union{File,Group}, name::String, data; pv...)
     obj, dtype = d_create(parent, name, data; pv...)
     try
         writearray(obj, dtype.id, data)
+    catch exc
+        o_delete(obj)
+        rethrow(exc)
     finally
         close(obj)
         close(dtype)
@@ -1435,6 +1438,9 @@ function a_write(parent::Union{File,Object}, name::String, data; pv...)
     obj, dtype = a_create(parent, name, data; pv...)
     try
         writearray(obj, dtype.id, data)
+    catch exc
+        o_delete(obj)
+        rethrow(exc)
     finally
         close(obj)
         close(dtype)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -112,6 +112,9 @@ for (fsym, ptype) in ((:d_write, Union{File,Group}),
             obj = ($crsym)(parent, name, dtype, dataspace(data), plists...)
             try
                 writearray(obj, dtype.id, data)
+            catch exc
+                o_delete(obj)
+                rethrow(exc)
             finally
                 close(obj)
                 close(dtype)
@@ -130,6 +133,9 @@ function write(parent::Union{File,Group}, name::String, data::Union{T,AbstractAr
     obj = __d_create(parent, name, dtype, dataspace(data), plists...)
     try
         writearray(obj, dtype.id, data)
+    catch exc
+        o_delete(obj)
+        rethrow(exc)
     finally
         close(obj)
         close(dtype)
@@ -146,6 +152,9 @@ function write(parent::Dataset, name::String, data::Union{T,AbstractArray{T}},
     obj = __a_create(parent, name, dtype, dataspace(data), plists...)
     try
         writearray(obj, dtype.id, data)
+    catch exc
+        o_delete(obj)
+        rethrow(exc)
     finally
         close(obj)
         close(dtype)


### PR DESCRIPTION
On a failed write that implicitly creates a new dataset/attribute,
delete the just-created object before continuing.

This makes following-up after an interactive error much more
ergonomic.