### PR TITLE
Use explicit extension of Base functions instead of manual imports

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -330,7 +330,7 @@ struct FixedString{N,PAD}
     data::NTuple{N,UInt8}
 end
 Base.length(::Type{FixedString{N,PAD}}) where {N,PAD} = N
-Base.length(::FixedString) where {T<:FixedString} = length(T)
+Base.length(str::FixedString) = length(typeof(str))
 pad(::Type{FixedString{N,PAD}}) where {N, PAD} = PAD
 pad(x::T) where {T<:FixedString} = pad(T)
 

--- a/src/datafile.jl
+++ b/src/datafile.jl
@@ -11,8 +11,6 @@
 
 abstract type DataFile end
 
-import Base: read, write
-
 # Convenience macros
 macro read(fid, sym)
     if !isa(sym, Symbol)
@@ -28,17 +26,17 @@ macro write(fid, sym)
 end
 
 # Read a list of variables, read(parent, "A", "B", "x", ...)
-read(parent::DataFile, name::AbstractString...) =
+Base.read(parent::DataFile, name::AbstractString...) =
 	tuple([read(parent, x) for x in name]...)
 
 # Read one or more variables and pass them to a function. This is
 # convenient for avoiding type inference pitfalls with the usual
 # read syntax.
-read(f::Base.Callable, parent::DataFile, name::AbstractString...) =
+Base.read(f::Base.Callable, parent::DataFile, name::AbstractString...) =
 	f(read(parent, name...)...)
 
 # Read every variable in the file
-function read(f::DataFile)
+function Base.read(f::DataFile)
     vars = keys(f)
     vals = Vector{Any}(undef,length(vars))
     for i = 1:length(vars)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -15,12 +15,12 @@ import Base: @deprecate, @deprecate_binding, depwarn
 # - using symbols instead of strings for property keys
 @deprecate setindex!(p::Properties, val, name::AbstractString) setindex!(p, val, Symbol(name))
 
-function getindex(parent::Union{File,Group}, path::AbstractString, prop1::AbstractString, val1, pv...)
+function Base.getindex(parent::Union{File,Group}, path::AbstractString, prop1::AbstractString, val1, pv...)
     depwarn("getindex(::Union{HDF5.File, HDF5.Group}, path, props...) with string key and value argument pairs is deprecated. Use keywords instead.", :getindex)
     props = (prop1, val1, pv...)
     return getindex(parent, path; [Symbol(props[i]) => props[i+1] for i in 1:2:length(props)]...)
 end
-function setindex!(parent::Union{File,Group}, val, path::AbstractString, prop1::AbstractString, val1, pv...)
+function Base.setindex!(parent::Union{File,Group}, val, path::AbstractString, prop1::AbstractString, val1, pv...)
     depwarn("setindex!(::Union{HDF5.File, HDF5.Group}, val, path, props...) with string key and value argument pairs is deprecated. Use keywords instead.", :setindex!)
     props = (prop1, val1, pv...)
     return setindex!(parent, val, path; [Symbol(props[i]) => props[i+1] for i in 1:2:length(props)]...)
@@ -60,6 +60,7 @@ end
 
 ### Changed in PR#652
 # - read takes array element type, not Array with eltype
+import Base: read
 @deprecate read(obj::DatasetOrAttribute, ::Type{A}, I...) where {A<:Array} read(obj, eltype(A), I...)
 
 ### Changed in PR#657
@@ -122,7 +123,7 @@ for (fsym, ptype) in ((:d_write, Union{File,Group}),
         end
     end
 end
-function write(parent::Union{File,Group}, name::AbstractString, data::Union{T,AbstractArray{T}},
+function Base.write(parent::Union{File,Group}, name::AbstractString, data::Union{T,AbstractArray{T}},
                plists::Properties...) where {T<:Union{ScalarType,<:AbstractString,Complex{<:ScalarType}}}
     depwarn("`write(parent::Union{HDF5.File, HDF5.Group}, name::AbstractString, data, plists::HDF5Properties...)` " *
             "with property lists is deprecated, use " *
@@ -141,7 +142,7 @@ function write(parent::Union{File,Group}, name::AbstractString, data::Union{T,Ab
         close(dtype)
     end
 end
-function write(parent::Dataset, name::AbstractString, data::Union{T,AbstractArray{T}},
+function Base.write(parent::Dataset, name::AbstractString, data::Union{T,AbstractArray{T}},
                plists::Properties...) where {T<:Union{ScalarType,<:AbstractString}}
     depwarn("`write(parent::HDF5Dataset, name::AbstractString, data, plists::HDF5Properties...)` " *
             "with property lists is deprecated, use " *

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -910,3 +910,7 @@ fn_external = GenericString(tempname())
 dset = d_create_external(hfile, "ext", fn_external, Int, (10,20))
 
 end
+
+# length for FixedString
+fix = HDF5.FixedString{4,0}((b"test"...,))
+@test length(fix) == 4


### PR DESCRIPTION
Major change:
1. Take advantage of defaults methods in `t_commit`

Unrelated changes:
1. Explicitly define method overloads (we should stick to this convention throughout the module, instead of imports as it can quickly be easy to forget where the methods are originally defined).
2. Misc whitespace fixups. 