### PR TITLE
Add binding for H5Tenum_insert

### DIFF
--- a/docs/src/api_bindings.md
+++ b/docs/src/api_bindings.md
@@ -214,7 +214,7 @@ h5t_commit(loc_id::hid_t, name::Ptr{UInt8}, dtype_id::hid_t, lcpl_id::hid_t, tcp
 h5t_committed(dtype_id::hid_t)
 h5t_copy(dtype_id::hid_t)
 h5t_create(class_id::Cint, sz::Csize_t)
-h5t_enum_insert(dtype_id::hid_t, name::Cstring, value::Ref{Bool})
+h5t_enum_insert(dtype_id::hid_t, name::Cstring, value::Ptr{Cvoid})
 h5t_equal(dtype_id1::hid_t, dtype_id2::hid_t)
 h5t_get_array_dims(dtype_id::hid_t, dims::Ptr{hsize_t})
 h5t_get_array_ndims(dtype_id::hid_t)

--- a/docs/src/api_bindings.md
+++ b/docs/src/api_bindings.md
@@ -214,6 +214,7 @@ h5t_commit(loc_id::hid_t, name::Ptr{UInt8}, dtype_id::hid_t, lcpl_id::hid_t, tcp
 h5t_committed(dtype_id::hid_t)
 h5t_copy(dtype_id::hid_t)
 h5t_create(class_id::Cint, sz::Csize_t)
+h5t_enum_insert(dtype_id::hid_t, name::Cstring, value::Ref{Bool})
 h5t_equal(dtype_id1::hid_t, dtype_id2::hid_t)
 h5t_get_array_dims(dtype_id::hid_t, dims::Ptr{hsize_t})
 h5t_get_array_ndims(dtype_id::hid_t)

--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -225,6 +225,7 @@
 @bind h5t_commit(loc_id::hid_t, name::Ptr{UInt8}, dtype_id::hid_t, lcpl_id::hid_t, tcpl_id::hid_t, tapl_id::hid_t)::herr_t "Error committing type"
 @bind h5t_copy(dtype_id::hid_t)::hid_t "Error copying datatype"
 @bind h5t_create(class_id::Cint, sz::Csize_t)::hid_t error("Error creating datatype of id ", class_id)
+@bind h5t_enum_insert(dtype_id::hid_t, name::Cstring, value::Ref{Bool})::herr_t error("Error adding ", name, " to enum datatype")
 @bind h5t_equal(dtype_id1::hid_t, dtype_id2::hid_t)::hid_t "Error checking datatype equality"
 @bind h5t_get_array_dims(dtype_id::hid_t, dims::Ptr{hsize_t})::Cint "Error getting dimensions of array"
 @bind h5t_get_array_ndims(dtype_id::hid_t)::Cint "Error getting ndims of array"

--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -225,7 +225,7 @@
 @bind h5t_commit(loc_id::hid_t, name::Ptr{UInt8}, dtype_id::hid_t, lcpl_id::hid_t, tcpl_id::hid_t, tapl_id::hid_t)::herr_t "Error committing type"
 @bind h5t_copy(dtype_id::hid_t)::hid_t "Error copying datatype"
 @bind h5t_create(class_id::Cint, sz::Csize_t)::hid_t error("Error creating datatype of id ", class_id)
-@bind h5t_enum_insert(dtype_id::hid_t, name::Cstring, value::Ref{Bool})::herr_t error("Error adding ", name, " to enum datatype")
+@bind h5t_enum_insert(dtype_id::hid_t, name::Cstring, value::Ptr{Cvoid})::herr_t error("Error adding ", name, " to enum datatype")
 @bind h5t_equal(dtype_id1::hid_t, dtype_id2::hid_t)::hid_t "Error checking datatype equality"
 @bind h5t_get_array_dims(dtype_id::hid_t, dims::Ptr{hsize_t})::Cint "Error getting dimensions of array"
 @bind h5t_get_array_ndims(dtype_id::hid_t)::Cint "Error getting ndims of array"

--- a/src/api.jl
+++ b/src/api.jl
@@ -885,7 +885,7 @@ function h5t_create(class_id, sz)
 end
 
 function h5t_enum_insert(dtype_id, name, value)
-    var"#status#" = ccall((:H5Tenum_insert, libhdf5), herr_t, (hid_t, Cstring, Ref{Bool}), dtype_id, name, value)
+    var"#status#" = ccall((:H5Tenum_insert, libhdf5), herr_t, (hid_t, Cstring, Ptr{Cvoid}), dtype_id, name, value)
     var"#status#" < 0 && error("Error adding ", name, " to enum datatype")
     return nothing
 end

--- a/src/api.jl
+++ b/src/api.jl
@@ -884,6 +884,12 @@ function h5t_create(class_id, sz)
     return var"#status#"
 end
 
+function h5t_enum_insert(dtype_id, name, value)
+    var"#status#" = ccall((:H5Tenum_insert, libhdf5), herr_t, (hid_t, Cstring, Ref{Bool}), dtype_id, name, value)
+    var"#status#" < 0 && error("Error adding ", name, " to enum datatype")
+    return nothing
+end
+
 function h5t_equal(dtype_id1, dtype_id2)
     var"#status#" = ccall((:H5Tequal, libhdf5), hid_t, (hid_t, hid_t), dtype_id1, dtype_id2)
     var"#status#" < 0 && error("Error checking datatype equality")


### PR DESCRIPTION
I needed this function to create an H5T_ENUM Datatype that would "conform to the `h5py` implementation of the numpy boolean type" as used in the UVH5 file format described [here](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/raw/main/docs/references/uvh5_memo.pdf).

Typical usage for this case would be:

```
# Create H5T_ENUM Datatype
boolenumtype = create_datatype(HDF5.H5T_ENUM, sizeof(Bool)); # Semicolon to avoid showing in REPL

# Insert enum names/values
HDF5.h5t_enum_insert(boolenumtype.id, "FALSE", false)
HDF5.h5t_enum_insert(boolenumtype.id, "TRUE", true)

# Create dataset using enum Datatype
flags = create_dataset(uvh5, "Data/flags", boolenumtype, flagsdataspace)
```