### PR TITLE
Bring back compatibility with HDF5 < v1.12

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -35,9 +35,6 @@ else
                     if libhdf5_size != filesize(Libdl.dlpath(libhdf5))
                         error("HDF5 library has changed, re-run Pkg.build(\\\"HDF5\\\")")
                     end
-                    if libversion < v"1.12"
-                        error("HDF5.jl requires ≥ v1.12 of the HDF5 library.")
-                    end
                 end
                 """
                )

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -713,16 +713,19 @@ dspace_scal = HDF5.Dataspace(HDF5.h5s_create(HDF5.H5S_SCALAR))
 dspace_norm = dataspace((100, 4))
 dspace_maxd = dataspace((100, 4), max_dims = (256, 4))
 dspace_slab = HDF5.hyperslab(dataspace((100, 4)), 1:20:100, 1:4)
-dspace_irrg = HDF5.Dataspace(HDF5.h5s_combine_select(
-        HDF5.h5s_copy(dspace_slab), HDF5.H5S_SELECT_OR,
-        HDF5.hyperslab(dataspace((100, 4)), 2, 2)))
 
 @test sprint(show, dspace_null) == "HDF5.Dataspace: H5S_NULL"
 @test sprint(show, dspace_scal) == "HDF5.Dataspace: H5S_SCALAR"
 @test sprint(show, dspace_norm) == "HDF5.Dataspace: (100, 4)"
 @test sprint(show, dspace_maxd) == "HDF5.Dataspace: (100, 4) / (256, 4)"
 @test sprint(show, dspace_slab) == "HDF5.Dataspace: (1:20:81, 1:4) / (1:100, 1:4)"
-@test sprint(show, dspace_irrg) == "HDF5.Dataspace: (100, 4) [irregular selection]"
+
+if HDF5.libversion ≥ v"1.12"
+    dspace_irrg = HDF5.Dataspace(HDF5.h5s_combine_select(
+            HDF5.h5s_copy(dspace_slab), HDF5.H5S_SELECT_OR,
+            HDF5.hyperslab(dataspace((100, 4)), 2, 2)))
+    @test sprint(show, dspace_irrg) == "HDF5.Dataspace: (100, 4) [irregular selection]"
+end
 
 # Now test printing after closing each object
 

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -720,7 +720,7 @@ dspace_slab = HDF5.hyperslab(dataspace((100, 4)), 1:20:100, 1:4)
 @test sprint(show, dspace_maxd) == "HDF5.Dataspace: (100, 4) / (256, 4)"
 @test sprint(show, dspace_slab) == "HDF5.Dataspace: (1:20:81, 1:4) / (1:100, 1:4)"
 
-if HDF5.libversion ≥ v"1.12"
+if HDF5.libversion ≥ v"1.10.7"
     dspace_irrg = HDF5.Dataspace(HDF5.h5s_combine_select(
             HDF5.h5s_copy(dspace_slab), HDF5.H5S_SELECT_OR,
             HDF5.hyperslab(dataspace((100, 4)), 2, 2)))


### PR DESCRIPTION
Since #739, HDF5 versions less than v1.12 are no longer supported. This is not a problem when one uses the default binaries provided by HDF5_jll. However, it kind of limits the use of custom binaries (as described [in the docs](https://juliaio.github.io/HDF5.jl/stable/#System-provided-HDF5-libraries)), since the HDF5 v1.12 libraries are not that common in existent systems, and one would need to build them from source there. For instance, the latest versions of Fedora and Ubuntu both default to HDF5 v1.10. This is particularly inconvenient when combining HDF5 with MPI.

This PR is a proposal to bring back compatibility with HDF5 library versions less than v1.12. I checked that, with these changes, tests now pass when using HDF5 v1.10.

Probably further changes are needed to make sure that either (1) all tests pass on HDF5 v1.10, or (2) the user is aware that HDF5 < v1.12 is not officially supported.

For option (1), I can add an extra test run that uses the HDF5 1.10 binaries from the Ubuntu repos (I've done something similar in one of my packages). For option (2), one could include a comment in the docs and the README, and maybe a warning when HDF5 < v1.12 is first detected.
