### PR TITLE
Fixup cleanup function for a_write

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1756,7 +1756,13 @@ end
 ### Convenience wrappers ###
 # These supply default values where possible
 # See also the "special handling" section below
-h5a_write(attr_id::hid_t, mem_type_id::hid_t, buf::String) = h5a_write(attr_id, mem_type_id, unsafe_wrap(Vector{UInt8}, pointer(buf), ncodeunits(buf)))
+function h5a_write(attr_id::hid_t, mem_type_id::hid_t, str::AbstractString)
+    strbuf = Base.cconvert(Cstring, str)
+    GC.@preserve strbuf begin
+        buf = Base.unsafe_convert(Ptr{UInt8}, strbuf)
+        h5a_write(attr_id, mem_type_id, buf)
+    end
+end
 function h5a_write(attr_id::hid_t, mem_type_id::hid_t, x::T) where {T<:Union{ScalarType,Complex{<:ScalarType}}}
     tmp = Ref{T}(x)
     h5a_write(attr_id, mem_type_id, tmp)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1419,7 +1419,7 @@ function a_write(parent::Union{File,Object}, name::AbstractString, data; pv...)
     try
         writearray(obj, dtype.id, data)
     catch exc
-        o_delete(obj)
+        a_delete(parent, name)
         rethrow(exc)
     finally
         close(obj)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -855,7 +855,9 @@ for obj in (d, g)
    @test_nowarn a_write(obj, GenericString("a"), 1)
    @test_nowarn a_read(obj, GenericString("a"))
    @test_nowarn write(obj, GenericString("aa"), 1)
+   @test_nowarn attrs(obj)["attr1"] = GenericString("b")
 end
+@test_nowarn write(d, "attr2", GenericString("c"))
 @test_nowarn d_write(g, GenericString("ag"), GenericString("gg"))
 @test_nowarn d_write(g, GenericString("ag_array"), [GenericString("a1"), GenericString("a2")])
 


### PR DESCRIPTION
Found this while working on another PR. Main issue is that 
`o_delete(obj)` when `obj` is attribute  doesn't work. 


Tests are not going to pass until the AbstractString clean up passes.
