### PR TITLE
Restrict HDF5_jll to v1.10 series

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Blosc = "0.5.1, 0.6, 0.7"
-HDF5_jll = "1.10.5"
+HDF5_jll = "~1.10.5"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
Note that this is set to merge into the v0.13 release branch.

With HDF5_jll serving v1.12 libraries, this has caused problems in the previous HDF5.jl release (which is still being used by JLD and MAT, for example) because the version bounds weren't sent restrictively enough to stick to the same libhdf5 "major" release.

This is an attempt to fix JuliaIO/JLD.jl#281