### PR TITLE
Add support for dimension scales API bindings

### DIFF
--- a/docs/src/api_bindings.md
+++ b/docs/src/api_bindings.md
@@ -250,6 +250,19 @@ h5do_append(dset_id::hid_t, dxpl_id::hid_t, index::Cuint, num_elem::hsize_t, mem
 h5do_write_chunk(dset_id::hid_t, dxpl_id::hid_t, filter_mask::Int32, offset::Ptr{hsize_t}, bufsize::Csize_t, buf::Ptr{Cvoid})
 ```
 
+## [`H5DS`](https://portal.hdfgroup.org/display/HDF5/Dimension+Scales) — Dimension Scale Interface
+```julia
+h5ds_attach_scale(did::hid_t, dsid::hid_t, idx::Cuint)
+h5ds_detach_scale(did::hid_t, dsid::hid_t, idx::Cuint)
+h5ds_get_label(did::hid_t, idx::Cuint, label::Ptr{UInt8}, size::hsize_t)
+h5ds_get_num_scales(did::hid_t, idx::Cuint)
+h5ds_get_scale_name(did::hid_t, name::Ptr{UInt8}, size::Csize_t)
+h5ds_is_attached(did::hid_t, dsid::hid_t, idx::Cuint)
+h5ds_is_scale(did::hid_t)
+h5ds_set_label(did::hid_t, idx::Cuint, label::Ref{UInt8})
+h5ds_set_scale(dsid::hid_t, dimname::Ptr{UInt8})
+```
+
 ## [`H5LT`](https://portal.hdfgroup.org/display/HDF5/Lite) — Lite Interface
 ```julia
 h5lt_dtype_to_text(datatype::hid_t, str::Ptr{UInt8}, lang_type::Cint, len::Ref{Csize_t})

--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -259,6 +259,21 @@
 @bind h5do_write_chunk(dset_id::hid_t, dxpl_id::hid_t, filter_mask::Int32, offset::Ptr{hsize_t}, bufsize::Csize_t, buf::Ptr{Cvoid})::herr_t "Error writing chunk"
 
 ###
+### High Level Dimension Scale Interface
+###
+
+@bind h5ds_attach_scale(did::hid_t, dsid::hid_t, idx::Cuint)::herr_t "Unable to attach scale"
+@bind h5ds_detach_scale(did::hid_t, dsid::hid_t, idx::Cuint)::herr_t "Unable to detach scale"
+@bind h5ds_get_label(did::hid_t, idx::Cuint, label::Ptr{UInt8}, size::hsize_t)::herr_t "Unable to get label"
+@bind h5ds_get_num_scales(did::hid_t, idx::Cuint)::Cint "Error getting number of scales"
+@bind h5ds_get_scale_name(did::hid_t, name::Ptr{UInt8}, size::Csize_t)::Cssize_t "Unable to get scale name"
+@bind h5ds_is_attached(did::hid_t, dsid::hid_t, idx::Cuint)::htri_t "Unable to check if dimension is attached"
+@bind h5ds_is_scale(did::hid_t)::htri_t "Unable to check if dataset is scale"
+@bind h5ds_set_label(did::hid_t, idx::Cuint, label::Ref{UInt8})::herr_t "Unable to set label"
+@bind h5ds_set_scale(dsid::hid_t, dimname::Ptr{UInt8})::herr_t "Unable to set scale"
+
+
+###
 ### HDF5 Lite Interface
 ###
 
@@ -275,17 +290,3 @@
 ###
 
 @bind h5z_register(filter_class::Ref{H5Z_class_t})::herr_t "Unable to register new filter"
-
-###
-### High Level Dimension Scale Interface
-###
-
-@bind h5ds_attach_scale(did::hid_t, dsid::hid_t, idx::Cuint)::herr_t "Unable to attach scale"
-@bind h5ds_detach_scale(did::hid_t, dsid::hid_t, idx::Cuint)::herr_t "Unable to detach scale"
-@bind h5ds_get_label(did::hid_t, idx::Cuint, label::Ptr{UInt8}, size::hsize_t)::herr_t "Unable to get label"
-@bind h5ds_get_num_scales(did::hid_t, idx::Cuint)::Cint "Error getting number of scales"
-@bind h5ds_get_scale_name(did::hid_t, name::Ptr{UInt8}, size::Csize_t)::Cssize_t "Unable to get scale name"
-@bind h5ds_is_attached(did::hid_t, dsid::hid_t, idx::Cuint)::htri_t "Unable to check if dimension is attached"
-@bind h5ds_is_scale(did::hid_t)::htri_t "Unable to check if dataset is scale"
-@bind h5ds_set_label(did::hid_t, idx::Cuint, label::Ref{UInt8})::herr_t "Unable to set label"
-@bind h5ds_set_scale(dsid::hid_t, dimname::Ptr{UInt8})::herr_t "Unable to set scale"

--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -275,3 +275,17 @@
 ###
 
 @bind h5z_register(filter_class::Ref{H5Z_class_t})::herr_t "Unable to register new filter"
+
+###
+### High Level Dimension Scale Interface
+###
+
+@bind h5ds_attach_scale(did::hid_t, dsid::hid_t, idx::Cuint)::herr_t "Unable to attach scale"
+@bind h5ds_detach_scale(did::hid_t, dsid::hid_t, idx::Cuint)::herr_t "Unable to detach scale"
+@bind h5ds_get_label(did::hid_t, idx::Cuint, label::Ptr{UInt8}, size::hsize_t)::herr_t "Unable to get label"
+@bind h5ds_get_num_scales(did::hid_t, idx::Cuint)::Cint "Error getting number of scales"
+@bind h5ds_get_scale_name(did::hid_t, name::Ptr{UInt8}, size::Csize_t)::Cssize_t "Unable to get scale name"
+@bind h5ds_is_attached(did::hid_t, dsid::hid_t, idx::Cuint)::htri_t "Unable to check if dimension is attached"
+@bind h5ds_is_scale(did::hid_t)::htri_t "Unable to check if dataset is scale"
+@bind h5ds_set_label(did::hid_t, idx::Cuint, label::Ref{UInt8})::herr_t "Unable to set label"
+@bind h5ds_set_scale(dsid::hid_t, dimname::Ptr{UInt8})::herr_t "Unable to set scale"

--- a/gen/bind_generator.jl
+++ b/gen/bind_generator.jl
@@ -115,7 +115,7 @@ macro bind(sig::Expr, err::Union{String,Expr,Nothing} = nothing)
     push!(funclist, string(funcsig))
 
     # Determine the underlying C library to call
-    lib = startswith(string(cfuncname), r"H5(DO|LT|TB)") ? :libhdf5_hl : :libhdf5
+    lib = startswith(string(cfuncname), r"H5(DO|LT|TB|DS)") ? :libhdf5_hl : :libhdf5
 
     # Now start building up the full expression:
     statsym = Symbol("#status#") # not using gensym() to have stable naming

--- a/gen/gen_wrappers.jl
+++ b/gen/gen_wrappers.jl
@@ -44,9 +44,9 @@ for (mod, desc, urltail) in (
     ("H5T", "Datatype Interface", "Datatypes"),
     ("H5Z", "Filter Interface", "Filters"),
     ("H5DO", "Optimized Functions Interface", "Optimizations"),
+    ("H5DS", "Dimension Scale Interface", "Dimension+Scales"),
     ("H5LT", "Lite Interface", "Lite"),
     ("H5TB", "Table Interface", "Tables"),
-    ("H5DS", "Dimension Scale Interface", "Dimension+Scales"),
     )
     global apidocs
     funcs = join(sort!(bound_api[mod]), "\n")

--- a/gen/gen_wrappers.jl
+++ b/gen/gen_wrappers.jl
@@ -46,6 +46,7 @@ for (mod, desc, urltail) in (
     ("H5DO", "Optimized Functions Interface", "Optimizations"),
     ("H5LT", "Lite Interface", "Lite"),
     ("H5TB", "Table Interface", "Tables"),
+    ("H5DS", "Dimension Scale Interface", "Dimension+Scales"),
     )
     global apidocs
     funcs = join(sort!(bound_api[mod]), "\n")

--- a/src/api.jl
+++ b/src/api.jl
@@ -1021,6 +1021,60 @@ function h5do_write_chunk(dset_id, dxpl_id, filter_mask, offset, bufsize, buf)
     return nothing
 end
 
+function h5ds_attach_scale(did, dsid, idx)
+    var"#status#" = ccall((:H5DSattach_scale, libhdf5_hl), herr_t, (hid_t, hid_t, Cuint), did, dsid, idx)
+    var"#status#" < 0 && error("Unable to attach scale")
+    return nothing
+end
+
+function h5ds_detach_scale(did, dsid, idx)
+    var"#status#" = ccall((:H5DSdetach_scale, libhdf5_hl), herr_t, (hid_t, hid_t, Cuint), did, dsid, idx)
+    var"#status#" < 0 && error("Unable to detach scale")
+    return nothing
+end
+
+function h5ds_get_label(did, idx, label, size)
+    var"#status#" = ccall((:H5DSget_label, libhdf5_hl), herr_t, (hid_t, Cuint, Ptr{UInt8}, hsize_t), did, idx, label, size)
+    var"#status#" < 0 && error("Unable to get label")
+    return nothing
+end
+
+function h5ds_get_num_scales(did, idx)
+    var"#status#" = ccall((:H5DSget_num_scales, libhdf5_hl), Cint, (hid_t, Cuint), did, idx)
+    var"#status#" < 0 && error("Error getting number of scales")
+    return var"#status#"
+end
+
+function h5ds_get_scale_name(did, name, size)
+    var"#status#" = ccall((:H5DSget_scale_name, libhdf5_hl), Cssize_t, (hid_t, Ptr{UInt8}, Csize_t), did, name, size)
+    var"#status#" < 0 && error("Unable to get scale name")
+    return var"#status#"
+end
+
+function h5ds_is_attached(did, dsid, idx)
+    var"#status#" = ccall((:H5DSis_attached, libhdf5_hl), htri_t, (hid_t, hid_t, Cuint), did, dsid, idx)
+    var"#status#" < 0 && error("Unable to check if dimension is attached")
+    return var"#status#" > 0
+end
+
+function h5ds_is_scale(did)
+    var"#status#" = ccall((:H5DSis_scale, libhdf5_hl), htri_t, (hid_t,), did)
+    var"#status#" < 0 && error("Unable to check if dataset is scale")
+    return var"#status#" > 0
+end
+
+function h5ds_set_label(did, idx, label)
+    var"#status#" = ccall((:H5DSset_label, libhdf5_hl), herr_t, (hid_t, Cuint, Ref{UInt8}), did, idx, label)
+    var"#status#" < 0 && error("Unable to set label")
+    return nothing
+end
+
+function h5ds_set_scale(dsid, dimname)
+    var"#status#" = ccall((:H5DSset_scale, libhdf5_hl), herr_t, (hid_t, Ptr{UInt8}), dsid, dimname)
+    var"#status#" < 0 && error("Unable to set scale")
+    return nothing
+end
+
 function h5lt_dtype_to_text(datatype, str, lang_type, len)
     var"#status#" = ccall((:H5LTdtype_to_text, libhdf5_hl), herr_t, (hid_t, Ptr{UInt8}, Cint, Ref{Csize_t}), datatype, str, lang_type, len)
     var"#status#" < 0 && error("Error getting datatype text representation")


### PR DESCRIPTION
This adds bindings to the HDF5 dimension scales API functions (H5DS)

All of the H5DS functions are added, except for `H5DS_ITERATE_SCALES` which I could not figure out how to bind to Julia, and it seemed of dubious use anyway.

`bind_generator.jl` was changed to allow for the H5DS functions to be correctly linked to the high level library instead of the default library.

`gen_wrappers.jl` is changed to add references to the API on the HDF Group's website.

This will close #716 