### PR TITLE
Wrap all tests in a testset

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using Pkg
 
 println("HDF5 version ", HDF5.h5_get_libversion())
 
+@testset "HDF5.jl" begin
+
 include("plain.jl")
 include("compound.jl")
 include("custom.jl")
@@ -22,4 +24,6 @@ try
     # basic MPI tests, for actual parallel tests we need to run in MPI mode
     include("mpio.jl")
 catch
+end
+    
 end


### PR DESCRIPTION
It's better that the whole test suit runs even if there's an error early on