### PR TITLE
WIP: Support reading opaque data recursively

### DIFF
--- a/docs/src/api_bindings.md
+++ b/docs/src/api_bindings.md
@@ -244,6 +244,7 @@ h5t_set_fields(dtype_id::hid_t, spos::Csize_t, epos::Csize_t, esize::Csize_t, mp
 h5t_set_precision(dtype_id::hid_t, sz::Csize_t)
 h5t_set_size(dtype_id::hid_t, sz::Csize_t)
 h5t_set_strpad(dtype_id::hid_t, sz::Cint)
+h5t_set_tag(dtype_id::hid_t, tag::Cstring)
 h5t_vlen_create(base_type_id::hid_t)
 ```
 

--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -253,6 +253,7 @@
 @bind h5t_set_precision(dtype_id::hid_t, sz::Csize_t)::herr_t "Error setting precision of datatype"
 @bind h5t_set_size(dtype_id::hid_t, sz::Csize_t)::herr_t "Error setting size of datatype"
 @bind h5t_set_strpad(dtype_id::hid_t, sz::Cint)::herr_t "Error setting size of datatype"
+@bind h5t_set_tag(dtype_id::hid_t, tag::Cstring)::herr_t "Error setting opaque tag"
 @bind h5t_vlen_create(base_type_id::hid_t)::hid_t "Error creating vlen type"
 # The following are not autoatically wrapped since they have requirements about freeing
 # the memory that is returned from the calls.

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1329,28 +1329,24 @@ end
 
 # Read OPAQUE datasets and attributes
 function Base.read(obj::DatasetOrAttribute, ::Type{Opaque})
-    local buf
-    local len
-    local tag
-    sz = size(obj)
     obj_type = datatype(obj)
-    try
-        len = h5t_get_size(obj_type)
-        buf = Vector{UInt8}(undef,prod(sz)*len)
-        tag = h5t_get_tag(obj_type)
-        if obj isa Dataset
-            read_dataset(obj, obj_type, buf)
-        else
-            read_attribute(obj, obj_type, buf)
-        end
-    finally
-        close(obj_type)
+    sz  = size(obj)
+    buf = Matrix{UInt8}(undef, sizeof(obj_type), prod(sz))
+    if obj isa Dataset
+        read_dataset(obj, obj_type, buf, obj.xfer)
+    else
+        read_attribute(obj, obj_type, buf)
     end
-    data = Array{Array{UInt8}}(undef,sz)
-    for i = 1:prod(sz)
-        data[i] = buf[(i-1)*len+1:i*len]
+    tag = h5t_get_tag(obj_type)
+    close(obj_type)
+    if isempty(sz)
+        # scalar (only) result
+        data = vec(buf)
+    else
+        # array of opaque objects
+        data = reshape([buf[:,i] for i in 1:prod(sz)], sz...)
     end
-    Opaque(data, tag)
+    return Opaque(data, tag)
 end
 
 # Array constructor for datasets
@@ -1842,6 +1838,12 @@ function get_mem_compatible_jl_type(obj_type::Datatype)
     elseif class_id == H5T_REFERENCE
         # TODO update to use version 1.12 reference functions/types
         return Reference
+    elseif class_id == H5T_OPAQUE
+        # TODO: opaque objects should get their own fixed-size data type; punning like
+        #       this permits recursively reading (i.e. compound data type containing an
+        #       opaque field). Requires figuring out what to do about the tag...
+        len = Int(h5t_get_size(obj_type))
+        return FixedArray{UInt8, (len,), len}
     elseif class_id == H5T_VLEN
         superid = h5t_get_super(obj_type)
         return VariableArray{get_mem_compatible_jl_type(Datatype(superid))}

--- a/src/api.jl
+++ b/src/api.jl
@@ -1051,6 +1051,12 @@ function h5t_set_strpad(dtype_id, sz)
     return nothing
 end
 
+function h5t_set_tag(dtype_id, tag)
+    var"#status#" = ccall((:H5Tset_tag, libhdf5), herr_t, (hid_t, Cstring), dtype_id, tag)
+    var"#status#" < 0 && error("Error setting opaque tag")
+    return nothing
+end
+
 function h5t_vlen_create(base_type_id)
     var"#status#" = ccall((:H5Tvlen_create, libhdf5), hid_t, (hid_t,), base_type_id)
     var"#status#" < 0 && error("Error creating vlen type")


### PR DESCRIPTION
This builds on top of the changes in #745.

Most of the added code is just tests of reading and writing opaque objects, and I've simplified the special-cased `read(::AttributeOrDataset, ::Type{Opaque}` implementation just a bit.

The interesting change is to `get_mem_compatible_jl_type`  — a recursively-reached opaque type is reported as having a `FixedArray{UInt8}` layout. This allows for the type-normalization code to automatically handle reading in opaque data embedded in other data types. The downside is that the opaque tag information is lost. (Note that this doesn't affect a "top level" opaque attribute or dataset which will still load into a `HDF5.Opaque` object which contains both the data and the tag.)

For instance, the one new example use in the tests reads in the HDF5 datatype:
```
HDF5.Datatype: H5T_COMPOUND {
      H5T_STD_I64LE "v" : 0;
      H5T_OPAQUE {
         OPQ_SIZE 4;
         OPQ_TAG "opaque test";
      } "d" : 8;
   }
```
as the named tuple `(v = 1, d = rand(UInt8, 4))`.

One minor thing I noticed while writing the tests is that an opaque scalar object is returned as a 0-dimensional array of a vector of bytes (i.e. `fill(UInt8[...])`). The generic `read` function takes note of scalar objects and dereferences the container array upon return, but the opaque read doesn't. I left that as-is (and the tests check for that case now), but that'd be easy to change in the opaque-specific read function.