### PR TITLE
Use `Int` type params in `FixedString`

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1622,9 +1622,9 @@ function get_mem_compatible_jl_type(obj_type::Datatype)
         if h5t_is_variable_str(obj_type)
             return Cstring
         else
-            n = h5t_get_size(obj_type)
-            pad = h5t_get_strpad(obj_type)
-            return FixedString{Int(n), pad}
+            n = Int(h5t_get_size(obj_type))
+            pad = Int(h5t_get_strpad(obj_type))
+            return FixedString{n, pad}
         end
     elseif class_id == H5T_INTEGER || class_id == H5T_FLOAT
         native_type = h5t_get_native_type(obj_type)


### PR DESCRIPTION
I discovered this while trying to figure out why type equality wasn't working (on my 64-bit machine):
```julia
julia> hid = h5open(tempname(), "w")
🗂️ HDF5.File: (read-write) /tmp/jl_JlItow

julia> hid["str"] = "test string"
"test string"

julia> HDF5.get_jl_type(hid["str"])
HDF5.FixedString{11, 0}

### before
julia> HDF5.get_jl_type(hid["str"]) == HDF5.FixedString{11, 0}
false

julia> HDF5.get_jl_type(hid["str"]) == HDF5.FixedString{11, Int32(0)}
true

### after
julia> HDF5.get_jl_type(hid["str"]) == HDF5.FixedString{11, 0}
true
```