### PR TITLE
Have deprecated `exists` export itself

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -221,4 +221,4 @@ import Base: names
 
 ### Changed in PR#694
 @deprecate has(parent::Union{File,Group,Dataset}, path::AbstractString) Base.haskey(parent, path)
-@deprecate exists(parent::Union{File,Group,Dataset,Datatype,Attributes}, path::AbstractString) Base.haskey(parent, path) false
+@deprecate exists(parent::Union{File,Group,Dataset,Datatype,Attributes}, path::AbstractString) Base.haskey(parent, path)


### PR DESCRIPTION
#694 deprecated `exists`, but that PR left it within the explicit export list so the deprecation binding still worked with the `false` final argument. Then in #701 it was removed from the main export list, so the deprecation itself needs to do the [implicit] export for the deprecation to be useful to downstream users.

Fixes #721.