### PR TITLE
Limit HDF5_jll compatible versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 [compat]
 Blosc = "0.5.1, 0.6, 0.7"
 Compat = "3.1.0"
-HDF5_jll = "1.12.0"
+HDF5_jll = "~1.12.0"
 Requires = "1.0"
 julia = "1.3"
 


### PR DESCRIPTION
HDF5_jll follows the versioning scheme of libhdf5 which uses the second set of digits as their "major" versions. Set the compatibility to agree with this use of versioning so that HDF5.jl doesn't try to pull in a newer library (which may be incompatible) without being explicitly allowed to in the future.

This was the issue on the HDF5.jl v0.13.6 release which required #743 and a subsequent patch release as v0.13.7 to fix. We should probably be more proactive about avoiding a similar issue.