### PR TITLE
3-arg show with hiearchical tree printing

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -365,6 +365,8 @@ function Base.cconvert(::Type{Ptr{Cvoid}}, v::VLen)
     return h
 end
 
+include("show.jl")
+
 # Blosc compression:
 include("blosc_filter.jl")
 
@@ -565,6 +567,7 @@ end
 # Ensure that objects haven't been closed
 Base.isvalid(obj::Union{File,Properties,Datatype,Dataspace}) = obj.id != -1 && h5i_is_valid(obj)
 Base.isvalid(obj::Union{Group,Dataset,Attribute}) = obj.id != -1 && obj.file.id != -1 && h5i_is_valid(obj)
+Base.isvalid(obj::Attributes) = isvalid(obj.parent)
 checkvalid(obj) = isvalid(obj) ? obj : error("File or object has been closed")
 
 # Close functions

--- a/src/show.jl
+++ b/src/show.jl
@@ -92,8 +92,8 @@ function _tree_icon(obj)
         return obj isa Attribute ? "🏷️ " :
                obj isa Group ? "📂 " :
                obj isa Dataset ? "🔢 " :
-               obj isa Datatype ? "📑 " :
-               obj isa File ? "🗃️ " :
+               obj isa Datatype ? "📄 " :
+               obj isa File ? "🗂️ " :
                "❓ "
     else
         return obj isa Attribute ? "[A] " :

--- a/src/show.jl
+++ b/src/show.jl
@@ -39,6 +39,9 @@ function Base.show(io::IO, attr::Attribute)
         print(io, "HDF5.Attribute: (invalid)")
     end
 end
+function Base.show(io::IO, attr::Attributes)
+    print(io, "Attributes of ", attr.parent)
+end
 
 function Base.show(io::IO, dtype::Datatype)
     print(io, "HDF5.Datatype: ")
@@ -104,10 +107,10 @@ function _tree_icon(obj)
                "[?] "
     end
 end
+_tree_icon(obj::Attributes) = _tree_icon(obj.parent)
 
-_tree_head(io::IO, obj::Union{File, Group, Dataset, Attribute}) = println(io, _tree_icon(obj), obj)
-_tree_head(io::IO, obj::Datatype) = println(io, _tree_icon(obj), "HDF5 Datatype: ", name(obj))
-_tree_head(io::IO, obj::Attributes) = println(io, _tree_icon(obj.parent), "Attributes of ", obj.parent)
+_tree_head(io::IO, obj) = println(io, _tree_icon(obj), obj)
+_tree_head(io::IO, obj::Datatype) = println(io, _tree_icon(obj), "HDF5.Datatype: ", name(obj))
 
 function _tree_children(parent::Union{File, Group}, attributes::Bool)
     names = keys(parent)

--- a/src/show.jl
+++ b/src/show.jl
@@ -144,7 +144,7 @@ function _tree_children(parent::Union{Attribute, Datatype}, attributes::Bool)
     return (String[], Union{Object, Attribute}[])
 end
 
