### PR TITLE
Move low-level method specializations to the middle-level API

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -711,8 +711,8 @@ end
 
 function g_create(parent::Union{File,Group}, path::AbstractString,
                   lcpl::Properties=_link_properties(path),
-                  dcpl::Properties=DEFAULT_PROPERTIES)
-    Group(h5g_create(checkvalid(parent), path, lcpl, dcpl, H5P_DEFAULT), file(parent))
+                  gcpl::Properties=DEFAULT_PROPERTIES)
+    Group(h5g_create(checkvalid(parent), path, lcpl, gcpl, H5P_DEFAULT), file(parent))
 end
 function g_create(f::Function, parent::Union{File,Group}, args...)
     g = g_create(parent, args...)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -222,3 +222,16 @@ import Base: names
 ### Changed in PR#694
 @deprecate has(parent::Union{File,Group,Dataset}, path::AbstractString) Base.haskey(parent, path)
 @deprecate exists(parent::Union{File,Group,Dataset,Datatype,Attributes}, path::AbstractString) Base.haskey(parent, path)
+
+### Changed in PR#
+@deprecate h5a_create(loc_id, name, type_id, space_id) h5a_create(loc_id, name, type_id, space_id, HDF5._attr_properties(name), HDF5.H5P_DEFAULT) false
+@deprecate h5a_open(obj_id, name) h5a_open(obj_id, name, HDF5.H5P_DEFAULT) false
+@deprecate h5d_create(loc_id, name, type_id, space_id) h5d_create(loc_id, name, type_id, space_id, HDF5._link_properties(path), HDF5.H5P_DEFAULT, HDF5.H5P_DEFAULT) false
+@deprecate h5d_open(loc_id, name) h5d_open(loc_id, name, HDF5.H5P_DEFAULT) false
+@deprecate h5f_create(pathname) h5f_create(pathname, HDF5.H5F_ACC_TRUNC, HDF5.H5P_DEFAULT, HDF5.H5P_DEFAULT) false
+@deprecate h5f_open(pathname, flags) h5f_open(pathname, flags, HDF5.H5P_DEFAULT) false
+@deprecate h5g_create(loc_id, pathname) h5g_create(loc_id, pathname, HDF5._link_properties(pathname), HDF5.H5P_DEFAULT, HDF5.H5P_DEFAULT) false
+@deprecate h5g_create(loc_id, pathname, lcpl_id, gcpl_id) h5g_create(loc_id, pathname, lcpl_id, gcpl_id, HDF5.H5P_DEFAULT) false
+@deprecate h5g_open(loc_id, pathname) h5g_open(loc_id, pathname, HDF5.H5P_DEFAULT) false
+@deprecate h5l_exists(loc_id, pathname) h5l_exists(loc_id, pathname, HDF5.H5P_DEFAULT) false
+@deprecate h5o_open(loc_id, name) h5o_open(loc_id, name, HDF5.H5P_DEFAULT) false

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -114,7 +114,7 @@ for (fsym, ptype) in ((:d_write, Union{File,Group}),
             dtype = datatype(data)
             obj = ($crsym)(parent, name, dtype, dataspace(data), prop1, plists...)
             try
-                writearray(obj, dtype.id, data)
+                $fsym(obj, dtype, data)
             catch exc
                 o_delete(obj)
                 rethrow(exc)
@@ -135,7 +135,7 @@ function Base.write(parent::Union{File,Group}, name::AbstractString, data::Union
     dtype = datatype(data)
     obj = __d_create(parent, name, dtype, dataspace(data), prop1, plists...)
     try
-        writearray(obj, dtype.id, data)
+        d_write(obj, dtype, data)
     catch exc
         o_delete(obj)
         rethrow(exc)
@@ -223,7 +223,7 @@ import Base: names
 @deprecate has(parent::Union{File,Group,Dataset}, path::AbstractString) Base.haskey(parent, path)
 @deprecate exists(parent::Union{File,Group,Dataset,Datatype,Attributes}, path::AbstractString) Base.haskey(parent, path)
 
-### Changed in PR#
+### Changed in PR#723
 @deprecate h5a_create(loc_id, name, type_id, space_id) h5a_create(loc_id, name, type_id, space_id, HDF5._attr_properties(name), HDF5.H5P_DEFAULT) false
 @deprecate h5a_open(obj_id, name) h5a_open(obj_id, name, HDF5.H5P_DEFAULT) false
 @deprecate h5d_create(loc_id, name, type_id, space_id) h5d_create(loc_id, name, type_id, space_id, HDF5._link_properties(path), HDF5.H5P_DEFAULT, HDF5.H5P_DEFAULT) false
@@ -237,3 +237,4 @@ import Base: names
 @deprecate h5o_open(loc_id, name) h5o_open(loc_id, name, HDF5.H5P_DEFAULT) false
 
 @deprecate writearray(obj::Attribute, type_id, x) a_write(obj, type_id, x) false
+@deprecate writearray(obj::Dataset, type_id, x) d_write(obj, type_id, x) false

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -238,3 +238,5 @@ import Base: names
 
 @deprecate writearray(obj::Attribute, type_id, x) a_write(obj, type_id, x) false
 @deprecate writearray(obj::Dataset, type_id, x) d_write(obj, type_id, x) false
+@deprecate readarray(obj::Dataset, type_id, buf) d_read(dset, type_id, buf) false
+@deprecate readarray(obj::Attribute, type_id, buf) a_read(attr, type_id, buf) false

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -154,7 +154,7 @@ function Base.write(parent::Dataset, name::AbstractString, data::Union{T,Abstrac
     dtype = datatype(data)
     obj = __a_create(parent, name, dtype, dataspace(data), prop1, plists...)
     try
-        writearray(obj, dtype.id, data)
+        a_create(obj, dtype.id, data)
     catch exc
         o_delete(obj)
         rethrow(exc)
@@ -235,3 +235,5 @@ import Base: names
 @deprecate h5g_open(loc_id, pathname) h5g_open(loc_id, pathname, HDF5.H5P_DEFAULT) false
 @deprecate h5l_exists(loc_id, pathname) h5l_exists(loc_id, pathname, HDF5.H5P_DEFAULT) false
 @deprecate h5o_open(loc_id, name) h5o_open(loc_id, name, HDF5.H5P_DEFAULT) false
+
+@deprecate writearray(obj::Attribute, type_id, x) a_write(obj, type_id, x) false

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -224,19 +224,61 @@ import Base: names
 @deprecate exists(parent::Union{File,Group,Dataset,Datatype,Attributes}, path::AbstractString) Base.haskey(parent, path)
 
 ### Changed in PR#723
-@deprecate h5a_create(loc_id, name, type_id, space_id) h5a_create(loc_id, name, type_id, space_id, HDF5._attr_properties(name), HDF5.H5P_DEFAULT) false
-@deprecate h5a_open(obj_id, name) h5a_open(obj_id, name, HDF5.H5P_DEFAULT) false
-@deprecate h5d_create(loc_id, name, type_id, space_id) h5d_create(loc_id, name, type_id, space_id, HDF5._link_properties(path), HDF5.H5P_DEFAULT, HDF5.H5P_DEFAULT) false
-@deprecate h5d_open(loc_id, name) h5d_open(loc_id, name, HDF5.H5P_DEFAULT) false
+# PRs #710 & #714 removed the argument type restrictions; deprecate just that form
+# explicitly since they were only forms to exist in last release.
+function h5a_create(parent_id::hid_t, name, dtype_id::hid_t, dspace_id::hid_t)
+    depwarn("`h5a_create(parent.id, name, dtype.id, dspace.id)` is deprecated, use `a_create(parent, name, dtype, dspace)` instead", :h5a_create)
+    h5a_create(parent_id, name, dtype_id, dspace_id, HDF5._attr_properties(name), HDF5.H5P_DEFAULT)
+end
+function h5a_open(parent_id::hid_t, name)
+    depwarn("`h5a_open(parent.id, name)` is deprecated, use `a_open(parent, name)` instead", :h5a_open)
+    h5a_open(parent_id, name, HDF5.H5P_DEFAULT)
+end
+function h5d_create(parent_id::hid_t, name, dtype_id::hid_t, dspace_id::hid_t)
+    depwarn("`h5d_create(parent.id, name, dtype.id, dspace.id)` is deprecated, use `d_create(parent, name, dtype, dspace)` instead", :h5d_create)
+    h5d_create(parent_id, name, dtype_id, dspace_id, HDF5._link_properties(path), HDF5.H5P_DEFAULT, HDF5.H5P_DEFAULT)
+end
+function h5d_open(parent_id::hid_t, name)
+    depwarn("`h5d_open(parent.id, name)` is deprecated, use `d_open(parent, name)` instead", :h5d_open)
+    h5d_open(parent_id, name, HDF5.H5P_DEFAULT)
+end
+function h5g_create(parent_id::hid_t, name)
+    depwarn("`h5g_create(parent.id, name)` is deprecated, use `g_create(parent, name)` instead", :h5g_create)
+    h5g_create(parent_id, name, HDF5._link_properties(name), HDF5.H5P_DEFAULT, HDF5.H5P_DEFAULT)
+end
+function h5g_create(parent_id::hid_t, name, lcpl_id::hid_t, gcpl_id::hid_t)
+    depwarn("`h5g_create(parent.id, name, lcpl.id, gcpl.id)` is deprecated, use `g_create(parent, name, lcpl, gcpl)` instead", :h5g_create)
+    h5g_create(parent_id, name, lcpl_id, gcpl_id, HDF5.H5P_DEFAULT)
+end
+function h5g_open(parent_id::hid_t, name)
+    depwarn("`h5g_open(parent.id, name)` is deprecated, use `g_open(parent, name)` instead", :h5g_open)
+    h5g_open(parent_id, name, HDF5.H5P_DEFAULT)
+end
+function h5o_open(parent_id::hid_t, name)
+    depwarn("`h5o_open(parent.id, name)` is deprecated, use `o_open(parent, name)` instead", :h5o_open)
+    h5o_open(parent_id, name, HDF5.H5P_DEFAULT)
+end
+
+function writearray(attr::Attribute, dtype_id::hid_t, x)
+    depwarn("`writearray(attr, dtype.id, x)` is deprecated, use `a_write(attr, dtype, x)` instead", :writearray)
+    dtype = Datatype(dtype_id, false)
+    a_write(attr, dtype, x)
+end
+function writearray(dset::Dataset, dtype_id::hid_t, x)
+    depwarn("`writearray(dset, dtype.id, x)` is deprecated, use `d_write(dset, dtype, x)` instead", :writearray)
+    dtype = Datatype(dtype_id, false)
+    d_write(dset, dtype, x)
+end
+function readarray(obj::Attribute, dtype_id::hid_t, buf)
+    depwarn("`readarray(attr, dtype.id, buf)` is deprecated, use `a_read(attr, dtype, buf)` instead", :readarray)
+    dtype = Datatype(dtype_id, false)
+    a_read(attr, dtype, buf)
+end
+function readarray(dset::Dataset, dtype_id::hid_t, buf)
+    depwarn("`readarray(dset, dtype.id, buf)` is deprecated, use `d_read(dset, dtype, buf)` instead", :readarray)
+    dtype = Datatype(dtype_id, false)
+    d_read(dset, dtype, buf)
+end
 @deprecate h5f_create(pathname) h5f_create(pathname, HDF5.H5F_ACC_TRUNC, HDF5.H5P_DEFAULT, HDF5.H5P_DEFAULT) false
 @deprecate h5f_open(pathname, flags) h5f_open(pathname, flags, HDF5.H5P_DEFAULT) false
-@deprecate h5g_create(loc_id, pathname) h5g_create(loc_id, pathname, HDF5._link_properties(pathname), HDF5.H5P_DEFAULT, HDF5.H5P_DEFAULT) false
-@deprecate h5g_create(loc_id, pathname, lcpl_id, gcpl_id) h5g_create(loc_id, pathname, lcpl_id, gcpl_id, HDF5.H5P_DEFAULT) false
-@deprecate h5g_open(loc_id, pathname) h5g_open(loc_id, pathname, HDF5.H5P_DEFAULT) false
-@deprecate h5l_exists(loc_id, pathname) h5l_exists(loc_id, pathname, HDF5.H5P_DEFAULT) false
-@deprecate h5o_open(loc_id, name) h5o_open(loc_id, name, HDF5.H5P_DEFAULT) false
-
-@deprecate writearray(obj::Attribute, type_id, x) a_write(obj, type_id, x) false
-@deprecate writearray(obj::Dataset, type_id, x) d_write(obj, type_id, x) false
-@deprecate readarray(obj::Dataset, type_id, buf) d_read(dset, type_id, buf) false
-@deprecate readarray(obj::Attribute, type_id, buf) a_read(attr, type_id, buf) false
+@deprecate h5l_exists(parent_id, name) h5l_exists(parent_id, name, HDF5.H5P_DEFAULT) false

--- a/test/compound.jl
+++ b/test/compound.jl
@@ -108,12 +108,12 @@ end
         foo_dtype = datatype(foo_hdf5)
         foo_space = dataspace(v_write)
         foo_dset = d_create(h5f, "foo", foo_dtype, foo_space)
-        HDF5.h5d_write(foo_dset, foo_dtype.id, v_write)
+        d_write(foo_dset, foo_dtype, v_write)
 
         bar_dtype = datatype(bar_hdf5)
         bar_space = dataspace(w_write)
         bar_dset = d_create(h5f, "bar", bar_dtype, bar_space)
-        HDF5.h5d_write(bar_dset, bar_dtype.id, w_write)
+        d_write(bar_dset, bar_dtype, w_write)
     end
 
     v_read = h5read(fn, "foo")

--- a/test/compound.jl
+++ b/test/compound.jl
@@ -107,12 +107,12 @@ end
     h5open(fn, "w") do h5f
         foo_dtype = datatype(foo_hdf5)
         foo_space = dataspace(v_write)
-        foo_dset = HDF5.h5d_create(h5f.id, "foo", foo_dtype.id, foo_space.id)
+        foo_dset = d_create(h5f, "foo", foo_dtype, foo_space)
         HDF5.h5d_write(foo_dset, foo_dtype.id, v_write)
 
         bar_dtype = datatype(bar_hdf5)
         bar_space = dataspace(w_write)
-        bar_dset = HDF5.h5d_create(h5f.id, "bar", bar_dtype.id, bar_space.id)
+        bar_dset = d_create(h5f, "bar", bar_dtype, bar_space)
         HDF5.h5d_write(bar_dset, bar_dtype.id, w_write)
     end
 

--- a/test/custom.jl
+++ b/test/custom.jl
@@ -23,7 +23,7 @@ end
         dtype = datatype(Simple)
         dspace = dataspace(v)
         dset = d_create(h5f, "data", dtype, dspace)
-        HDF5.h5d_write(dset, dtype.id, v)
+        d_write(dset, dtype, v)
     end
 
     h5open(fn, "r") do h5f

--- a/test/custom.jl
+++ b/test/custom.jl
@@ -22,7 +22,7 @@ end
     h5open(fn, "w") do h5f
         dtype = datatype(Simple)
         dspace = dataspace(v)
-        dset = HDF5.h5d_create(h5f.id, "data", dtype.id, dspace.id)
+        dset = d_create(h5f, "data", dtype, dspace)
         HDF5.h5d_write(dset, dtype.id, v)
     end
 


### PR DESCRIPTION
This implements the API cleanup I advocated for in #666, moving some of the current method overloads on what should be the low-level API up to the middle-level API layer.

Marked as WIP because:
- [x] I've built this on top of merge commits of both #714 and #719. Those should be finished and merged first.
- [x] I haven't yet sorted out how to add all the necessary method deprecations.
- [x] There's one remaining `h5d_read` to be ported.