### PR TITLE
Fix #742, avoid instantiating large tuples

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1398,6 +1398,10 @@ function _typed_load(::Type{T}, buf::V) where {T, V <: Union{Vector{UInt8}, Base
     dest = Ref{T}()
     GC.@preserve dest buf Base._memcpy!(unsafe_convert(Ptr{Cvoid}, dest), pointer(buf), sizeof(T))
     return dest[]
+    # TODO: The above can maybe be replaced with
+    #   return GC.@preserve buf unsafe_load(convert(Ptr{t}, pointer(buf)))
+    # dependent on data elements being properly aligned for all datatypes, on all
+    # platforms.
 end
 
 _normalize_types(::Type{T}, buf::AbstractVector{UInt8}) where {T} = _typed_load(T, buf)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -1055,6 +1055,67 @@ dset = HDF5.create_external_dataset(hfile, "ext", fn_external, Int, (10,20))
 
 end
 
-# length for FixedString
-fix = HDF5.FixedString{4,0}((b"test"...,))
-@test length(fix) == 4
+@testset "FixedStrings and FixedArrays" begin
+    # properties for FixedString
+    fix = HDF5.FixedString{4,0}((b"test"...,))
+    @test length(typeof(fix)) == 4
+    @test length(fix) == 4
+    @test HDF5.pad(typeof(fix)) == 0
+    @test HDF5.pad(fix) == 0
+    # issue #742, large fixed strings are readable
+    mktemp() do path, io
+        close(io)
+        ref = join('a':'z') ^ 1000
+        fid = h5open(path, "w")
+        # long string serialized as FixedString
+        fid["longstring"] = ref
+
+        # compound datatype containing a FixedString
+        compound_dtype = HDF5.Datatype(HDF5.h5t_create(HDF5.H5T_COMPOUND, sizeof(Int64) + sizeof(ref)))
+        HDF5.h5t_insert(compound_dtype, "n", 0, datatype(Int64))
+        HDF5.h5t_insert(compound_dtype, "a", sizeof(Int64), datatype(ref))
+        c = create_dataset(fid, "compoundlongstring", compound_dtype, dataspace(()))
+        # normally this is done with a `struct name; n::Int64; a::NTuple{N,Char}; end`, but
+        # we need to not actually instantiate the NTuple.
+        buf = IOBuffer()
+        write(buf, Int64(9), ref)
+        @assert position(buf) == sizeof(compound_dtype)
+        write_dataset(c, compound_dtype, take!(buf))
+
+
+        # Test reading without stalling
+        d = fid["longstring"]
+        T = HDF5.get_jl_type(d)
+        @test T <: HDF5.FixedString
+        @test length(T) == length(ref)
+        @test read(d) == ref
+
+        T = HDF5.get_jl_type(c)
+        @test T <: NamedTuple
+        @test fieldnames(T) == (:n, :a)
+        @test read(c) == (n = 9, a = ref)
+    end
+
+    fix = HDF5.FixedArray{Float64,(2,2),4}((1, 2, 3, 4))
+    @test size(typeof(fix)) == (2, 2)
+    @test size(fix) == (2, 2)
+    @test eltype(typeof(fix)) == Float64
+    @test eltype(fix) == Float64
+    # large fixed arrays are readable
+    mktemp() do path, io
+        close(io)
+        ref = rand(Float64, 3000)
+        t = HDF5.Datatype(HDF5.h5t_array_create(datatype(Float64), ndims(ref), collect(size(ref))))
+        scalarspace = dataspace(())
+
+        fid = h5open(path, "w")
+        d = create_dataset(fid, "longnums", t, scalarspace)
+        write_dataset(d, t, ref)
+
+        T = HDF5.get_jl_type(d)
+        @test T <: HDF5.FixedArray
+        @test size(T) == size(ref)
+        @test eltype(T) == eltype(ref)
+        @test read(d) == ref
+    end
+end


### PR DESCRIPTION
This is an attempt at fixing #742 by replacing typed arrays with a generic bytes buffer for types which require special read handling.

The underlying issue in #742 appears to be that instantiating either of `FixedString` or `FixedArray` types which large values of `N` in the tuple causes Julia's type inference and/or codegen to take extremely long/fail. Note that instantiation to a "physical object" seems to be the problem, and type-only constructs (i.e. `Type{FixedString{30000,0}}`) seem to work OK, so it's convenient to leave the type declarations as-is since it makes things like computing the `sizeof` a `NamedTuple` with an arbitrarily-sized `FixedString` element work without any extra effort on our part.

The cost to keeping some of the type (size) information, though, is that we have to jump through hoops to avoid actually instantiating the large tuples. What this PR does to achieve that is to explicitly pass around an `Array{UInt8}` buffer to the internal `normalize_types` functions, which all had to be modified to work directly on the untyped data buffer instead.

I would very much appreciate more eyes on this code since it's pretty invasive. Furthermore, I haven't attempted any sort of profiling to see if this construction creates significant regression in performance (precompile/load time or actual runtime uses), so that should probably be done before merging.