-function show_tree(io::IO, obj::Union{File,Group,Dataset,Datatype,Attributes,Attribute}, indent::String="";
+function _show_tree(io::IO, obj::Union{File,Group,Dataset,Datatype,Attributes,Attribute}, indent::String="";
                    attributes::Bool = true)
     isempty(indent) && _tree_head(io, obj)
     !isvalid(obj) && return
@@ -160,8 +160,14 @@ function show_tree(io::IO, obj::Union{File,Group,Dataset,Datatype,Attributes,Att
         println(io, indent, islast ? "└─ " : "├─ ", icon, name)
 
         nextindent = indent * (islast ? "   " : "│  ")
-        show_tree(io, child, nextindent; attributes = attributes)
+        _show_tree(io, child, nextindent; attributes = attributes)
     end
     return nothing
 end
+
 show_tree(obj; kws...) = show_tree(stdout, obj; kws...)
+function show_tree(io::IO, obj; kws...)
+    buf = IOBuffer()
+    _show_tree(IOContext(buf, io), obj; kws...)
+    print(io, String(take!(buf)))
+end

--- a/src/show.jl
+++ b/src/show.jl
@@ -64,14 +64,46 @@ function Base.show(io::IO, dtype::Datatype)
     end
 end
 
-Base.show(io::IO, ::MIME"text/plain", obj::Union{File,Group,Dataset,Attributes,Attribute}) = show_tree(io, obj)
+"""
+    SHOW_TREE = Ref{Bool}(true)
 
-_tree_icon(obj) = obj isa Attribute ? "🏷️ " :
-                  obj isa Group ? "📂 " :
-                  obj isa Dataset ? "🔢 " :
-                  obj isa Datatype ? "📑 " :
-                  obj isa File ? "🗃️ " :
-                  "❓ "
+Configurable option to control whether the default `show` for HDF5 objects is printed
+using `show_tree` or not.
+"""
+const SHOW_TREE = Ref{Bool}(true)
+"""
+    SHOW_TREE_ICONS = Ref{Bool}(true)
+
+Configurable option to control whether emoji icons (`true`) or a plain-text annotation
+(`false`) is used to indicate the object type by `show_tree`.
+"""
+const SHOW_TREE_ICONS = Ref{Bool}(true)
+
+function Base.show(io::IO, ::MIME"text/plain", obj::Union{File,Group,Dataset,Attributes,Attribute})
+    if SHOW_TREE[]
+        show_tree(io, obj)
+    else
+        show(io, obj)
+    end
+end
+
+function _tree_icon(obj)
+    if SHOW_TREE_ICONS[]
+        return obj isa Attribute ? "🏷️ " :
+               obj isa Group ? "📂 " :
+               obj isa Dataset ? "🔢 " :
+               obj isa Datatype ? "📑 " :
+               obj isa File ? "🗃️ " :
+               "❓ "
+    else
+        return obj isa Attribute ? "[A] " :
+               obj isa Group ? "[G]" :
+               obj isa Dataset ? "[D] " :
+               obj isa Datatype ? "[T] " :
+               obj isa File ? "[F] " :
+               "[?] "
+    end
+end
 
 _tree_head(io::IO, obj::Union{File, Group, Dataset, Attribute}) = println(io, _tree_icon(obj), obj)
 _tree_head(io::IO, obj::Datatype) = println(io, _tree_icon(obj), "HDF5 Datatype: ", name(obj))

--- a/src/show.jl
+++ b/src/show.jl
@@ -46,6 +46,7 @@ end
 function Base.show(io::IO, dtype::Datatype)
     print(io, "HDF5.Datatype: ")
     if isvalid(dtype)
+        h5t_committed(dtype) && print(io, name(dtype), " ")
         print(io, h5lt_dtype_to_text(dtype))
     else
         # Note that h5i_is_valid returns `false` on the built-in datatypes (e.g.

--- a/src/show.jl
+++ b/src/show.jl
@@ -64,6 +64,8 @@ function Base.show(io::IO, dtype::Datatype)
     end
 end
 
+Base.show(io::IO, ::MIME"text/plain", obj::Union{File,Group,Dataset,Attributes,Attribute}) = show_tree(io, obj)
+
 _tree_icon(obj) = obj isa Attribute ? "🏷️ " :
                   obj isa Group ? "📂 " :
                   obj isa Dataset ? "🔢 " :

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,0 +1,64 @@
+_tree_icon(obj) = obj isa Attribute ? "🏷️ " :
+                  obj isa Group ? "📂 " :
+                  obj isa Dataset ? "🔢 " :
+                  obj isa Datatype ? "📑 " :
+                  obj isa File ? "🗃️ " :
+                  "❓ "
+
+_tree_head(io::IO, obj::Union{File, Group, Dataset, Attribute}) = println(io, _tree_icon(obj), obj)
+_tree_head(io::IO, obj::Datatype) = println(io, _tree_icon(obj), "HDF5 Datatype: ", name(obj))
+_tree_head(io::IO, obj::Attributes) = println(io, _tree_icon(obj.parent), "Attributes of ", obj.parent)
+
+function _tree_children(parent::Union{File, Group}, attributes::Bool)
+    names = keys(parent)
+    objs  = Union{Object, Attribute}[parent[n] for n in names]
+    if attributes
+        attrn = keys(attrs(parent))
+        attro = Union{Object, Attribute}[attrs(parent)[n] for n in attrn]
+        names = append!(attrn, names)
+        objs  = append!(attro, objs)
+    end
+    return (names, objs)
+end
+function _tree_children(parent::Dataset, attributes::Bool)
+    names = String[]
+    objs = Union{Object, Attribute}[parent[n] for n in names]
+    if attributes
+        attrn = keys(attrs(parent))
+        attro = Union{Object, Attribute}[attrs(parent)[n] for n in attrn]
+        names = append!(attrn, names)
+        objs  = append!(attro, objs)
+    end
+    return (names, objs)
+end
+function _tree_children(parent::Attributes, attributes::Bool)
+    names = keys(parent)
+    objs  = Union{Object,Attribute}[parent[n] for n in names]
+    return (names, objs)
+end
+function _tree_children(parent::Union{Attribute, Datatype}, attributes::Bool)
+    # TODO: add our own implementation of much of what h5lt_dtype_to_text() does?
+    return (String[], Union{Object, Attribute}[])
+end
+
+function show_tree(io::IO, obj::Union{File,Group,Dataset,Datatype,Attributes,Attribute}, indent::String="";
+                   attributes::Bool = true)
+    isempty(indent) && _tree_head(io, obj)
+    !isvalid(obj) && return
+
+    names, children = _tree_children(obj, attributes)
+    nchildren = length(children)
+    for ii in 1:nchildren
+        name = names[ii]
+        child  = children[ii]
+
+        islast = ii == nchildren
+        icon = _tree_icon(child)
+        println(io, indent, islast ? "└─ " : "├─ ", icon, name)
+
+        nextindent = indent * (islast ? "   " : "│  ")
+        show_tree(io, child, nextindent; attributes = attributes)
+    end
+    return nothing
+end
+show_tree(obj; kws...) = show_tree(stdout, obj; kws...)

--- a/src/show.jl
+++ b/src/show.jl
@@ -93,25 +93,25 @@ end
 
 function _tree_icon(obj)
     if SHOW_TREE_ICONS[]
-        return obj isa Attribute ? "🏷️ " :
-               obj isa Group ? "📂 " :
-               obj isa Dataset ? "🔢 " :
-               obj isa Datatype ? "📄 " :
-               obj isa File ? "🗂️ " :
-               "❓ "
+        return obj isa Attribute ? "🏷️" :
+               obj isa Group ? "📂" :
+               obj isa Dataset ? "🔢" :
+               obj isa Datatype ? "📄" :
+               obj isa File ? "🗂️" :
+               "❓"
     else
-        return obj isa Attribute ? "[A] " :
+        return obj isa Attribute ? "[A]" :
                obj isa Group ? "[G]" :
-               obj isa Dataset ? "[D] " :
-               obj isa Datatype ? "[T] " :
-               obj isa File ? "[F] " :
-               "[?] "
+               obj isa Dataset ? "[D]" :
+               obj isa Datatype ? "[T]" :
+               obj isa File ? "[F]" :
+               "[?]"
     end
 end
 _tree_icon(obj::Attributes) = _tree_icon(obj.parent)
 
-_tree_head(io::IO, obj) = println(io, _tree_icon(obj), obj)
-_tree_head(io::IO, obj::Datatype) = println(io, _tree_icon(obj), "HDF5.Datatype: ", name(obj))
+_tree_head(io::IO, obj) = print(io, _tree_icon(obj), " ", obj)
+_tree_head(io::IO, obj::Datatype) = print(io, _tree_icon(obj), " HDF5.Datatype: ", name(obj))
 
 function _tree_children(parent::Union{File, Group}, attributes::Bool)
     names = keys(parent)
@@ -158,7 +158,7 @@ function _show_tree(io::IO, obj::Union{File,Group,Dataset,Datatype,Attributes,At
 
         islast = ii == nchildren
         icon = _tree_icon(child)
-        println(io, indent, islast ? "└─ " : "├─ ", icon, name)
+        print(io, "\n", indent, islast ? "└─ " : "├─ ", icon, " ", name)
 
         nextindent = indent * (islast ? "   " : "│  ")
         _show_tree(io, child, nextindent; attributes = attributes)

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,6 +1,11 @@
 function Base.show(io::IO, fid::File)
     if isvalid(fid)
-        print(io, "HDF5.File: ", fid.filename)
+        intent = h5f_get_intent(fid)
+        RW_MASK   = H5F_ACC_RDONLY | H5F_ACC_RDWR
+        SWMR_MASK = H5F_ACC_SWMR_READ | H5F_ACC_SWMR_WRITE
+        rw = (intent & RW_MASK) == H5F_ACC_RDONLY ? "(read-only" : "(read-write"
+        swmr = (intent & SWMR_MASK) != 0 ? ", swmr) " : ") "
+        print(io, "HDF5.File: ", rw, swmr, fid.filename)
     else
         print(io, "HDF5.File: (closed) ", fid.filename)
     end

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,47 +1,47 @@
 function Base.show(io::IO, fid::File)
     if isvalid(fid)
-        print(io, "HDF5 data file: ", fid.filename)
+        print(io, "HDF5.File: ", fid.filename)
     else
-        print(io, "HDF5 data file (closed): ", fid.filename)
+        print(io, "HDF5.File: (closed) ", fid.filename)
     end
 end
 
 function Base.show(io::IO, g::Group)
     if isvalid(g)
-        print(io, "HDF5 group: ", name(g), " (file: ", g.file.filename, ")")
+        print(io, "HDF5.Group: ", name(g), " (file: ", g.file.filename, ")")
     else
-        print(io, "HDF5 group (invalid)")
+        print(io, "HDF5.Group: (invalid)")
     end
 end
 
 function Base.show(io::IO, prop::Properties)
     if prop.class == H5P_DEFAULT
-        print(io, "HDF5 property: default class")
+        print(io, "HDF5.Properties: default class")
     elseif isvalid(prop)
-        print(io, "HDF5 property: ", h5p_get_class_name(prop.class), " class")
+        print(io, "HDF5.Properties: ", h5p_get_class_name(prop.class), " class")
     else
-        print(io, "HDF5 property (invalid)")
+        print(io, "HDF5.Properties: (invalid)")
     end
 end
 
 function Base.show(io::IO, dset::Dataset)
     if isvalid(dset)
-        print(io, "HDF5 dataset: ", name(dset), " (file: ", dset.file.filename, " xfer_mode: ", dset.xfer.id, ")")
+        print(io, "HDF5.Dataset: ", name(dset), " (file: ", dset.file.filename, " xfer_mode: ", dset.xfer.id, ")")
     else
-        print(io, "HDF5 dataset (invalid)")
+        print(io, "HDF5.Dataset: (invalid)")
     end
 end
 
 function Base.show(io::IO, attr::Attribute)
     if isvalid(attr)
-        print(io, "HDF5 attribute: ", name(attr))
+        print(io, "HDF5.Attribute: ", name(attr))
     else
-        print(io, "HDF5 attribute (invalid)")
+        print(io, "HDF5.Attribute: (invalid)")
     end
 end
 
 function Base.show(io::IO, dtype::Datatype)
-    print(io, "HDF5 datatype: ")
+    print(io, "HDF5.Datatype: ")
     if isvalid(dtype)
         print(io, h5lt_dtype_to_text(dtype))
     else

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -716,6 +716,8 @@ prop = p_create(HDF5.H5P_DATASET_CREATE)
 
 dtype = HDF5.Datatype(HDF5.h5t_copy(HDF5.H5T_IEEE_F64LE))
 @test sprint(show, dtype) == "HDF5.Datatype: H5T_IEEE_F64LE"
+t_commit(hfile, "type", dtype)
+@test sprint(show, dtype) == "HDF5.Datatype: /type H5T_IEEE_F64LE"
 
 dspace = dataspace((1,))
 @test occursin(r"^HDF5.Dataspace\(\d+\)", sprint(show, dspace))

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -708,6 +708,9 @@ dset = d_create(group, "dset", datatype(Int), dataspace((1,)))
 meta = a_create(dset, "meta", datatype(Bool), dataspace((1,)))
 @test sprint(show, meta) == "HDF5.Attribute: meta"
 
+dsetattrs = attrs(dset)
+@test sprint(show, dsetattrs) == "Attributes of HDF5.Dataset: /group/dset (file: $fn xfer_mode: 0)"
+
 prop = p_create(HDF5.H5P_DATASET_CREATE)
 @test sprint(show, prop) == "HDF5.Properties: dataset create class"
 
@@ -733,6 +736,7 @@ close(meta)
 
 close(dset)
 @test sprint(show, dset) == "HDF5.Dataset: (invalid)"
+@test sprint(show, dsetattrs) == "Attributes of HDF5.Dataset: (invalid)"
 
 close(group)
 @test sprint(show, group) == "HDF5.Group: (invalid)"

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -783,8 +783,7 @@ msg = String(take!(buf))
 │  ├─ 🏷️ dirty
 │  └─ 🔢 data
 │     └─ 🏷️ mode
-└─ 🔢 version
-"""m, msg)
+└─ 🔢 version"""m, msg)
 @test sprint(show3, hfile) == msg
 
 HDF5.show_tree(buf, hfile, attributes = false)
@@ -793,15 +792,13 @@ HDF5.show_tree(buf, hfile, attributes = false)
 ├─ 📄 dtype
 ├─ 📂 inner
 │  └─ 🔢 data
-└─ 🔢 version
-"""m, String(take!(buf)))
+└─ 🔢 version"""m, String(take!(buf)))
 
 HDF5.show_tree(buf, attrs(hfile))
 msg = String(take!(buf))
 @test occursin(r"""
 🗂️ Attributes of HDF5.File: .*$
-└─ 🏷️ creator
-"""m, msg)
+└─ 🏷️ creator"""m, msg)
 @test sprint(show3, attrs(hfile)) == msg
 
 HDF5.show_tree(buf, hfile["inner"])
@@ -810,37 +807,31 @@ msg = String(take!(buf))
 📂 HDF5.Group: /inner .*$
 ├─ 🏷️ dirty
 └─ 🔢 data
-   └─ 🏷️ mode
-"""m, msg)
+   └─ 🏷️ mode"""m, msg)
 @test sprint(show3, hfile["inner"]) == msg
 
 HDF5.show_tree(buf, hfile["inner"], attributes = false)
 @test occursin(r"""
 📂 HDF5.Group: /inner .*$
-└─ 🔢 data
-"""m, String(take!(buf)))
+└─ 🔢 data"""m, String(take!(buf)))
 
 HDF5.show_tree(buf, hfile["inner/data"])
 msg = String(take!(buf))
 @test occursin(r"""
 🔢 HDF5.Dataset: /inner/data .*$
-└─ 🏷️ mode
-"""m, msg)
+└─ 🏷️ mode"""m, msg)
 # xfer_mode changes between printings, so need regex again
 @test occursin(r"""
 🔢 HDF5.Dataset: /inner/data .*$
-└─ 🏷️ mode
-"""m, sprint(show3, hfile["inner/data"]))
+└─ 🏷️ mode"""m, sprint(show3, hfile["inner/data"]))
 
 HDF5.show_tree(buf, hfile["inner/data"], attributes = false)
 @test occursin(r"""
-🔢 HDF5.Dataset: /inner/data .*$
-"""m, String(take!(buf)))
+🔢 HDF5.Dataset: /inner/data .*$"""m, String(take!(buf)))
 
 HDF5.show_tree(buf, hfile["dtype"])
 @test occursin(r"""
