### PR TITLE
Add custom printing for Dataspaces

### DIFF
--- a/docs/src/api_bindings.md
+++ b/docs/src/api_bindings.md
@@ -189,14 +189,18 @@ h5r_get_region(loc_id::hid_t, ref_type::Cint, ref::Ptr{Cvoid})
 ## [`H5S`](https://portal.hdfgroup.org/display/HDF5/Dataspaces) — Dataspace Interface
 ```julia
 h5s_close(space_id::hid_t)
+h5s_combine_select(space1_id::hid_t, op::Cint, space2_id::hid_t)
 h5s_copy(space_id::hid_t)
 h5s_create(class::Cint)
 h5s_create_simple(rank::Cint, current_dims::Ptr{hsize_t}, maximum_dims::Ptr{hsize_t})
 h5s_get_regular_hyperslab(space_id::hid_t, start::Ptr{hsize_t}, stride::Ptr{hsize_t}, count::Ptr{hsize_t}, block::Ptr{hsize_t})
+h5s_get_select_hyper_nblocks(space_id::hid_t)
 h5s_get_select_npoints(space_id::hid_t)
+h5s_get_select_type(space_id::hid_t)
 h5s_get_simple_extent_dims(space_id::hid_t, dims::Ptr{hsize_t}, maxdims::Ptr{hsize_t})
 h5s_get_simple_extent_ndims(space_id::hid_t)
 h5s_get_simple_extent_type(space_id::hid_t)
+h5s_is_regular_hyperslab(space_id::hid_t)
 h5s_is_simple(space_id::hid_t)
 h5s_select_hyperslab(dspace_id::hid_t, seloper::Cint, start::Ptr{hsize_t}, stride::Ptr{hsize_t}, count::Ptr{hsize_t}, block::Ptr{hsize_t})
 ```

--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -199,6 +199,7 @@
 ###
 
 @bind h5s_close(space_id::hid_t)::herr_t "Error closing dataspace"
+@bind h5s_combine_select(space1_id::hid_t, op::Cint, space2_id::hid_t)::hid_t "Error combining dataspaces"
 @bind h5s_copy(space_id::hid_t)::hid_t "Error copying dataspace"
 @bind h5s_create(class::Cint)::hid_t "Error creating dataspace"
 @bind h5s_create_simple(rank::Cint, current_dims::Ptr{hsize_t}, maximum_dims::Ptr{hsize_t})::hid_t "Error creating simple dataspace"
@@ -206,7 +207,10 @@
 @bind h5s_get_simple_extent_dims(space_id::hid_t, dims::Ptr{hsize_t}, maxdims::Ptr{hsize_t})::Cint "Error getting the dimensions for a dataspace"
 @bind h5s_get_simple_extent_ndims(space_id::hid_t)::Cint "Error getting the number of dimensions for a dataspace"
 @bind h5s_get_simple_extent_type(space_id::hid_t)::Cint "Error getting the dataspace type"
+@bind h5s_get_select_hyper_nblocks(space_id::hid_t)::hssize_t "Error getting number of selected blocks"
 @bind h5s_get_select_npoints(space_id::hid_t)::hsize_t "Error getting the number of selected points"
+@bind h5s_get_select_type(space_id::hid_t)::Cint "Error getting the selection type"
+@bind h5s_is_regular_hyperslab(space_id::hid_t)::htri_t "Error determining whether datapace is regular hyperslab"
 @bind h5s_is_simple(space_id::hid_t)::htri_t "Error determining whether dataspace is simple"
 @bind h5s_select_hyperslab(dspace_id::hid_t, seloper::Cint, start::Ptr{hsize_t}, stride::Ptr{hsize_t}, count::Ptr{hsize_t}, block::Ptr{hsize_t})::herr_t "Error selecting hyperslab"
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -758,6 +758,12 @@ function h5s_close(space_id)
     return nothing
 end
 
+function h5s_combine_select(space1_id, op, space2_id)
+    var"#status#" = ccall((:H5Scombine_select, libhdf5), hid_t, (hid_t, Cint, hid_t), space1_id, op, space2_id)
+    var"#status#" < 0 && error("Error combining dataspaces")
+    return var"#status#"
+end
+
 function h5s_copy(space_id)
     var"#status#" = ccall((:H5Scopy, libhdf5), hid_t, (hid_t,), space_id)
     var"#status#" < 0 && error("Error copying dataspace")
@@ -800,10 +806,28 @@ function h5s_get_simple_extent_type(space_id)
     return var"#status#"
 end
 
+function h5s_get_select_hyper_nblocks(space_id)
+    var"#status#" = ccall((:H5Sget_select_hyper_nblocks, libhdf5), hssize_t, (hid_t,), space_id)
+    var"#status#" < 0 && error("Error getting number of selected blocks")
+    return var"#status#"
+end
+
 function h5s_get_select_npoints(space_id)
     var"#status#" = ccall((:H5Sget_select_npoints, libhdf5), hsize_t, (hid_t,), space_id)
     var"#status#" == -1 % hsize_t && error("Error getting the number of selected points")
     return var"#status#"
+end
+
+function h5s_get_select_type(space_id)
+    var"#status#" = ccall((:H5Sget_select_type, libhdf5), Cint, (hid_t,), space_id)
+    var"#status#" < 0 && error("Error getting the selection type")
+    return var"#status#"
+end
+
+function h5s_is_regular_hyperslab(space_id)
+    var"#status#" = ccall((:H5Sis_regular_hyperslab, libhdf5), htri_t, (hid_t,), space_id)
+    var"#status#" < 0 && error("Error determining whether datapace is regular hyperslab")
+    return var"#status#" > 0
 end
 
 function h5s_is_simple(space_id)

