### PR TITLE
Replace `vlenpack` with `cconvert`

### DIFF
--- a/test/plain.jl
+++ b/test/plain.jl
@@ -58,6 +58,11 @@ write(f, "salut_2d", salut_2d)
 # Arrays of strings as vlen
 vlen = HDF5.VLen(salut_split)
 d_write(f, "salut_vlen", vlen)
+# Arrays of scalars as vlen
+vlen_int = [[3], [1], [4]]
+vleni = HDF5.VLen(vlen_int)
+d_write(f, "int_vlen", vleni)
+a_write(f["int_vlen"], "vlen_attr", vleni)
 # Empty arrays
 empty = UInt32[]
 write(f, "empty", empty)
@@ -179,6 +184,10 @@ salut_2dr = read(fr, "salut_2d")
 @test salut_2d == salut_2dr
 salut_vlenr = read(fr, "salut_vlen")
 #@test salut_vlenr == salut_split
+vlen_intr = read(fr, "int_vlen")
+@test vlen_intr == vlen_int
+vlen_attrr = read(fr["int_vlen"]["vlen_attr"])
+@test vlen_attrr == vlen_int
 Rr = read(fr, "mygroup/CompressedA")
 @test Rr == R
 Rr2 = read(fr, "mygroup2/CompressedA")


### PR DESCRIPTION
It's sufficient to have the implicit `cconvert` call at `ccall` time trigger the packing procedure. This is a step toward removing of the `h5d_write` specializations.

As I understand it, at the moment the type restrictions on the `VLen` constructors restrict the possible datasets to a much narrower range than the HDF5 library supports, but that should be OK since a wider type can always be added in the future.

(I think the narrow type range actually means GC handling is OK right now; in principle there should be calls to `cconvert` before the `unsafe_convert` to pointers, but skipping it for the small range of types allowed doesn't have any consequence. For more generic types, a `cconvert` is required, but then there's potentially the issue of rooting the returned objects through the `ccall`.)