-📄 HDF5.Datatype: /dtype
-""", String(take!(buf)))
+📄 HDF5.Datatype: /dtype""", String(take!(buf)))
 
 # configurable options
 
@@ -850,12 +841,11 @@ HDF5.SHOW_TREE_ICONS[] = false
 \[F\] HDF5.File: .*$
 ├─ \[A\] creator
 ├─ \[T\] dtype
-├─ \[G\]inner
+├─ \[G\] inner
 │  ├─ \[A\] dirty
 │  └─ \[D\] data
 │     └─ \[A\] mode
-└─ \[D\] version
-"""m, sprint(show3, hfile))
+└─ \[D\] version"""m, sprint(show3, hfile))
 HDF5.SHOW_TREE_ICONS[] = true
 
 # no tree printing

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -765,8 +765,10 @@ HDF5.h5t_insert(t, "type", sizeof(tmeta), tstr)
 HDF5.t_commit(hfile, "dtype", t)
 
 buf = IOBuffer()
+show3(io::IO, x) = show(io, MIME"text/plain"(), x)
 
 HDF5.show_tree(buf, hfile)
+msg = String(take!(buf))
 @test occursin(r"""
 🗃️ HDF5 data file: .*
 ├─ 🏷️ creator
@@ -776,7 +778,8 @@ HDF5.show_tree(buf, hfile)
 │  └─ 🔢 data
 │     └─ 🏷️ mode
 └─ 🔢 version
-""", String(take!(buf)))
+""", msg)
+@test sprint(show3, hfile) == msg
 
 HDF5.show_tree(buf, hfile, attributes = false)
 @test occursin(r"""
