### PR TITLE
Fix a few ambiguities

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1274,11 +1274,13 @@ end
 unpad(s, pad::Integer) = unpad(String(s), pad)
 
 # Dereference
-function Base.getindex(parent::Union{File,Group,Dataset}, r::Reference)
+function _deref(parent, r::Reference)
     r == Reference() && error("Reference is null")
     obj_id = h5r_dereference(checkvalid(parent), H5P_DEFAULT, H5R_OBJECT, r)
     h5object(obj_id, parent)
 end
+Base.getindex(parent::Union{File,Group}, r::Reference) = _deref(parent, r)
+Base.getindex(parent::Dataset, r::Reference) = _deref(parent, r) # defined separately to resolve ambiguity
 
 # convert special types to native julia types
 normalize_types(x) = x

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -741,7 +741,7 @@ function d_create(parent::Union{File,Group}, path::AbstractString, dtype::Dataty
 end
 d_create(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace_dims::Dims; pv...) = d_create(checkvalid(parent), path, dtype, dataspace(dspace_dims); pv...)
 d_create(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace_dims::Tuple{Dims,Dims}; pv...) = d_create(checkvalid(parent), path, dtype, dataspace(dspace_dims[1], max_dims=dspace_dims[2]); pv...)
-d_create(parent::Union{File,Group}, path::AbstractString, dtype::Type, dspace_dims; pv...) = d_create(checkvalid(parent), path, datatype(dtype), dataspace(dspace_dims[1], max_dims=dspace_dims[2]); pv...)
+d_create(parent::Union{File,Group}, path::AbstractString, dtype::Type, dspace_dims::Tuple{Dims,Dims}; pv...) = d_create(checkvalid(parent), path, datatype(dtype), dataspace(dspace_dims[1], max_dims=dspace_dims[2]); pv...)
 
 # Note that H5Tcreate is very different; H5Tcommit is the analog of these others
 t_create(class_id, sz) = Datatype(h5t_create(class_id, sz))

--- a/test/reference.jl
+++ b/test/reference.jl
@@ -7,15 +7,32 @@ using Random, Test, HDF5
 
     f = h5open(fn, "w")
     f["data"] = data
-    f["data_ref"] = HDF5.Reference(f, "data")
+    f["group_data"] = data
+    f["attr_data"] = data
+    # reference attached to file
+    f["file_ref"] = HDF5.Reference(f, "data")
+    # reference attached to group
+    g = g_create(f, "sub")
+    g["group_ref"] = HDF5.Reference(f, "group_data")
+    # reference attached to dataset
+    f["data"]["attr_ref"] = HDF5.Reference(f, "attr_data")
+
     close(f)
 
     f = h5open(fn, "r")
-    ref = read(f["data_ref"])
-    dset = f[ref]
-    data_read = read(dset)
-    @test data == data_read
-    close(f)
+    # read back file-attached reference
+    ref = read(f["file_ref"])
+    @test ref isa HDF5.Reference
+    @test data == read(f[ref])
+    # read back group-attached reference
+    gref = read(f["sub"]["group_ref"])
+    @test gref isa HDF5.Reference
+    @test data == read(f["sub"][gref])
+    # read back dataset-attached reference
+    aref = read(f["data"]["attr_ref"])
+    @test aref isa HDF5.Reference
+    @test data == read(f["data"][aref])
 
+    close(f)
     rm(fn)
 end


### PR DESCRIPTION
The first commit doesn't actually fix any ambiguities on master, but as I'm playing with rewriting `h5d_write` methods to `d_write`, I think these signatures are going to be relevant.

The other two commits' problems were identified by running
```julia
using HDF5, Test
Test.detect_ambiguities(HDF5)
```
I've added tests for the ambiguity in the `getindex(::Dataset, ::Reference)` method since that was obviously not being tested, but I haven't for the `d_create` ambiguity since I'm thinking the method should just be deprecated. It's not tested here, nor does it get used in MAT.jl or JLD.jl since none of those test suites have run into the ambiguity either.