### PR TITLE
Improve  interface to permit AbstractString

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1363,7 +1363,7 @@ function readmmap(obj::Dataset)
 end
 
 # Generic write
-function write(parent::Union{File,Group}, name1::String, val1, name2::String, val2, nameval...)
+function write(parent::Union{File,Group}, name1::AbstractString, val1, name2::AbstractString, val2, nameval...) # FIXME: remove?
     if !iseven(length(nameval))
         error("name, value arguments must come in pairs")
     end
@@ -1371,7 +1371,7 @@ function write(parent::Union{File,Group}, name1::String, val1, name2::String, va
     write(parent, name2, val2)
     for i = 1:2:length(nameval)
         thisname = nameval[i]
-        if !isa(thisname, String)
+        if !isa(thisname, AbstractString)
             error("Argument ", i+5, " should be a string, but it's a ", typeof(thisname))
         end
         write(parent, thisname, nameval[i+1])

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1384,7 +1384,7 @@ end
 # Create datasets and attributes with "native" types, but don't write the data.
 # The return syntax is: dset, dtype = d_create(parent, name, data; properties...)
 
-function d_create(parent::Union{File,Group}, name::String, data; pv...)
+function d_create(parent::Union{File,Group}, name::AbstractString, data; pv...)
     dtype = datatype(data)
     dspace = dataspace(data)
     obj = try
@@ -1394,7 +1394,7 @@ function d_create(parent::Union{File,Group}, name::String, data; pv...)
     end
     return obj, dtype
 end
-function a_create(parent::Union{File,Object}, name::String, data; pv...)
+function a_create(parent::Union{File,Object}, name::AbstractString, data; pv...)
     dtype = datatype(data)
     dspace = dataspace(data)
     obj = try

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -651,9 +651,9 @@ flush(f::Union{Object,Attribute,Datatype,File}, scope = H5F_SCOPE_GLOBAL) = h5f_
 
 # Open objects
 g_open(parent::Union{File,Group}, name::AbstractString, apl::Properties=DEFAULT_PROPERTIES) = Group(h5g_open(checkvalid(parent).id, name, apl.id), file(parent))
-d_open(parent::Union{File,Group}, name::String, apl::Properties=DEFAULT_PROPERTIES, xpl::Properties=DEFAULT_PROPERTIES) = Dataset(h5d_open(checkvalid(parent).id, name, apl.id), file(parent), xpl)
-t_open(parent::Union{File,Group}, name::String, apl::Properties=DEFAULT_PROPERTIES) = Datatype(h5t_open(checkvalid(parent).id, name, apl.id), file(parent))
-a_open(parent::Union{File,Object}, name::String) = Attribute(h5a_open(checkvalid(parent).id, name, H5P_DEFAULT), file(parent))
+d_open(parent::Union{File,Group}, name::AbstractString, apl::Properties=DEFAULT_PROPERTIES, xpl::Properties=DEFAULT_PROPERTIES) = Dataset(h5d_open(checkvalid(parent), name, apl), file(parent), xpl)
+t_open(parent::Union{File,Group}, name::AbstractString, apl::Properties=DEFAULT_PROPERTIES) = Datatype(h5t_open(checkvalid(parent), name, apl), file(parent))
+a_open(parent::Union{File,Object}, name::AbstractString, apl::Properties=DEFAULT_PROPERTIES) = Attribute(h5a_open(checkvalid(parent), name, apl), file(parent))
 # Object (group, named datatype, or dataset) open
 function h5object(obj_id::hid_t, parent)
     obj_type = h5i_get_type(obj_id)
@@ -674,7 +674,7 @@ root(h5file::File) = g_open(h5file, "/")
 root(obj::Union{Group,Dataset}) = g_open(file(obj), "/")
 # getindex syntax: obj2 = obj1[path]
 #getindex(parent::Union{HDF5File, HDF5Group}, path::String) = o_open(parent, path)
-getindex(dset::Dataset, name::String) = a_open(dset, name)
+getindex(dset::Dataset, name::AbstractString) = a_open(dset, name)
 getindex(x::Attributes, name::String) = a_open(x.parent, name)
 
 function getindex(parent::Union{File,Group}, path::AbstractString; pv...)
@@ -1777,7 +1777,7 @@ function h5a_write(attr_id::hid_t, memtype_id::hid_t, v::VLen{T}) where {T<:Unio
     h5a_write(attr_id, memtype_id, vp)
 end
 h5a_create(loc_id, name, type_id, space_id) = h5a_create(loc_id, name, type_id, space_id, _attr_properties(name), H5P_DEFAULT)
-h5a_open(obj_id::hid_t, name::String) = h5a_open(obj_id, name, H5P_DEFAULT)
+h5a_open(obj_id, name) = h5a_open(obj_id, name, H5P_DEFAULT)
 h5d_create(loc_id, name, type_id, space_id) = h5d_create(loc_id, name, type_id, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)
 h5d_open(obj_id::hid_t, name::String) = h5d_open(obj_id, name, H5P_DEFAULT)
 function h5d_read(dataset_id::hid_t, memtype_id::hid_t, buf::AbstractArray, xfer::hid_t=H5P_DEFAULT)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -287,9 +287,9 @@ end
 attrs(p::Union{File,Group,Dataset}) = Attributes(p)
 
 # Methods for reference types
-function Reference(parent::Union{File,Group,Dataset}, name::String)
+function Reference(parent::Union{File,Group,Dataset}, name::AbstractString)
     ref = Ref{hobj_ref_t}()
-    h5r_create(ref, checkvalid(parent).id, name, H5R_OBJECT, -1)
+    h5r_create(ref, checkvalid(parent), name, H5R_OBJECT, -1)
     return Reference(ref[])
 end
 ==(a::Reference, b::Reference) = a.r == b.r
@@ -410,7 +410,7 @@ function h5open(filename::AbstractString, rd::Bool, wr::Bool, cr::Bool, tr::Bool
     end
     if cr && (tr || !isfile(filename))
         flag = swmr ? H5F_ACC_TRUNC|H5F_ACC_SWMR_WRITE : H5F_ACC_TRUNC
-        fid = h5f_create(filename, flag, cpl.id, apl.id)
+        fid = h5f_create(filename, flag, cpl, apl)
     else
         if !h5f_is_hdf5(filename)
             error("This does not appear to be an HDF5 file")
@@ -675,7 +675,7 @@ root(obj::Union{Group,Dataset}) = g_open(file(obj), "/")
 # getindex syntax: obj2 = obj1[path]
 #getindex(parent::Union{HDF5File, HDF5Group}, path::String) = o_open(parent, path)
 getindex(dset::Dataset, name::AbstractString) = a_open(dset, name)
-getindex(x::Attributes, name::String) = a_open(x.parent, name)
+getindex(x::Attributes, name::AbstractString) = a_open(x.parent, name)
 
 function getindex(parent::Union{File,Group}, path::AbstractString; pv...)
     objtype = gettype(parent, path)
@@ -875,7 +875,7 @@ o_copy(src_obj::Object, dst_parent::Union{File,Group}, dst_path::String) = h5o_c
 # Assign syntax: obj[path] = value
 # Creates a dataset unless obj is a dataset, in which case it creates an attribute
 setindex!(dset::Dataset, val, name::String) = a_write(dset, name, val)
-setindex!(x::Attributes, val, name::String) = a_write(x.parent, name, val)
+setindex!(x::Attributes, val, name::AbstractString) = a_write(x.parent, name, val)
 # Getting and setting properties: p[:chunk] = dims, p[:compress] = 6
 getindex(p::Properties, name::Symbol) = _prop_get(checkvalid(p), name)
 function setindex!(p::Properties, val, name::Symbol)
@@ -1803,7 +1803,7 @@ function h5d_write(dataset_id::hid_t, memtype_id::hid_t, v::VLen{T}, xfer::hid_t
     vp = vlenpack(v)
     h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, xfer, vp)
 end
-h5f_create(filename::String) = h5f_create(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)
+h5f_create(filename) = h5f_create(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)
 h5f_open(filename::String, mode) = h5f_open(filename, mode, H5P_DEFAULT)
 h5g_create(obj_id, name) = h5g_create(obj_id, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)
 h5g_create(obj_id, name, lcpl_id, gcpl_id) = h5g_create(obj_id, name, lcpl_id, gcpl_id, H5P_DEFAULT)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -527,7 +527,7 @@ function h5read(filename, name_type_pair::Pair{<:AbstractString,DataType}; pv...
     dat
 end
 
-function h5read(filename, name::String, indices::Tuple{Vararg{Union{AbstractRange{Int},Int,Colon}}}; pv...)
+function h5read(filename, name::AbstractString, indices::Tuple{Vararg{Union{AbstractRange{Int},Int,Colon}}}; pv...)
     local dat
     fid = h5open(filename, "r"; pv...)
     try

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -873,7 +873,7 @@ o_copy(src_obj::Object, dst_parent::Union{File,Group}, dst_path::String) = h5o_c
 
 # Assign syntax: obj[path] = value
 # Creates a dataset unless obj is a dataset, in which case it creates an attribute
-setindex!(dset::Dataset, val, name::String) = a_write(dset, name, val)
+setindex!(dset::Dataset, val, name::AbstractString) = (@show "NO"; a_write(dset, name, val))
 setindex!(x::Attributes, val, name::AbstractString) = a_write(x.parent, name, val)
 # Getting and setting properties: p[:chunk] = dims, p[:compress] = 6
 getindex(p::Properties, name::Symbol) = _prop_get(checkvalid(p), name)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -494,7 +494,7 @@ function h5rewrite(f::Function, filename::AbstractString, args...)
     end
 end
 
-function h5write(filename, name::String, data; pv...)
+function h5write(filename, name::AbstractString, data; pv...)
     fid = h5open(filename, "cw"; pv...)
     try
         write(fid, name, data)
@@ -503,7 +503,7 @@ function h5write(filename, name::String, data; pv...)
     end
 end
 
-function h5read(filename, name::String; pv...)
+function h5read(filename, name::AbstractString; pv...)
     local dat
     fid = h5open(filename, "r"; pv...)
     try
@@ -515,7 +515,7 @@ function h5read(filename, name::String; pv...)
     dat
 end
 
-function h5read(filename, name_type_pair::Pair{String,DataType}; pv...)
+function h5read(filename, name_type_pair::Pair{<:AbstractString,DataType}; pv...)
     local dat
     fid = h5open(filename, "r"; pv...)
     try

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -882,7 +882,7 @@ function setindex!(p::Properties, val, name::Symbol)
     return p
 end
 # Create a dataset with properties: obj[path, prop = val, ...] = val
-function setindex!(parent::Union{File,Group}, val, path::String; pv...)
+function setindex!(parent::Union{File,Group}, val, path::AbstractString; pv...)
     need_chunks = any(k in keys(chunked_props) for k in keys(pv))
     have_chunks = any(k == :chunk for k in keys(pv))
 
@@ -1287,7 +1287,7 @@ do_reclaim(::Type{T}) where {T} = false
 do_reclaim(::Type{NamedTuple{T,U}}) where {U,T} = any(i -> do_reclaim(fieldtype(U,i)), 1:fieldcount(U))
 do_reclaim(::Type{T}) where T <: Union{Cstring,VariableArray} = true
 
-read(attr::Attributes, name::String) = a_read(attr.parent, name)
+read(attr::Attributes, name::AbstractString) = a_read(attr.parent, name)
 
 # Reading with mmap
 function iscontiguous(obj::Dataset)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -420,7 +420,7 @@ function h5open(filename::AbstractString, rd::Bool, wr::Bool, cr::Bool, tr::Bool
         else
             flag = swmr ? H5F_ACC_RDONLY|H5F_ACC_SWMR_READ : H5F_ACC_RDONLY
         end
-        fid = h5f_open(filename, flag, apl.id)
+        fid = h5f_open(filename, flag, apl)
     end
     if close_apl
         # Close properties manually to avoid errors when the file is
@@ -1778,7 +1778,7 @@ end
 h5a_create(loc_id, name, type_id, space_id) = h5a_create(loc_id, name, type_id, space_id, _attr_properties(name), H5P_DEFAULT)
 h5a_open(obj_id, name) = h5a_open(obj_id, name, H5P_DEFAULT)
 h5d_create(loc_id, name, type_id, space_id) = h5d_create(loc_id, name, type_id, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)
-h5d_open(obj_id::hid_t, name::String) = h5d_open(obj_id, name, H5P_DEFAULT)
+h5d_open(obj_id, name) = h5d_open(obj_id, name, H5P_DEFAULT)
 function h5d_read(dataset_id::hid_t, memtype_id::hid_t, buf::AbstractArray, xfer::hid_t=H5P_DEFAULT)
     stride(buf, 1) != 1 && throw(ArgumentError("Cannot read arrays with a different stride than `Array`"))
     h5d_read(dataset_id, memtype_id, H5S_ALL, H5S_ALL, xfer, buf)
@@ -1803,7 +1803,7 @@ function h5d_write(dataset_id::hid_t, memtype_id::hid_t, v::VLen{T}, xfer::hid_t
     h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, xfer, vp)
 end
 h5f_create(filename) = h5f_create(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)
-h5f_open(filename::String, mode) = h5f_open(filename, mode, H5P_DEFAULT)
+h5f_open(filename, mode) = h5f_open(filename, mode, H5P_DEFAULT)
 h5g_create(obj_id, name) = h5g_create(obj_id, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)
 h5g_create(obj_id, name, lcpl_id, gcpl_id) = h5g_create(obj_id, name, lcpl_id, gcpl_id, H5P_DEFAULT)
 h5g_open(file_id, name) = h5g_open(file_id, name, H5P_DEFAULT)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -863,10 +863,9 @@ function p_create(class; pv...)
 end
 
 # Delete objects
-a_delete(parent::Union{File,Object}, path::String) = h5a_delete(checkvalid(parent).id, path)
-o_delete(parent::Union{File,Group}, path::String, lapl::Properties) = h5l_delete(checkvalid(parent).id, path, lapl.id)
-o_delete(parent::Union{File,Group}, path::String) = h5l_delete(checkvalid(parent).id, path, H5P_DEFAULT)
-o_delete(obj::Object) = o_delete(parent(obj), ascii(split(name(obj),"/")[end]))
+a_delete(parent::Union{File,Object}, path::AbstractString) = h5a_delete(checkvalid(parent), path)
+o_delete(parent::Union{File,Group}, path::AbstractString, lapl::Properties=DEFAULT_PROPERTIES) = h5l_delete(checkvalid(parent), path, lapl)
+o_delete(obj::Object) = o_delete(parent(obj), ascii(split(name(obj),"/")[end])) # FIXME: remove ascii?
 
 # Copy objects
 o_copy(src_parent::Union{File,Group}, src_path::String, dst_parent::Union{File,Group}, dst_path::String) = h5o_copy(checkvalid(src_parent).id, src_path, checkvalid(dst_parent).id, dst_path, H5P_DEFAULT, _link_properties(dst_path))

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -673,7 +673,7 @@ end
 root(h5file::File) = g_open(h5file, "/")
 root(obj::Union{Group,Dataset}) = g_open(file(obj), "/")
 # getindex syntax: obj2 = obj1[path]
-#getindex(parent::Union{HDF5File, HDF5Group}, path::String) = o_open(parent, path)
+#getindex(parent::Union{HDF5File, HDF5Group}, path::String) = o_open(parent, path) # REM
 getindex(dset::Dataset, name::AbstractString) = a_open(dset, name)
 getindex(x::Attributes, name::AbstractString) = a_open(x.parent, name)
 
@@ -1563,13 +1563,12 @@ end
 
 # Link to bytes in an external file
 # If you need to link to multiple segments, use low-level interface
-function d_create_external(parent::Union{File,Group}, name::String, filepath::String, t, sz::Dims, offset::Integer)
+function d_create_external(parent::Union{File,Group}, name::AbstractString, filepath::AbstractString, t, sz::Dims, offset::Integer=0)
     checkvalid(parent)
-    p = p_create(H5P_DATASET_CREATE)
-    h5p_set_external(p, filepath, Int(offset), prod(sz)*sizeof(t))
-    d_create(parent, name, datatype(t), dataspace(sz), Properties(), p)
+    dcpl  = p_create(H5P_DATASET_CREATE)
+    h5p_set_external(dcpl , filepath, Int(offset), prod(sz)*sizeof(t)) # TODO: allow H5F_UNLIMITED
+    d_create(parent, name, datatype(t), dataspace(sz); dcpl=dcpl)
 end
-d_create_external(parent::Union{File,Group}, name::String, filepath::String, t::Type, sz::Dims) = d_create_external(parent, name, filepath, t, sz, 0)
 
 function do_write_chunk(dataset::Dataset, offset, chunk_bytes::Vector{UInt8}, filter_mask=0)
     checkvalid(dataset)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -650,7 +650,7 @@ fd(obj::Object) = h5i_get_file_id(checkvalid(obj).id)
 flush(f::Union{Object,Attribute,Datatype,File}, scope = H5F_SCOPE_GLOBAL) = h5f_flush(checkvalid(f).id, scope)
 
 # Open objects
-g_open(parent::Union{File,Group}, name::String, apl::Properties=DEFAULT_PROPERTIES) = Group(h5g_open(checkvalid(parent).id, name, apl.id), file(parent))
+g_open(parent::Union{File,Group}, name::AbstractString, apl::Properties=DEFAULT_PROPERTIES) = Group(h5g_open(checkvalid(parent).id, name, apl.id), file(parent))
 d_open(parent::Union{File,Group}, name::String, apl::Properties=DEFAULT_PROPERTIES, xpl::Properties=DEFAULT_PROPERTIES) = Dataset(h5d_open(checkvalid(parent).id, name, apl.id), file(parent), xpl)
 t_open(parent::Union{File,Group}, name::String, apl::Properties=DEFAULT_PROPERTIES) = Datatype(h5t_open(checkvalid(parent).id, name, apl.id), file(parent))
 a_open(parent::Union{File,Object}, name::String) = Attribute(h5a_open(checkvalid(parent).id, name, H5P_DEFAULT), file(parent))
@@ -662,12 +662,12 @@ function h5object(obj_id::hid_t, parent)
     obj_type == H5I_DATASET ? Dataset(obj_id, file(parent)) :
     error("Invalid object type for path ", path)
 end
-o_open(parent, path::String) = h5object(h5o_open(checkvalid(parent).id, path), parent)
-function gettype(parent, path::String)
-    obj_id = h5o_open(checkvalid(parent).id, path)
-    t = h5i_get_type(obj_id)
+o_open(parent, path::AbstractString) = h5object(h5o_open(checkvalid(parent).id, path), parent)
+function gettype(parent, path::AbstractString)
+    obj_id = h5o_open(checkvalid(parent), path)
+    obj_type = h5i_get_type(obj_id)
     h5o_close(obj_id)
-    t
+    return obj_type
 end
 # Get the root group
 root(h5file::File) = g_open(h5file, "/")
@@ -677,7 +677,7 @@ root(obj::Union{Group,Dataset}) = g_open(file(obj), "/")
 getindex(dset::Dataset, name::String) = a_open(dset, name)
 getindex(x::Attributes, name::String) = a_open(x.parent, name)
 
-function getindex(parent::Union{File,Group}, path::String; pv...)
+function getindex(parent::Union{File,Group}, path::AbstractString; pv...)
     objtype = gettype(parent, path)
     if objtype == H5I_DATASET
         dapl = p_create(H5P_DATASET_ACCESS; pv...)
@@ -1809,7 +1809,7 @@ h5g_create(obj_id, name) = h5g_create(obj_id, name, H5P_DEFAULT, H5P_DEFAULT, H5
 h5g_create(obj_id, name, lcpl_id, gcpl_id) = h5g_create(obj_id, name, lcpl_id, gcpl_id, H5P_DEFAULT)
 h5g_open(file_id::hid_t, name::String) = h5g_open(file_id, name, H5P_DEFAULT)
 h5l_exists(loc_id::hid_t, name::String) = h5l_exists(loc_id, name, H5P_DEFAULT)
-h5o_open(obj_id::hid_t, name::String) = h5o_open(obj_id, name, H5P_DEFAULT)
+h5o_open(obj_id, name) = h5o_open(obj_id, name, H5P_DEFAULT)
 #h5s_get_simple_extent_ndims(space_id::hid_t) = h5s_get_simple_extent_ndims(space_id, C_NULL, C_NULL)
 h5t_get_native_type(type_id::hid_t) = h5t_get_native_type(type_id, H5T_DIR_ASCEND)
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1102,7 +1102,7 @@ for (fsym, osym, ptype) in
     ((:d_read, :d_open, Union{File,Group}),
      (:a_read, :a_open, Union{File,Group,Dataset,Datatype}))
     @eval begin
-        function ($fsym)(parent::$ptype, name::String)
+        function ($fsym)(parent::$ptype, name::AbstractString)
             local ret
             obj = ($osym)(parent, name)
             try
@@ -1116,14 +1116,14 @@ for (fsym, osym, ptype) in
 end
 
 # Datafile.jl defines generic read for multiple datasets, so we cannot simply add properties here.
-function read(parent::Union{File,Group}, name::String; pv...)
+function read(parent::Union{File,Group}, name::AbstractString; pv...)
     obj = getindex(parent, name; pv...)
     val = read(obj)
     close(obj)
     val
 end
 
-function read(parent::Union{File,Group}, name_type_pair::Pair{String,DataType}; pv...)
+function read(parent::Union{File,Group}, name_type_pair::Pair{<:AbstractString,DataType}; pv...)
     obj = getindex(parent, name_type_pair[1]; pv...)
     val = read(obj, name_type_pair[2])
     close(obj)
@@ -1406,7 +1406,7 @@ function a_create(parent::Union{File,Object}, name::AbstractString, data; pv...)
 end
 
 # Create and write, closing the objects upon exit
-function d_write(parent::Union{File,Group}, name::String, data; pv...)
+function d_write(parent::Union{File,Group}, name::AbstractString, data; pv...)
     obj, dtype = d_create(parent, name, data; pv...)
     try
         writearray(obj, dtype.id, data)
@@ -1419,7 +1419,7 @@ function d_write(parent::Union{File,Group}, name::String, data; pv...)
     end
     nothing
 end
-function a_write(parent::Union{File,Object}, name::String, data; pv...)
+function a_write(parent::Union{File,Object}, name::AbstractString, data; pv...)
     obj, dtype = a_create(parent, name, data; pv...)
     try
         writearray(obj, dtype.id, data)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -650,7 +650,7 @@ fd(obj::Object) = h5i_get_file_id(checkvalid(obj).id)
 flush(f::Union{Object,Attribute,Datatype,File}, scope = H5F_SCOPE_GLOBAL) = h5f_flush(checkvalid(f).id, scope)
 
 # Open objects
-g_open(parent::Union{File,Group}, name::AbstractString, apl::Properties=DEFAULT_PROPERTIES) = Group(h5g_open(checkvalid(parent).id, name, apl.id), file(parent))
+g_open(parent::Union{File,Group}, name::AbstractString, apl::Properties=DEFAULT_PROPERTIES) = Group(h5g_open(checkvalid(parent), name, apl), file(parent))
 d_open(parent::Union{File,Group}, name::AbstractString, apl::Properties=DEFAULT_PROPERTIES, xpl::Properties=DEFAULT_PROPERTIES) = Dataset(h5d_open(checkvalid(parent), name, apl), file(parent), xpl)
 t_open(parent::Union{File,Group}, name::AbstractString, apl::Properties=DEFAULT_PROPERTIES) = Datatype(h5t_open(checkvalid(parent), name, apl), file(parent))
 a_open(parent::Union{File,Object}, name::AbstractString, apl::Properties=DEFAULT_PROPERTIES) = Attribute(h5a_open(checkvalid(parent), name, apl), file(parent))
@@ -905,7 +905,7 @@ function Base.haskey(parent::Union{File,Group}, path::AbstractString, lapl::Prop
     first, rest = split1(path)
     if first == "/"
         parent = root(parent)
-    elseif !h5l_exists(parent.id, first, lapl.id)
+    elseif !h5l_exists(parent, first, lapl)
         return false
     end
     exists = true
@@ -1806,8 +1806,8 @@ h5f_create(filename) = h5f_create(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFA
 h5f_open(filename::String, mode) = h5f_open(filename, mode, H5P_DEFAULT)
 h5g_create(obj_id, name) = h5g_create(obj_id, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)
 h5g_create(obj_id, name, lcpl_id, gcpl_id) = h5g_create(obj_id, name, lcpl_id, gcpl_id, H5P_DEFAULT)
-h5g_open(file_id::hid_t, name::String) = h5g_open(file_id, name, H5P_DEFAULT)
-h5l_exists(loc_id::hid_t, name::String) = h5l_exists(loc_id, name, H5P_DEFAULT)
+h5g_open(file_id, name) = h5g_open(file_id, name, H5P_DEFAULT)
+h5l_exists(loc_id, name) = h5l_exists(loc_id, name, H5P_DEFAULT)
 h5o_open(obj_id, name) = h5o_open(obj_id, name, H5P_DEFAULT)
 #h5s_get_simple_extent_ndims(space_id::hid_t) = h5s_get_simple_extent_ndims(space_id, C_NULL, C_NULL)
 h5t_get_native_type(type_id::hid_t) = h5t_get_native_type(type_id, H5T_DIR_ASCEND)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -873,7 +873,7 @@ o_copy(src_obj::Object, dst_parent::Union{File,Group}, dst_path::String) = h5o_c
 
 # Assign syntax: obj[path] = value
 # Creates a dataset unless obj is a dataset, in which case it creates an attribute
-setindex!(dset::Dataset, val, name::AbstractString) = (@show "NO"; a_write(dset, name, val))
+setindex!(dset::Dataset, val, name::AbstractString) = a_write(dset, name, val)
 setindex!(x::Attributes, val, name::AbstractString) = a_write(x.parent, name, val)
 # Getting and setting properties: p[:chunk] = dims, p[:compress] = 6
 getindex(p::Properties, name::Symbol) = _prop_get(checkvalid(p), name)
@@ -1453,10 +1453,10 @@ function write(obj::DatasetOrAttribute, data::VLen{T}) where {T<:Union{ScalarTyp
     end
 end
 # For plain files and groups, let "write(obj, name, val; properties...)" mean "d_write"
-write(parent::Union{File,Group}, name::String, data::Union{T,AbstractArray{T}}; pv...) where {T<:Union{ScalarType,String,Complex{<:ScalarType}}} =
+write(parent::Union{File,Group}, name::AbstractString, data::Union{T,AbstractArray{T}}; pv...) where {T<:Union{ScalarType,String,Complex{<:ScalarType}}} =
     d_write(parent, name, data; pv...)
 # For datasets, "write(dset, name, val; properties...)" means "a_write"
-write(parent::Dataset, name::String, data::Union{T, AbstractArray{T}}; pv...) where {T<:ScalarType,String} =
+write(parent::Dataset, name::AbstractString, data::Union{T,AbstractArray{T}}; pv...) where {T<:Union{ScalarType,String}} =
     a_write(parent, name, data; pv...)
 
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -707,7 +707,7 @@ end
 function g_create(parent::Union{File,Group}, path::AbstractString,
                   lcpl::Properties=_link_properties(path),
                   dcpl::Properties=DEFAULT_PROPERTIES)
-    Group(h5g_create(checkvalid(parent).id, path, lcpl.id, dcpl.id), file(parent))
+    Group(h5g_create(checkvalid(parent), path, lcpl, dcpl), file(parent))
 end
 function g_create(f::Function, parent::Union{File,Group}, args...)
     g = g_create(parent, args...)
@@ -721,7 +721,7 @@ end
 function d_create(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace::Dataspace,
                   lcpl::Properties, dcpl::Properties,
                   dapl::Properties, dxpl::Properties)
-    Dataset(h5d_create(checkvalid(parent).id, path, dtype.id, dspace.id, lcpl.id, dcpl.id, dapl.id), file(parent), dxpl)
+    Dataset(h5d_create(checkvalid(parent), path, dtype, dspace, lcpl, dcpl, dapl), file(parent), dxpl)
 end
 
 # Setting dset creation properties with name/value pairs
@@ -729,7 +729,7 @@ function d_create(parent::Union{File,Group}, path::AbstractString, dtype::Dataty
     dcpl = isempty(pv) ? DEFAULT_PROPERTIES : p_create(H5P_DATASET_CREATE; pv...)
     dxpl = isempty(pv) ? DEFAULT_PROPERTIES : p_create(H5P_DATASET_XFER; pv...)
     dapl = isempty(pv) ? DEFAULT_PROPERTIES : p_create(H5P_DATASET_ACCESS; pv...)
-    Dataset(h5d_create(checkvalid(parent).id, path, dtype.id, dspace.id, _link_properties(path), dcpl.id, dapl.id), file(parent), dxpl)
+    Dataset(h5d_create(checkvalid(parent), path, dtype, dspace, _link_properties(path), dcpl, dapl), file(parent), dxpl)
 end
 d_create(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace_dims::Dims; pv...) = d_create(checkvalid(parent), path, dtype, dataspace(dspace_dims); pv...)
 d_create(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace_dims::Tuple{Dims,Dims}; pv...) = d_create(checkvalid(parent), path, dtype, dataspace(dspace_dims[1], max_dims=dspace_dims[2]); pv...)
@@ -757,7 +757,7 @@ function t_commit(parent::Union{File,Group}, path::String, dtype::Datatype, lcpl
 end
 t_commit(parent::Union{File,Group}, path::String, dtype::Datatype) = t_commit(parent, path, dtype, p_create(H5P_LINK_CREATE))
 
-a_create(parent::Union{File,Object}, name::AbstractString, dtype::Datatype, dspace::Dataspace) = Attribute(h5a_create(checkvalid(parent).id, name, dtype.id, dspace.id), file(parent))
+a_create(parent::Union{File,Object}, name::AbstractString, dtype::Datatype, dspace::Dataspace) = Attribute(h5a_create(checkvalid(parent), name, dtype, dspace), file(parent))
 
 function _prop_get(p::Properties, name::Symbol)
     class = p.class

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1789,7 +1789,7 @@ function h5a_write(attr_id::hid_t, memtype_id::hid_t, v::VLen{T}) where {T<:Unio
     vp = vlenpack(v)
     h5a_write(attr_id, memtype_id, vp)
 end
-h5a_create(loc_id, name, type_id, space_id) = h5a_create(loc_id, name, type_id, space_id, H5P_DEFAULT, H5P_DEFAULT) # last two arguments not used in HDF5 lib
+h5a_create(loc_id, name, type_id, space_id) = h5a_create(loc_id, name, type_id, space_id, _attr_properties(name), H5P_DEFAULT)
 h5a_open(obj_id::hid_t, name::String) = h5a_open(obj_id, name, H5P_DEFAULT)
 h5d_create(loc_id, name, type_id, space_id) = h5d_create(loc_id, name, type_id, space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)
 h5d_open(obj_id::hid_t, name::String) = h5d_open(obj_id, name, H5P_DEFAULT)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -539,7 +539,7 @@ function h5read(filename, name::AbstractString, indices::Tuple{Vararg{Union{Abst
     dat
 end
 
-function h5writeattr(filename, name::String, data::Dict)
+function h5writeattr(filename, name::AbstractString, data::Dict)
     fid = h5open(filename, "r+")
     try
         for x in keys(data)
@@ -550,7 +550,7 @@ function h5writeattr(filename, name::String, data::Dict)
     end
 end
 
-function h5readattr(filename, name::String)
+function h5readattr(filename, name::AbstractString)
     local dat
     fid = h5open(filename,"r")
     try

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1014,13 +1014,13 @@ end
 datatype(x::Complex{T}) where {T<:ScalarType} = datatype(typeof(x))
 datatype(A::AbstractArray{Complex{T}}) where {T<:ScalarType} = datatype(eltype(A))
 
-function datatype(str::String)
+function datatype(str::AbstractString)
     type_id = h5t_copy(hdf5_type_id(typeof(str)))
     h5t_set_size(type_id, max(sizeof(str), 1))
     h5t_set_cset(type_id, cset(typeof(str)))
     Datatype(type_id)
 end
-function datatype(str::Array{S}) where {S<:String}
+function datatype(::Array{S}) where {S<:AbstractString}
     type_id = h5t_copy(hdf5_type_id(S))
     h5t_set_size(type_id, H5T_VARIABLE)
     h5t_set_cset(type_id, cset(S))
@@ -1043,7 +1043,7 @@ dataspace(attr::Attribute) = Dataspace(h5a_get_space(checkvalid(attr).id))
 
 # Create a dataspace from in-memory types
 dataspace(x::Union{T, Complex{T}}) where {T<:ScalarType} = Dataspace(h5s_create(H5S_SCALAR))
-dataspace(str::String) = Dataspace(h5s_create(H5S_SCALAR))
+dataspace(::AbstractString) = Dataspace(h5s_create(H5S_SCALAR))
 
 function _dataspace(sz::Dims{N}, max_dims::Union{Dims{N}, Tuple{}}=()) where N
     dims = hsize_t[sz[i] for i in N:-1:1]
@@ -1786,14 +1786,14 @@ function h5d_write(dataset_id::hid_t, memtype_id::hid_t, buf::AbstractArray, xfe
     stride(buf, 1) != 1 && throw(ArgumentError("Cannot write arrays with a different stride than `Array`"))
     h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, xfer, buf)
 end
-function h5d_write(dataset_id::hid_t, memtype_id::hid_t, str::String, xfer::hid_t=H5P_DEFAULT)
+function h5d_write(dataset_id::hid_t, memtype_id::hid_t, str::AbstractString, xfer::hid_t=H5P_DEFAULT)
     ccall((:H5Dwrite, libhdf5), herr_t, (hid_t, hid_t, hid_t, hid_t, hid_t, Cstring), dataset_id, memtype_id, H5S_ALL, H5S_ALL, xfer, str)
 end
 function h5d_write(dataset_id::hid_t, memtype_id::hid_t, x::T, xfer::hid_t=H5P_DEFAULT) where {T<:Union{ScalarType, Complex{<:ScalarType}}}
     tmp = Ref{T}(x)
     h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, xfer, tmp)
 end
-function h5d_write(dataset_id::hid_t, memtype_id::hid_t, strs::Array{S}, xfer::hid_t=H5P_DEFAULT) where {S<:String}
+function h5d_write(dataset_id::hid_t, memtype_id::hid_t, strs::Array{<:AbstractString}, xfer::hid_t=H5P_DEFAULT)
     p = Ref{Cstring}(strs)
     h5d_write(dataset_id, memtype_id, H5S_ALL, H5S_ALL, xfer, p)
 end

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -673,7 +673,6 @@ end
 root(h5file::File) = g_open(h5file, "/")
 root(obj::Union{Group,Dataset}) = g_open(file(obj), "/")
 # getindex syntax: obj2 = obj1[path]
-#getindex(parent::Union{HDF5File, HDF5Group}, path::String) = o_open(parent, path) # REM
 getindex(dset::Dataset, name::AbstractString) = a_open(dset, name)
 getindex(x::Attributes, name::AbstractString) = a_open(x.parent, name)
 
@@ -737,7 +736,8 @@ d_create(parent::Union{File,Group}, path::AbstractString, dtype::Type, dspace_di
 
 # Note that H5Tcreate is very different; H5Tcommit is the analog of these others
 t_create(class_id, sz) = Datatype(h5t_create(class_id, sz))
-function t_commit(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, lcpl::Properties=p_create(H5P_LINK_CREATE), tcpl::Properties=DEFAULT_PROPERTIES, tapl::Properties=DEFAULT_PROPERTIES)
+function t_commit(parent::Union{File,Group}, path::AbstractString, dtype::Datatype,
+                  lcpl::Properties=p_create(H5P_LINK_CREATE), tcpl::Properties=DEFAULT_PROPERTIES, tapl::Properties=DEFAULT_PROPERTIES)
     h5p_set_char_encoding(lcpl, cset(typeof(path)))
     h5t_commit(checkvalid(parent), path, dtype, lcpl, tcpl, tapl)
     dtype.file = file(parent)
@@ -1435,7 +1435,7 @@ end
 
 # Write to already-created objects
 # Scalars
-function write(obj::DatasetOrAttribute, x::Union{T,Array{T}}) where {T<:Union{ScalarType,String,Complex{<:ScalarType}}}
+function write(obj::DatasetOrAttribute, x::Union{T,Array{T}}) where {T<:Union{ScalarType,<:AbstractString,Complex{<:ScalarType}}}
     dtype = datatype(x)
     try
         writearray(obj, dtype.id, x)
@@ -1453,10 +1453,10 @@ function write(obj::DatasetOrAttribute, data::VLen{T}) where {T<:Union{ScalarTyp
     end
 end
 # For plain files and groups, let "write(obj, name, val; properties...)" mean "d_write"
-write(parent::Union{File,Group}, name::AbstractString, data::Union{T,AbstractArray{T}}; pv...) where {T<:Union{ScalarType,String,Complex{<:ScalarType}}} =
+write(parent::Union{File,Group}, name::AbstractString, data::Union{T,AbstractArray{T}}; pv...) where {T<:Union{ScalarType,<:AbstractString,Complex{<:ScalarType}}} =
     d_write(parent, name, data; pv...)
 # For datasets, "write(dset, name, val; properties...)" means "a_write"
-write(parent::Dataset, name::AbstractString, data::Union{T,AbstractArray{T}}; pv...) where {T<:Union{ScalarType,String}} =
+write(parent::Dataset, name::AbstractString, data::Union{T,AbstractArray{T}}; pv...) where {T<:Union{ScalarType,<:AbstractString}} =
     a_write(parent, name, data; pv...)
 
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -868,8 +868,8 @@ o_delete(parent::Union{File,Group}, path::AbstractString, lapl::Properties=DEFAU
 o_delete(obj::Object) = o_delete(parent(obj), ascii(split(name(obj),"/")[end])) # FIXME: remove ascii?
 
 # Copy objects
-o_copy(src_parent::Union{File,Group}, src_path::String, dst_parent::Union{File,Group}, dst_path::String) = h5o_copy(checkvalid(src_parent).id, src_path, checkvalid(dst_parent).id, dst_path, H5P_DEFAULT, _link_properties(dst_path))
-o_copy(src_obj::Object, dst_parent::Union{File,Group}, dst_path::String) = h5o_copy(checkvalid(src_obj).id, ".", checkvalid(dst_parent).id, dst_path, H5P_DEFAULT, _link_properties(dst_path))
+o_copy(src_parent::Union{File,Group}, src_path::AbstractString, dst_parent::Union{File,Group}, dst_path::AbstractString) = h5o_copy(checkvalid(src_parent), src_path, checkvalid(dst_parent), dst_path, H5P_DEFAULT, _link_properties(dst_path))
+o_copy(src_obj::Object, dst_parent::Union{File,Group}, dst_path::AbstractString) = h5o_copy(checkvalid(src_obj), ".", checkvalid(dst_parent), dst_path, H5P_DEFAULT, _link_properties(dst_path))
 
 # Assign syntax: obj[path] = value
 # Creates a dataset unless obj is a dataset, in which case it creates an attribute

--- a/src/datafile.jl
+++ b/src/datafile.jl
@@ -28,13 +28,13 @@ macro write(fid, sym)
 end
 
 # Read a list of variables, read(parent, "A", "B", "x", ...)
-read(parent::DataFile, name::String...) =
+read(parent::DataFile, name::AbstractString...) =
 	tuple([read(parent, x) for x in name]...)
 
 # Read one or more variables and pass them to a function. This is
 # convenient for avoiding type inference pitfalls with the usual
 # read syntax.
-read(f::Base.Callable, parent::DataFile, name::String...) =
+read(f::Base.Callable, parent::DataFile, name::AbstractString...) =
 	f(read(parent, name...)...)
 
 # Read every variable in the file

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -123,7 +123,7 @@ for (fsym, ptype) in ((:d_write, Union{File,Group}),
     end
 end
 function write(parent::Union{File,Group}, name::AbstractString, data::Union{T,AbstractArray{T}},
-               plists::Properties...) where {T<:Union{ScalarType,String,Complex{<:ScalarType}}}
+               plists::Properties...) where {T<:Union{ScalarType,<:AbstractString,Complex{<:ScalarType}}}
     depwarn("`write(parent::Union{HDF5.File, HDF5.Group}, name::AbstractString, data, plists::HDF5Properties...)` " *
             "with property lists is deprecated, use " *
             "`write(parent::Union{HDF5.File, HDF5.Group}, name::AbstractString, data; properties...)` " *
@@ -142,7 +142,7 @@ function write(parent::Union{File,Group}, name::AbstractString, data::Union{T,Ab
     end
 end
 function write(parent::Dataset, name::AbstractString, data::Union{T,AbstractArray{T}},
-               plists::Properties...) where {T<:Union{ScalarType,String}}
+               plists::Properties...) where {T<:Union{ScalarType,<:AbstractString}}
     depwarn("`write(parent::HDF5Dataset, name::AbstractString, data, plists::HDF5Properties...)` " *
             "with property lists is deprecated, use " *
             "`write(parent::HDF5Dataset, name::AbstractString, data; properties...)` " *

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -124,9 +124,9 @@ for (fsym, ptype) in ((:d_write, Union{File,Group}),
 end
 function write(parent::Union{File,Group}, name::AbstractString, data::Union{T,AbstractArray{T}},
                plists::Properties...) where {T<:Union{ScalarType,String,Complex{<:ScalarType}}}
-    depwarn("`write(parent::Union{HDF5.File, HDF5.Group}, name::String, data, plists::HDF5Properties...)` " *
+    depwarn("`write(parent::Union{HDF5.File, HDF5.Group}, name::AbstractString, data, plists::HDF5Properties...)` " *
             "with property lists is deprecated, use " *
-            "`write(parent::Union{HDF5.File, HDF5.Group}, name::String, data; properties...)` " *
+            "`write(parent::Union{HDF5.File, HDF5.Group}, name::AbstractString, data; properties...)` " *
             "with keywords instead.", :write)
     # We avoid using the d_write method to prevent double deprecation warnings.
     dtype = datatype(data)
@@ -143,9 +143,9 @@ function write(parent::Union{File,Group}, name::AbstractString, data::Union{T,Ab
 end
 function write(parent::Dataset, name::AbstractString, data::Union{T,AbstractArray{T}},
                plists::Properties...) where {T<:Union{ScalarType,String}}
-    depwarn("`write(parent::HDF5Dataset, name::String, data, plists::HDF5Properties...)` " *
+    depwarn("`write(parent::HDF5Dataset, name::AbstractString, data, plists::HDF5Properties...)` " *
             "with property lists is deprecated, use " *
-            "`write(parent::HDF5Dataset, name::String, data; properties...)` " *
+            "`write(parent::HDF5Dataset, name::AbstractString, data; properties...)` " *
             "with keywords instead.", :write)
     # We avoid using the a_write method to prevent double deprecation warnings.
     dtype = datatype(data)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -122,7 +122,7 @@ for (fsym, ptype) in ((:d_write, Union{File,Group}),
         end
     end
 end
-function write(parent::Union{File,Group}, name::String, data::Union{T,AbstractArray{T}},
+function write(parent::Union{File,Group}, name::AbstractString, data::Union{T,AbstractArray{T}},
                plists::Properties...) where {T<:Union{ScalarType,String,Complex{<:ScalarType}}}
     depwarn("`write(parent::Union{HDF5.File, HDF5.Group}, name::String, data, plists::HDF5Properties...)` " *
             "with property lists is deprecated, use " *
@@ -141,8 +141,8 @@ function write(parent::Union{File,Group}, name::String, data::Union{T,AbstractAr
         close(dtype)
     end
 end
-function write(parent::Dataset, name::String, data::Union{T,AbstractArray{T}},
-               plists::Properties...) where {T<:ScalarType,String}
+function write(parent::Dataset, name::AbstractString, data::Union{T,AbstractArray{T}},
+               plists::Properties...) where {T<:Union{ScalarType,String}}
     depwarn("`write(parent::HDF5Dataset, name::String, data, plists::HDF5Properties...)` " *
             "with property lists is deprecated, use " *
             "`write(parent::HDF5Dataset, name::String, data; properties...)` " *

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -4,23 +4,23 @@ import Base: @deprecate, @deprecate_binding, depwarn
 # - HDF5.Dataset.xfer from ::hid_t to ::HDF5.Properties
 @deprecate h5d_read(dataset_id::hid_t, memtype_id::hid_t, buf::AbstractArray, xfer::Properties) h5d_read(dataset_id, memtype_id, buf, xfer.id) false
 @deprecate h5d_write(dataset_id::hid_t, memtype_id::hid_t, buf::AbstractArray, xfer::Properties) h5d_write(dataset_id, memtype_id, buf, xfer.id) false
-@deprecate h5d_write(dataset_id::hid_t, memtype_id::hid_t, str::String, xfer::Properties) h5d_write(dataset_id, memtype_id, str, xfer.id) false
+@deprecate h5d_write(dataset_id::hid_t, memtype_id::hid_t, str::AbstractString, xfer::Properties) h5d_write(dataset_id, memtype_id, str, xfer.id) false
 @deprecate h5d_write(dataset_id::hid_t, memtype_id::hid_t, x::T, xfer::Properties) where {T<:Union{ScalarType, Complex{<:ScalarType}}} h5d_write(dataset_id, memtype_id, x, xfer.id) false
-@deprecate h5d_write(dataset_id::hid_t, memtype_id::hid_t, strs::Array{S}, xfer::Properties) where {S<:String} h5d_write(dataset_id, memtype_id, strs, xfer.id) false
+@deprecate h5d_write(dataset_id::hid_t, memtype_id::hid_t, strs::Array{S}, xfer::Properties) where {S<:AbstractString} h5d_write(dataset_id, memtype_id, strs, xfer.id) false
 @deprecate h5d_write(dataset_id::hid_t, memtype_id::hid_t, v::VLen{T}, xfer::Properties) where {T<:Union{ScalarType,CharType}} h5d_write(dataset_id, memtype_id, v, xfer.id) false
 # - p_create lost toclose argument
 @deprecate p_create(class, toclose::Bool, pv...) p_create(class, pv...)
 
 ### Changed in PR#632
 # - using symbols instead of strings for property keys
-@deprecate setindex!(p::Properties, val, name::String) setindex!(p, val, Symbol(name))
+@deprecate setindex!(p::Properties, val, name::AbstractString) setindex!(p, val, Symbol(name))
 
-function getindex(parent::Union{File,Group}, path::String, prop1::String, val1, pv...)
+function getindex(parent::Union{File,Group}, path::AbstractString, prop1::AbstractString, val1, pv...)
     depwarn("getindex(::Union{HDF5.File, HDF5.Group}, path, props...) with string key and value argument pairs is deprecated. Use keywords instead.", :getindex)
     props = (prop1, val1, pv...)
     return getindex(parent, path; [Symbol(props[i]) => props[i+1] for i in 1:2:length(props)]...)
 end
-function setindex!(parent::Union{File,Group}, val, path::String, prop1::String, val1, pv...)
+function setindex!(parent::Union{File,Group}, val, path::AbstractString, prop1::AbstractString, val1, pv...)
     depwarn("setindex!(::Union{HDF5.File, HDF5.Group}, val, path, props...) with string key and value argument pairs is deprecated. Use keywords instead.", :setindex!)
     props = (prop1, val1, pv...)
     return setindex!(parent, val, path; [Symbol(props[i]) => props[i+1] for i in 1:2:length(props)]...)
@@ -30,29 +30,29 @@ function h5open(filename::AbstractString, mode::AbstractString, pv...; kws...)
     depwarn("h5open with string key and value argument pairs is deprecated. Use keywords instead.", :h5open)
     return h5open(filename, mode; kws..., [Symbol(pv[i]) => pv[i+1] for i in 1:2:length(pv)]...)
 end
-function h5write(filename, name::String, data, pv...)
+function h5write(filename, name::AbstractString, data, pv...)
     depwarn("h5write with string key and value argument pairs is deprecated. Use keywords instead.", :h5write)
     return h5write(filename, name, data; [Symbol(pv[i]) => pv[i+1] for i in 1:2:length(pv)]...)
 end
-function h5read(filename, name::String, pv...)
+function h5read(filename, name::AbstractString, pv...)
     depwarn("h5read with string key and value argument pairs is deprecated. Use keywords instead.", :h5read)
     return h5read(filename, name; [Symbol(pv[i]) => pv[i+1] for i in 1:2:length(pv)]...)
 end
-function h5read(filename, name::String, indices::Tuple{Vararg{Union{AbstractRange{Int},Int,Colon}}}, pv...)
+function h5read(filename, name::AbstractString, indices::Tuple{Vararg{Union{AbstractRange{Int},Int,Colon}}}, pv...)
     depwarn("h5read with string key and value argument pairs is deprecated. Use keywords instead.", :h5read)
     return h5read(filename, name, indices; [Symbol(pv[i]) => pv[i+1] for i in 1:2:length(pv)]...)
 end
-function d_create(parent::Union{File,Group}, path::String, dtype::Datatype, dspace::D, prop1::String, val1, pv...) where D <: Union{Dataspace, Dims, Tuple{Dims,Dims}}
+function d_create(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace::D, prop1::AbstractString, val1, pv...) where D <: Union{Dataspace, Dims, Tuple{Dims,Dims}}
     depwarn("d_create with string key and value argument pairs is deprecated. Use keywords instead.", :d_create)
     props = (prop1, val1, pv...)
     return d_create(parent, path, dtype, dspace; [Symbol(props[i]) => props[i+1] for i in 1:2:length(props)]...)
 end
-function d_create(parent::Union{File,Group}, path::String, dtype::Type, dspace, prop1::String, val1, pv...)
+function d_create(parent::Union{File,Group}, path::AbstractString, dtype::Type, dspace, prop1::AbstractString, val1, pv...)
     depwarn("d_create with string key and value argument pairs is deprecated. Use keywords instead.", :d_create)
     props = (prop1, val1, pv...)
     return d_create(parent, path, dtype, dspace; [Symbol(props[i]) => props[i+1] for i in 1:2:length(props)]...)
 end
-function p_create(class, prop1::String, val1, pv...)
+function p_create(class, prop1::AbstractString, val1, pv...)
     depwarn("p_create with string key and value argument pairs is deprecated. Use keywords instead.", :p_create)
     props = (prop1, val1, pv...)
     return p_create(class; [Symbol(props[i]) => props[i+1] for i in 1:2:length(props)]...)
@@ -67,7 +67,7 @@ end
 
 # deprecation helpers to avoid having default values on the equivalent low-level
 # constructors in HDF5.jl
-function __d_create(parent::Union{File, Group}, path::String, dtype::Datatype,
+function __d_create(parent::Union{File, Group}, path::AbstractString, dtype::Datatype,
                    dspace::Dataspace, lcpl::Properties,
                    dcpl::Properties = DEFAULT_PROPERTIES,
                    dapl::Properties = DEFAULT_PROPERTIES,
@@ -217,5 +217,5 @@ import Base: names
 @deprecate names(x::Union{Group,File,Attributes}) keys(x) false
 
 ### Changed in PR#694
-@deprecate has(parent::Union{File,Group,Dataset}, path::String) Base.haskey(parent, path)
-@deprecate exists(parent::Union{File,Group,Dataset,Datatype,Attributes}, path::String) Base.haskey(parent, path) false
+@deprecate has(parent::Union{File,Group,Dataset}, path::AbstractString) Base.haskey(parent, path)
+@deprecate exists(parent::Union{File,Group,Dataset,Datatype,Attributes}, path::AbstractString) Base.haskey(parent, path) false

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -81,11 +81,11 @@ for (fsym, ptype) in ((:d_create, Union{File, Group}),
                       (:a_create, Union{File, Object}),
                      )
     chainsym = Symbol(:__, fsym)
-    depsig = "$fsym(parent::$ptype, name::String, data, plists::HDF5Properties...)"
-    usesig = "$fsym(parent::$ptype, name::String, data; properties...)"
+    depsig = "$fsym(parent::$ptype, name::AbstractString, data, plists::HDF5Properties...)"
+    usesig = "$fsym(parent::$ptype, name::AbstractString, data; properties...)"
     warnstr = "`$depsig` with property lists is deprecated, use `$usesig` with keywords instead"
     @eval begin
-        function ($fsym)(parent::$ptype, name::String, data, plists::Properties...)
+        function ($fsym)(parent::$ptype, name::AbstractString, data, plists::Properties...)
             depwarn($warnstr, $(QuoteNode(fsym)))
             dtype = datatype(data)
             dspace = dataspace(data)
@@ -102,11 +102,11 @@ for (fsym, ptype) in ((:d_write, Union{File,Group}),
                       (:a_write, Union{File,Object}),
                      )
     crsym = Symbol(:__, replace(string(fsym), "write" => "create"))
-    depsig = "$fsym(parent::$ptype, name::String, data, plists::HDF5Properties...)"
-    usesig = "$fsym(parent::$ptype, name::String, data; properties...)"
+    depsig = "$fsym(parent::$ptype, name::AbstractString, data, plists::HDF5Properties...)"
+    usesig = "$fsym(parent::$ptype, name::AbstractString, data; properties...)"
     warnstr = "`$depsig` with property lists is deprecated, use `$usesig` with keywords instead"
     @eval begin
-        function ($fsym)(parent::$ptype, name::String, data, plists::Properties...)
+        function ($fsym)(parent::$ptype, name::AbstractString, data, plists::Properties...)
             depwarn($warnstr, $(QuoteNode(fsym)))
             dtype = datatype(data)
             obj = ($crsym)(parent, name, dtype, dataspace(data), plists...)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -764,11 +764,12 @@ path2 = acomb * "/α"
 end # split1 tests
 
 
+# Also tests AbstractString interface
 @testset "haskey" begin
 fn = tempname()
 hfile = h5open(fn, "w")
 
-group1 = g_create(hfile, "group1")
+group1 = g_create(hfile, GenericString("group1"))
 group2 = g_create(group1, "group2")
 
 @test haskey(hfile, GenericString("group1"))
@@ -776,7 +777,7 @@ group2 = g_create(group1, "group2")
 @test haskey(hfile, "group1/group2")
 @test !haskey(hfile, "group1/groupna")
 
-dset1 = d_create(hfile, "dset1", datatype(Int), dataspace((1,)))
+dset1 = d_create(hfile, GenericString("dset1"), datatype(Int), dataspace((1,)))
 dset2 = d_create(group1, "dset2", datatype(Int), dataspace((1,)))
 
 @test haskey(hfile, "dset1")
@@ -784,8 +785,10 @@ dset2 = d_create(group1, "dset2", datatype(Int), dataspace((1,)))
 @test haskey(hfile, "group1/dset2")
 @test !haskey(hfile, "group1/dsetna")
 
-meta1 = a_create(dset1, "meta1", datatype(Bool), dataspace((1,)))
+meta1 = a_create(dset1, GenericString("meta1"), datatype(Bool), dataspace((1,)))
+meta2 = a_create(dset1, "meta2", datatype(Bool), dataspace((1,)))
 @test haskey(dset1, "meta1")
+@test haskey(dset1, "meta2")
 @test !haskey(dset1, "metana")
 
 

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -837,6 +837,11 @@ t_commit(hfile, GenericString("dt"), dt)
 array_of_strings = ["test",]
 write(hfile, "array_of_strings", array_of_strings)
 attrs(hfile)["ref_test"] = HDF5.Reference(hfile, GenericString("array_of_strings"))
-@test read(attrs(hfile)["ref_test"]) === HDF5.Reference(f, "array_of_strings")
+@test read(attrs(hfile)["ref_test"]) === HDF5.Reference(hfile, "array_of_strings")
+
+hfile["test"] = 17.2
+@test_nowarn o_delete(hfile, GenericString("test"))
+@test_nowarn a_delete(dset1, GenericString("meta1"))
+
 
 end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -847,9 +847,9 @@ t_commit(hfile, GenericString("dt"), dt)
 
 dt = datatype(Int)
 ds = dataspace(0)
-@test_nowarn d = d_create(hfile, GenericString("d"), dt, ds)
-@test_nowarn g = g_create(hfile, GenericString("g"))
-@test_nowarn a = a_create(hfile, GenericString("a"), dt, ds)
+d = d_create(hfile, GenericString("d"), dt, ds)
+g = g_create(hfile, GenericString("g"))
+a = a_create(hfile, GenericString("a"), dt, ds)
 
 for obj in (d, g)
    @test_nowarn a_write(obj, GenericString("a"), 1)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -878,22 +878,25 @@ fn = GenericString(tempname())
 A = Matrix(reshape(1:120, 15, 8))
 @test_nowarn h5write(fn, GenericString("A"), A)
 @test_nowarn h5read(fn, GenericString("A"))
-Ar = h5read(fn, GenericString("A"), (2:3:15, 3:5))
+@test_nowarn h5read(fn, GenericString("A"), (2:3:15, 3:5))
 
-h5write(fn, GenericString("x"), 1)
-h5read(fn, GenericString("x") => Int)
+@test_nowarn h5write(fn, GenericString("x"), 1)
+@test_nowarn h5read(fn, GenericString("x") => Int)
 
 
-h5rewrite(fn) do fid
+@test_nowarn h5rewrite(fn) do fid
     g_create(fid, "mygroup") do g
         write(g, "x", 3.3)
     end
 end
-h5rewrite(fn) do fid
+@test_nowarn h5rewrite(fn) do fid
     g_create(fid, "mygroup") do g
         write(g, "y", 3.3)
     end
 end
 
+@test_nowarn h5write(fn, "W", [1 2; 3 4])
+@test_nowarn h5writeattr(fn, GenericString("W"), Dict("a" => 1, "b" => 2))
+@test_nowarn h5readattr(fn, GenericString("W"))
 
 end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -847,37 +847,38 @@ t_commit(hfile, GenericString("dt"), dt)
 
 dt = datatype(Int)
 ds = dataspace(0)
-d = d_create(hfile, GenericString("d"), dt, ds)
-g = g_create(hfile, GenericString("g"))
-a = a_create(hfile, GenericString("a"), dt, ds)
+@test_nowarn d = d_create(hfile, GenericString("d"), dt, ds)
+@test_nowarn g = g_create(hfile, GenericString("g"))
+@test_nowarn a = a_create(hfile, GenericString("a"), dt, ds)
 
 for obj in (d, g)
-    a_write(obj, GenericString("a"), 1)
-    a_read(obj, GenericString("a"))
-    write(obj, GenericString("aa"), 1)
+   @test_nowarn a_write(obj, GenericString("a"), 1)
+   @test_nowarn a_read(obj, GenericString("a"))
+   @test_nowarn write(obj, GenericString("aa"), 1)
 end
 
 for obj in (hfile,)
-    d_open(obj, GenericString("d"))
-    d_write(obj, GenericString("dd"), 1)
-    d_read(obj, GenericString("dd"))
-    read(obj, GenericString("dd"))
-    read(obj, GenericString("dd")=>Int)
+    @test_nowarn d_open(obj, GenericString("d"))
+    @test_nowarn d_write(obj, GenericString("dd"), 1)
+    @test_nowarn d_read(obj, GenericString("dd"))
+    @test_nowarn read(obj, GenericString("dd"))
+    @test_nowarn read(obj, GenericString("dd")=>Int)
 end
 
 # test writing multiple variable
-write(hfile, GenericString("a1"), rand(2,2), GenericString("a2"), rand(2,2))
+@test_nowarn write(hfile, GenericString("a1"), rand(2,2), GenericString("a2"), rand(2,2))
 
 # copy methods
 d1 = d_create(hfile, GenericString("d1"), dt, ds)
 d1["x"] = 32
-o_copy(hfile, GenericString("d1"), hfile, GenericString("d1copy1"))
-o_copy(d1, hfile, GenericString("d1copy2"))
+@test_nowarn o_copy(hfile, GenericString("d1"), hfile, GenericString("d1copy1"))
+@test_nowarn o_copy(d1, hfile, GenericString("d1copy2"))
 
 fn = GenericString(tempname())
 A = Matrix(reshape(1:120, 15, 8))
-h5write(fn, GenericString("A"), A)
-Ar = h5read(fn, GenericString("A"))
+@test_nowarn h5write(fn, GenericString("A"), A)
+@test_nowarn h5read(fn, GenericString("A"))
+Ar = h5read(fn, GenericString("A"), (2:3:15, 3:5))
 
 h5write(fn, GenericString("x"), 1)
 h5read(fn, GenericString("x") => Int)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -868,6 +868,10 @@ for obj in (hfile,)
 end
 read(attrs(hfile), GenericString("a"))
 
+write(hfile, GenericString("ASD"), GenericString("Aa"))
+write(g, GenericString("ASD"), GenericString("Aa"))
+write(g, GenericString("ASD1"), [GenericString("Aa")])
+
 # test writing multiple variable
 @test_nowarn write(hfile, GenericString("a1"), rand(2,2), GenericString("a2"), rand(2,2))
 

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -845,4 +845,26 @@ hfile["test"] = 17.2
 @test_nowarn a_delete(dset1, GenericString("meta1"))
 
 
+
+dt = datatype(Int)
+ds = dataspace(0)
+d = d_create(hfile, GenericString("d"), dt, ds)
+g = g_create(hfile, GenericString("g"))
+a = a_create(hfile, GenericString("a"), dt, ds)
+
+
+for obj in (d, g)
+    a_write(obj, GenericString("a"), 1)
+    a_read(obj, GenericString("a"))
+end
+
+for obj in (hfile,)
+    d_open(obj, GenericString("d"))
+    d_write(obj, GenericString("dd"), 1)
+    d_read(obj, GenericString("dd"))
+    read(obj, GenericString("dd"))
+    read(obj, GenericString("dd")=>Int)
+end
+
+
 end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -769,7 +769,7 @@ end # split1 tests
 fn = tempname()
 hfile = h5open(fn, "w")
 
-group1 = g_create(hfile, GenericString("group1"))
+group1 = g_create(hfile, "group1")
 group2 = g_create(group1, "group2")
 
 @test haskey(hfile, GenericString("group1"))
@@ -777,7 +777,7 @@ group2 = g_create(group1, "group2")
 @test haskey(hfile, "group1/group2")
 @test !haskey(hfile, "group1/groupna")
 
-dset1 = d_create(hfile, GenericString("dset1"), datatype(Int), dataspace((1,)))
+dset1 = d_create(hfile, "dset1", datatype(Int), dataspace((1,)))
 dset2 = d_create(group1, "dset2", datatype(Int), dataspace((1,)))
 
 @test haskey(hfile, "dset1")
@@ -785,10 +785,8 @@ dset2 = d_create(group1, "dset2", datatype(Int), dataspace((1,)))
 @test haskey(hfile, "group1/dset2")
 @test !haskey(hfile, "group1/dsetna")
 
-meta1 = a_create(dset1, GenericString("meta1"), datatype(Bool), dataspace((1,)))
-meta2 = a_create(dset1, "meta2", datatype(Bool), dataspace((1,)))
+meta1 = a_create(dset1, "meta1", datatype(Bool), dataspace((1,)))
 @test haskey(dset1, "meta1")
-@test haskey(dset1, "meta2")
 @test !haskey(dset1, "metana")
 
 
@@ -807,3 +805,22 @@ haskey(attribs, GenericString("attr"))
 close(hfile)
 rm(fn)
 end # haskey tests
+
+
+@testset "AbstractString" begin
+
+fn = tempname()
+hfile = h5open(fn, "w")
+
+# test that these work with GenericString
+@test_nowarn g_create(hfile, GenericString("group1"))
+@test_nowarn d_create(hfile, GenericString("dset1"), datatype(Int), dataspace((1,)))
+@test_nowarn a_create(hfile["dset1"], GenericString("meta1"), datatype(Bool), dataspace((1,)))
+
+memtype_id = HDF5.h5t_copy(HDF5.H5T_NATIVE_DOUBLE)
+dt = HDF5.Datatype(memtype_id)
+@test !HDF5.h5t_committed(dt)
+t_commit(hfile, GenericString("dt"), dt)
+@test HDF5.h5t_committed(dt)
+
+end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -856,6 +856,8 @@ for obj in (d, g)
    @test_nowarn a_read(obj, GenericString("a"))
    @test_nowarn write(obj, GenericString("aa"), 1)
 end
+@test_nowarn d_write(g, GenericString("ag"), GenericString("gg"))
+@test_nowarn d_write(g, GenericString("ag_array"), [GenericString("a1"), GenericString("a2")])
 
 for obj in (hfile,)
     @test_nowarn d_open(obj, GenericString("d"))

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -811,6 +811,9 @@ end # haskey tests
 
 fn = GenericString(tempname())
 hfile = h5open(fn, "w")
+close(hfile)
+hfile = h5open(fn); close(hfile)
+hfile = h5open(fn, "w")
 
 @test_nowarn g_create(hfile, GenericString("group1"))
 @test_nowarn d_create(hfile, GenericString("dset1"), datatype(Int), dataspace((1,)))

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -812,16 +812,17 @@ end # haskey tests
 fn = GenericString(tempname())
 hfile = h5open(fn, "w")
 
-# test that these work with GenericString
-# creation
 @test_nowarn g_create(hfile, GenericString("group1"))
 @test_nowarn d_create(hfile, GenericString("dset1"), datatype(Int), dataspace((1,)))
-# reading
+@test_nowarn d_create(hfile, GenericString("dset2"), 1)
+
 @test_nowarn hfile[GenericString("group1")]
 @test_nowarn hfile[GenericString("dset1")]
 
+
 dset1 = hfile["dset1"]
 @test_nowarn a_create(dset1, GenericString("meta1"), datatype(Bool), dataspace((1,)))
+@test_nowarn a_create(dset1, GenericString("meta2"), 1)
 @test_nowarn  dset1[GenericString("meta1")]
 
 

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -813,17 +813,24 @@ fn = tempname()
 hfile = h5open(fn, "w")
 
 # test that these work with GenericString
+# creation
 @test_nowarn g_create(hfile, GenericString("group1"))
 @test_nowarn d_create(hfile, GenericString("dset1"), datatype(Int), dataspace((1,)))
-@test_nowarn a_create(hfile["dset1"], GenericString("meta1"), datatype(Bool), dataspace((1,)))
+# reading
+@test_nowarn hfile[GenericString("group1")]
+@test_nowarn hfile[GenericString("dset1")]
 
-hfile[GenericString("group1")]
+dset1 = hfile["dset1"]
+@test_nowarn a_create(dset1, GenericString("meta1"), datatype(Bool), dataspace((1,)))
+@test_nowarn  dset1[GenericString("meta1")]
 
 
+# transient types
 memtype_id = HDF5.h5t_copy(HDF5.H5T_NATIVE_DOUBLE)
 dt = HDF5.Datatype(memtype_id)
 @test !HDF5.h5t_committed(dt)
 t_commit(hfile, GenericString("dt"), dt)
 @test HDF5.h5t_committed(dt)
+
 
 end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -834,7 +834,7 @@ write(hfile, "array_of_strings", array_of_strings)
 @test_nowarn attrs(hfile)[GenericString("ref_test")] = HDF5.Reference(hfile, GenericString("array_of_strings"))
 @test read(attrs(hfile)[GenericString("ref_test")]) === HDF5.Reference(hfile, "array_of_strings")
 
-hfile["test"] = 17.2
+hfile[GenericString("test")] = 17.2
 @test_nowarn o_delete(hfile, GenericString("test"))
 @test_nowarn a_delete(dset1, GenericString("meta1"))
 
@@ -864,6 +864,7 @@ for obj in (hfile,)
     @test_nowarn read(obj, GenericString("dd"))
     @test_nowarn read(obj, GenericString("dd")=>Int)
 end
+read(attrs(hfile), GenericString("a"))
 
 # test writing multiple variable
 @test_nowarn write(hfile, GenericString("a1"), rand(2,2), GenericString("a2"), rand(2,2))

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -857,6 +857,7 @@ a = a_create(hfile, GenericString("a"), dt, ds)
 for obj in (d, g)
     a_write(obj, GenericString("a"), 1)
     a_read(obj, GenericString("a"))
+    write(obj, GenericString("aa"), 1)
 end
 
 for obj in (hfile,)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -829,13 +829,6 @@ dset1 = hfile["dset1"]
 @test_nowarn dset1[GenericString("meta1")]
 @test_nowarn dset1[GenericString("x")] = 2
 
-# transient types
-memtype_id = HDF5.h5t_copy(HDF5.H5T_NATIVE_DOUBLE)
-dt = HDF5.Datatype(memtype_id)
-@test !HDF5.h5t_committed(dt)
-t_commit(hfile, GenericString("dt"), dt)
-@test HDF5.h5t_committed(dt)
-
 array_of_strings = ["test",]
 write(hfile, "array_of_strings", array_of_strings)
 @test_nowarn attrs(hfile)[GenericString("ref_test")] = HDF5.Reference(hfile, GenericString("array_of_strings"))
@@ -845,14 +838,18 @@ hfile["test"] = 17.2
 @test_nowarn o_delete(hfile, GenericString("test"))
 @test_nowarn a_delete(dset1, GenericString("meta1"))
 
-
+# transient types
+memtype_id = HDF5.h5t_copy(HDF5.H5T_NATIVE_DOUBLE)
+dt = HDF5.Datatype(memtype_id)
+@test !HDF5.h5t_committed(dt)
+t_commit(hfile, GenericString("dt"), dt)
+@test HDF5.h5t_committed(dt)
 
 dt = datatype(Int)
 ds = dataspace(0)
 d = d_create(hfile, GenericString("d"), dt, ds)
 g = g_create(hfile, GenericString("g"))
 a = a_create(hfile, GenericString("a"), dt, ds)
-
 
 for obj in (d, g)
     a_write(obj, GenericString("a"), 1)
@@ -870,5 +867,12 @@ end
 
 # test writing multiple variable
 write(hfile, GenericString("a1"), rand(2,2), GenericString("a2"), rand(2,2))
+
+# copy methods
+d1 = d_create(hfile, GenericString("d1"), dt, ds)
+d1["x"] = 32
+o_copy(hfile, GenericString("d1"), hfile, GenericString("d1copy1"))
+o_copy(d1, hfile, GenericString("d1copy2"))
+
 
 end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -823,8 +823,8 @@ hfile = h5open(fn, "w")
 dset1 = hfile["dset1"]
 @test_nowarn a_create(dset1, GenericString("meta1"), datatype(Bool), dataspace((1,)))
 @test_nowarn a_create(dset1, GenericString("meta2"), 1)
-@test_nowarn  dset1[GenericString("meta1")]
-
+@test_nowarn dset1[GenericString("meta1")]
+@test_nowarn dset1[GenericString("x")] = 2
 
 # transient types
 memtype_id = HDF5.h5t_copy(HDF5.H5T_NATIVE_DOUBLE)
@@ -833,12 +833,10 @@ dt = HDF5.Datatype(memtype_id)
 t_commit(hfile, GenericString("dt"), dt)
 @test HDF5.h5t_committed(dt)
 
-
-# Scalar reference values in attributes
 array_of_strings = ["test",]
 write(hfile, "array_of_strings", array_of_strings)
-attrs(hfile)["ref_test"] = HDF5.Reference(hfile, GenericString("array_of_strings"))
-@test read(attrs(hfile)["ref_test"]) === HDF5.Reference(hfile, "array_of_strings")
+@test_nowarn attrs(hfile)[GenericString("ref_test")] = HDF5.Reference(hfile, GenericString("array_of_strings"))
+@test read(attrs(hfile)[GenericString("ref_test")]) === HDF5.Reference(hfile, "array_of_strings")
 
 hfile["test"] = 17.2
 @test_nowarn o_delete(hfile, GenericString("test"))

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -817,6 +817,9 @@ hfile = h5open(fn, "w")
 @test_nowarn d_create(hfile, GenericString("dset1"), datatype(Int), dataspace((1,)))
 @test_nowarn a_create(hfile["dset1"], GenericString("meta1"), datatype(Bool), dataspace((1,)))
 
+hfile[GenericString("group1")]
+
+
 memtype_id = HDF5.h5t_copy(HDF5.H5T_NATIVE_DOUBLE)
 dt = HDF5.Datatype(memtype_id)
 @test !HDF5.h5t_committed(dt)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -868,5 +868,7 @@ for obj in (hfile,)
     read(obj, GenericString("dd")=>Int)
 end
 
+# test writing multiple variable
+write(hfile, GenericString("a1"), rand(2,2), GenericString("a2"), rand(2,2))
 
 end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -900,4 +900,7 @@ end
 @test_nowarn h5writeattr(fn, GenericString("W"), Dict("a" => 1, "b" => 2))
 @test_nowarn h5readattr(fn, GenericString("W"))
 
+fn_external = GenericString(tempname())
+dset = d_create_external(hfile, "ext", fn_external, Int, (10,20))
+
 end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -809,7 +809,7 @@ end # haskey tests
 
 @testset "AbstractString" begin
 
-fn = tempname()
+fn = GenericString(tempname())
 hfile = h5open(fn, "w")
 
 # test that these work with GenericString
@@ -832,5 +832,11 @@ dt = HDF5.Datatype(memtype_id)
 t_commit(hfile, GenericString("dt"), dt)
 @test HDF5.h5t_committed(dt)
 
+
+# Scalar reference values in attributes
+array_of_strings = ["test",]
+write(hfile, "array_of_strings", array_of_strings)
+attrs(hfile)["ref_test"] = HDF5.Reference(hfile, GenericString("array_of_strings"))
+@test read(attrs(hfile)["ref_test"]) === HDF5.Reference(f, "array_of_strings")
 
 end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -874,5 +874,25 @@ d1["x"] = 32
 o_copy(hfile, GenericString("d1"), hfile, GenericString("d1copy1"))
 o_copy(d1, hfile, GenericString("d1copy2"))
 
+fn = GenericString(tempname())
+A = Matrix(reshape(1:120, 15, 8))
+h5write(fn, GenericString("A"), A)
+Ar = h5read(fn, GenericString("A"))
+
+h5write(fn, GenericString("x"), 1)
+h5read(fn, GenericString("x") => Int)
+
+
+h5rewrite(fn) do fid
+    g_create(fid, "mygroup") do g
+        write(g, "x", 3.3)
+    end
+end
+h5rewrite(fn) do fid
+    g_create(fid, "mygroup") do g
+        write(g, "y", 3.3)
+    end
+end
+
 
 end


### PR DESCRIPTION
Incremental improvements to allow: 
1. Permits methods to accept `AbstractStrings`
2. Take advantage of convert methods to `hid_t` types


part of https://github.com/JuliaIO/HDF5.jl/issues/453