@@ -788,18 +791,22 @@ HDF5.show_tree(buf, hfile, attributes = false)
 """, String(take!(buf)))
 
 HDF5.show_tree(buf, attrs(hfile))
+msg = String(take!(buf))
 @test occursin(r"""
 🗃️ Attributes of HDF5 data file: .*
 └─ 🏷️ creator
-""", String(take!(buf)))
+""", msg)
+@test sprint(show3, attrs(hfile)) == msg
 
 HDF5.show_tree(buf, hfile["inner"])
+msg = String(take!(buf))
 @test occursin(r"""
 📂 HDF5 group: /inner .*
 ├─ 🏷️ dirty
 └─ 🔢 data
    └─ 🏷️ mode
-""", String(take!(buf)))
+""", msg)
+@test sprint(show3, hfile["inner"]) == msg
 
 HDF5.show_tree(buf, hfile["inner"], attributes = false)
 @test occursin(r"""
@@ -808,10 +815,16 @@ HDF5.show_tree(buf, hfile["inner"], attributes = false)
 """, String(take!(buf)))
 
 HDF5.show_tree(buf, hfile["inner/data"])
+msg = String(take!(buf))
 @test occursin(r"""
 🔢 HDF5 dataset: /inner/data .*
 └─ 🏷️ mode