--- a/src/api_types.jl
+++ b/src/api_types.jl
@@ -234,13 +234,15 @@ const H5R_OBJ_REF_BUF_SIZE      = 8  # == sizeof(hobj_ref_t)
 const H5R_DSET_REG_REF_BUF_SIZE = 12 # == sizeof(hdset_reg_ref_t)
 
 # Dataspace constants
-const H5S_ALL          = hid_t(0)
-const H5S_SCALAR       = hid_t(0)
-const H5S_SIMPLE       = hid_t(1)
-const H5S_NULL         = hid_t(2)
-const H5S_UNLIMITED    = typemax(hsize_t)
+const H5S_ALL       = hid_t(0)
+const H5S_UNLIMITED = typemax(hsize_t)
 
-# Dataspace selection constants
+# Dataspace classes (C enum H5S_class_t)
+const H5S_SCALAR = 0
+const H5S_SIMPLE = 1
+const H5S_NULL   = 2
+
+# Dataspace selection constants (C enum H5S_seloper_t)
 const H5S_SELECT_SET     = 0
 const H5S_SELECT_OR      = 1
 const H5S_SELECT_AND     = 2
@@ -249,6 +251,12 @@ const H5S_SELECT_NOTB    = 4
 const H5S_SELECT_NOTA    = 5
 const H5S_SELECT_APPEND  = 6
 const H5S_SELECT_PREPEND = 7
+
+# Dataspace selection types (C enum H5S_sel_type)
+const H5S_SEL_NONE       = 0
+const H5S_SEL_POINTS     = 1
+const H5S_SEL_HYPERSLABS = 2
+const H5S_SEL_ALL        = 3
 
 # type classes (C enum H5T_class_t)
 const H5T_INTEGER      = hid_t(0)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -708,13 +708,26 @@ dtype = HDF5.Datatype(HDF5.h5t_copy(HDF5.H5T_IEEE_F64LE))
 commit_datatype(hfile, "type", dtype)
 @test sprint(show, dtype) == "HDF5.Datatype: /type H5T_IEEE_F64LE"
 
-dspace = dataspace((1,))
-@test occursin(r"^HDF5.Dataspace\(\d+\)", sprint(show, dspace))
+dspace_null = HDF5.Dataspace(HDF5.h5s_create(HDF5.H5S_NULL))
+dspace_scal = HDF5.Dataspace(HDF5.h5s_create(HDF5.H5S_SCALAR))
+dspace_norm = dataspace((100, 4))
+dspace_maxd = dataspace((100, 4), max_dims = (256, 4))
+dspace_slab = HDF5.hyperslab(dataspace((100, 4)), 1:20:100, 1:4)
+dspace_irrg = HDF5.Dataspace(HDF5.h5s_combine_select(
+        HDF5.h5s_copy(dspace_slab), HDF5.H5S_SELECT_OR,
+        HDF5.hyperslab(dataspace((100, 4)), 2, 2)))
+
+@test sprint(show, dspace_null) == "HDF5.Dataspace: H5S_NULL"
+@test sprint(show, dspace_scal) == "HDF5.Dataspace: H5S_SCALAR"
+@test sprint(show, dspace_norm) == "HDF5.Dataspace: (100, 4)"
+@test sprint(show, dspace_maxd) == "HDF5.Dataspace: (100, 4) / (256, 4)"
+@test sprint(show, dspace_slab) == "HDF5.Dataspace: (1:20:81, 1:4) / (1:100, 1:4)"
+@test sprint(show, dspace_irrg) == "HDF5.Dataspace: (100, 4) [irregular selection]"
 
 # Now test printing after closing each object
 
-close(dspace)
-@test sprint(show, dspace) == "HDF5.Dataspace(-1)"
+close(dspace_null)
+@test sprint(show, dspace_null) == "HDF5.Dataspace: (invalid)"
 
 close(dtype)
 @test sprint(show, dtype) == "HDF5.Datatype: (invalid)"


### PR DESCRIPTION
Exploring datasets interactively is a lot easier when you can quickly get feedback on the shapes of dataspaces, so it was annoying that all we had printing was the `hid_t` value.

The tests are a good summary of what this custom printing adds:
```julia
dspace_null = HDF5.Dataspace(HDF5.h5s_create(HDF5.H5S_NULL))
dspace_scal = HDF5.Dataspace(HDF5.h5s_create(HDF5.H5S_SCALAR))
dspace_norm = dataspace((100, 4))
dspace_maxd = dataspace((100, 4), max_dims = (256, 4))
dspace_slab = HDF5.hyperslab(dataspace((100, 4)), 1:20:100, 1:2:4)
dspace_irrg = HDF5.Dataspace(HDF5.h5s_combine_select(
        HDF5.h5s_copy(dspace_slab), HDF5.H5S_SELECT_OR,
        HDF5.hyperslab(dataspace((100, 4)), 2, 2)))

@test sprint(show, dspace_null) == "HDF5.Dataspace: H5S_NULL"
@test sprint(show, dspace_scal) == "HDF5.Dataspace: H5S_SCALAR"
@test sprint(show, dspace_norm) == "HDF5.Dataspace: (100, 4)"
@test sprint(show, dspace_maxd) == "HDF5.Dataspace: (100, 4) / (256, 4)"
@test sprint(show, dspace_slab) == "HDF5.Dataspace: (1:20:81, 1:2:3) / (1:100, 1:4)"
@test sprint(show, dspace_irrg) == "HDF5.Dataspace: (100, 4) [irregular selection]"
```