-""", String(take!(buf)))
+""", msg)
+# xfer_mode changes between printings, so need regex again
+@test occursin(r"""
+🔢 HDF5 dataset: /inner/data .*
+└─ 🏷️ mode
+""", sprint(show3, hfile["inner/data"]))
 
 HDF5.show_tree(buf, hfile["inner/data"], attributes = false)
 @test occursin(r"""

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -697,22 +697,22 @@ fn = tempname()
 # First create data objects and sure they print useful outputs
 
 hfile = h5open(fn, "w")
-@test sprint(show, hfile) == "HDF5 data file: $fn"
+@test sprint(show, hfile) == "HDF5.File: $fn"
 
 group = g_create(hfile, "group")
-@test sprint(show, group) == "HDF5 group: /group (file: $fn)"
+@test sprint(show, group) == "HDF5.Group: /group (file: $fn)"
 
 dset = d_create(group, "dset", datatype(Int), dataspace((1,)))
-@test sprint(show, dset) == "HDF5 dataset: /group/dset (file: $fn xfer_mode: 0)"
+@test sprint(show, dset) == "HDF5.Dataset: /group/dset (file: $fn xfer_mode: 0)"
 
 meta = a_create(dset, "meta", datatype(Bool), dataspace((1,)))
-@test sprint(show, meta) == "HDF5 attribute: meta"
+@test sprint(show, meta) == "HDF5.Attribute: meta"
 
 prop = p_create(HDF5.H5P_DATASET_CREATE)
-@test sprint(show, prop) == "HDF5 property: dataset create class"
+@test sprint(show, prop) == "HDF5.Properties: dataset create class"
 
 dtype = HDF5.Datatype(HDF5.h5t_copy(HDF5.H5T_IEEE_F64LE))
-@test sprint(show, dtype) == "HDF5 datatype: H5T_IEEE_F64LE"
+@test sprint(show, dtype) == "HDF5.Datatype: H5T_IEEE_F64LE"
 
 dspace = dataspace((1,))
 @test occursin(r"^HDF5.Dataspace\(\d+\)", sprint(show, dspace))
@@ -723,22 +723,22 @@ close(dspace)
 @test sprint(show, dspace) == "HDF5.Dataspace(-1)"
 
 close(dtype)
-@test sprint(show, dtype) == "HDF5 datatype: (invalid)"
+@test sprint(show, dtype) == "HDF5.Datatype: (invalid)"
 
 close(prop)
-@test sprint(show, prop) == "HDF5 property (invalid)"
+@test sprint(show, prop) == "HDF5.Properties: (invalid)"
 
 close(meta)
-@test sprint(show, meta) == "HDF5 attribute (invalid)"
+@test sprint(show, meta) == "HDF5.Attribute: (invalid)"
 
 close(dset)
-@test sprint(show, dset) == "HDF5 dataset (invalid)"
+@test sprint(show, dset) == "HDF5.Dataset: (invalid)"
 
 close(group)
-@test sprint(show, group) == "HDF5 group (invalid)"
+@test sprint(show, group) == "HDF5.Group: (invalid)"
 
 close(hfile)
-@test sprint(show, hfile) == "HDF5 data file (closed): $fn"
+@test sprint(show, hfile) == "HDF5.File: (closed) $fn"
 
 rm(fn)
 
@@ -770,7 +770,7 @@ show3(io::IO, x) = show(io, MIME"text/plain"(), x)
 HDF5.show_tree(buf, hfile)
 msg = String(take!(buf))
 @test occursin(r"""
-🗂️ HDF5 data file: .*$
+🗂️ HDF5.File: .*$
 ├─ 🏷️ creator
 ├─ 📄 dtype
 ├─ 📂 inner
@@ -783,7 +783,7 @@ msg = String(take!(buf))
 
 HDF5.show_tree(buf, hfile, attributes = false)
 @test occursin(r"""
-🗂️ HDF5 data file: .*$
+🗂️ HDF5.File: .*$
 ├─ 📄 dtype
 ├─ 📂 inner
 │  └─ 🔢 data
@@ -793,7 +793,7 @@ HDF5.show_tree(buf, hfile, attributes = false)
 HDF5.show_tree(buf, attrs(hfile))
 msg = String(take!(buf))
 @test occursin(r"""
-🗂️ Attributes of HDF5 data file: .*$
+🗂️ Attributes of HDF5.File: .*$
 └─ 🏷️ creator
 """m, msg)
 @test sprint(show3, attrs(hfile)) == msg
@@ -801,7 +801,7 @@ msg = String(take!(buf))
 HDF5.show_tree(buf, hfile["inner"])
 msg = String(take!(buf))
 @test occursin(r"""
-📂 HDF5 group: /inner .*$
+📂 HDF5.Group: /inner .*$
 ├─ 🏷️ dirty
 └─ 🔢 data
    └─ 🏷️ mode
@@ -810,30 +810,30 @@ msg = String(take!(buf))
 
 HDF5.show_tree(buf, hfile["inner"], attributes = false)
 @test occursin(r"""
-📂 HDF5 group: /inner .*$
+📂 HDF5.Group: /inner .*$
 └─ 🔢 data
 """m, String(take!(buf)))
 
 HDF5.show_tree(buf, hfile["inner/data"])
 msg = String(take!(buf))
 @test occursin(r"""
-🔢 HDF5 dataset: /inner/data .*$
+🔢 HDF5.Dataset: /inner/data .*$
 └─ 🏷️ mode
 """m, msg)
 # xfer_mode changes between printings, so need regex again
 @test occursin(r"""
-🔢 HDF5 dataset: /inner/data .*$
+🔢 HDF5.Dataset: /inner/data .*$
 └─ 🏷️ mode
 """m, sprint(show3, hfile["inner/data"]))
 
 HDF5.show_tree(buf, hfile["inner/data"], attributes = false)
 @test occursin(r"""
-🔢 HDF5 dataset: /inner/data .*$
+🔢 HDF5.Dataset: /inner/data .*$
 """m, String(take!(buf)))
 
 HDF5.show_tree(buf, hfile["dtype"])
 @test occursin(r"""
-📄 HDF5 Datatype: /dtype
+📄 HDF5.Datatype: /dtype
 """, String(take!(buf)))
 
 # configurable options
@@ -841,7 +841,7 @@ HDF5.show_tree(buf, hfile["dtype"])
 # no emoji icons
 HDF5.SHOW_TREE_ICONS[] = false
 @test occursin(r"""
-\[F\] HDF5 data file: .*$
+\[F\] HDF5.File: .*$
 ├─ \[A\] creator
 ├─ \[T\] dtype
 ├─ \[G\]inner

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -770,9 +770,9 @@ show3(io::IO, x) = show(io, MIME"text/plain"(), x)
 HDF5.show_tree(buf, hfile)
 msg = String(take!(buf))
 @test occursin(r"""
-🗃️ HDF5 data file: .*$
+🗂️ HDF5 data file: .*$
 ├─ 🏷️ creator
-├─ 📑 dtype
+├─ 📄 dtype
 ├─ 📂 inner
 │  ├─ 🏷️ dirty
 │  └─ 🔢 data
@@ -783,8 +783,8 @@ msg = String(take!(buf))
 
 HDF5.show_tree(buf, hfile, attributes = false)
 @test occursin(r"""
-🗃️ HDF5 data file: .*$
-├─ 📑 dtype
+🗂️ HDF5 data file: .*$
+├─ 📄 dtype
 ├─ 📂 inner
 │  └─ 🔢 data
 └─ 🔢 version
@@ -793,7 +793,7 @@ HDF5.show_tree(buf, hfile, attributes = false)
 HDF5.show_tree(buf, attrs(hfile))
 msg = String(take!(buf))
 @test occursin(r"""
-🗃️ Attributes of HDF5 data file: .*$
+🗂️ Attributes of HDF5 data file: .*$
 └─ 🏷️ creator
 """m, msg)
 @test sprint(show3, attrs(hfile)) == msg
@@ -833,7 +833,7 @@ HDF5.show_tree(buf, hfile["inner/data"], attributes = false)
 
 HDF5.show_tree(buf, hfile["dtype"])
 @test occursin(r"""
-📑 HDF5 Datatype: /dtype
+📄 HDF5 Datatype: /dtype
 """, String(take!(buf)))
 
 # configurable options

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -770,7 +770,7 @@ show3(io::IO, x) = show(io, MIME"text/plain"(), x)
 HDF5.show_tree(buf, hfile)
 msg = String(take!(buf))
 @test occursin(r"""
-🗃️ HDF5 data file: .*
+🗃️ HDF5 data file: .*$
 ├─ 🏷️ creator
 ├─ 📑 dtype
 ├─ 📂 inner
@@ -778,63 +778,84 @@ msg = String(take!(buf))
 │  └─ 🔢 data
 │     └─ 🏷️ mode
 └─ 🔢 version
-""", msg)
+"""m, msg)
 @test sprint(show3, hfile) == msg
 
 HDF5.show_tree(buf, hfile, attributes = false)
 @test occursin(r"""
-🗃️ HDF5 data file: .*
+🗃️ HDF5 data file: .*$
 ├─ 📑 dtype
 ├─ 📂 inner
 │  └─ 🔢 data
 └─ 🔢 version
-""", String(take!(buf)))
+"""m, String(take!(buf)))
 
 HDF5.show_tree(buf, attrs(hfile))
 msg = String(take!(buf))
 @test occursin(r"""
-🗃️ Attributes of HDF5 data file: .*
+🗃️ Attributes of HDF5 data file: .*$
 └─ 🏷️ creator
-""", msg)
+"""m, msg)
 @test sprint(show3, attrs(hfile)) == msg
 
 HDF5.show_tree(buf, hfile["inner"])
 msg = String(take!(buf))
 @test occursin(r"""
-📂 HDF5 group: /inner .*
+📂 HDF5 group: /inner .*$
 ├─ 🏷️ dirty
 └─ 🔢 data
    └─ 🏷️ mode
-""", msg)
+"""m, msg)
 @test sprint(show3, hfile["inner"]) == msg
 
 HDF5.show_tree(buf, hfile["inner"], attributes = false)
 @test occursin(r"""
-📂 HDF5 group: /inner .*
+📂 HDF5 group: /inner .*$
 └─ 🔢 data
-""", String(take!(buf)))
+"""m, String(take!(buf)))
 
 HDF5.show_tree(buf, hfile["inner/data"])
 msg = String(take!(buf))
 @test occursin(r"""
-🔢 HDF5 dataset: /inner/data .*
+🔢 HDF5 dataset: /inner/data .*$
 └─ 🏷️ mode
-""", msg)
+"""m, msg)
 # xfer_mode changes between printings, so need regex again
 @test occursin(r"""
-🔢 HDF5 dataset: /inner/data .*
+🔢 HDF5 dataset: /inner/data .*$
 └─ 🏷️ mode
-""", sprint(show3, hfile["inner/data"]))
+"""m, sprint(show3, hfile["inner/data"]))
 
 HDF5.show_tree(buf, hfile["inner/data"], attributes = false)
 @test occursin(r"""
-🔢 HDF5 dataset: /inner/data .*
-""", String(take!(buf)))
+🔢 HDF5 dataset: /inner/data .*$
+"""m, String(take!(buf)))
 
 HDF5.show_tree(buf, hfile["dtype"])
 @test occursin(r"""
 📑 HDF5 Datatype: /dtype
 """, String(take!(buf)))
+
+# configurable options
+
+# no emoji icons
+HDF5.SHOW_TREE_ICONS[] = false
+@test occursin(r"""
+\[F\] HDF5 data file: .*$
+├─ \[A\] creator
+├─ \[T\] dtype
+├─ \[G\]inner
+│  ├─ \[A\] dirty
+│  └─ \[D\] data
+│     └─ \[A\] mode
+└─ \[D\] version
+"""m, sprint(show3, hfile))
+HDF5.SHOW_TREE_ICONS[] = true
+
+# no tree printing
+HDF5.SHOW_TREE[] = false
+@test sprint(show3, hfile) == sprint(show, hfile)
+HDF5.SHOW_TREE[] = true
 
 close(hfile)
 rm(fn)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -696,8 +696,8 @@ fn = tempname()
 
 # First create data objects and sure they print useful outputs
 
-hfile = h5open(fn, "w")
-@test sprint(show, hfile) == "HDF5.File: $fn"
+hfile = h5open(fn, "w", swmr = true)
+@test sprint(show, hfile) == "HDF5.File: (read-write, swmr) $fn"
 
 group = g_create(hfile, "group")
 @test sprint(show, group) == "HDF5.Group: /group (file: $fn)"
@@ -745,6 +745,20 @@ close(group)
 
 close(hfile)
 @test sprint(show, hfile) == "HDF5.File: (closed) $fn"
+
+# Go back and check different access modes for file printing
+hfile = h5open(fn, "r+", swmr = true)
+@test sprint(show, hfile) == "HDF5.File: (read-write, swmr) $fn"
+close(hfile)
+hfile = h5open(fn, "r", swmr = true)
+@test sprint(show, hfile) == "HDF5.File: (read-only, swmr) $fn"
+close(hfile)
+hfile = h5open(fn, "r")
+@test sprint(show, hfile) == "HDF5.File: (read-only) $fn"
+close(hfile)
+hfile = h5open(fn, "cw")
+@test sprint(show, hfile) == "HDF5.File: (read-write) $fn"
+close(hfile)
 
 rm(fn)
 


### PR DESCRIPTION
This is an alternative to #561, adding a simpler version of the tree printing (no values or datatypes yet) but also hooks up the tree printing as the default 3-arg show for most of the high-level datatypes so that the tree printing is shown by default at the REPL.

For example, the output for an HDF5 file handle at the REPL now looks like:
```julia
julia> hfile
🗃️ HDF5 data file: /tmp/jl_mH1PGw
├─ 🏷️ creator
├─ 📑 dtype
├─ 📂 inner
│  ├─ 🏷️ dirty
│  └─ 🔢 data
│     └─ 🏷️ mode
└─ 🔢 version
```