### PR TITLE
Update `h5t_equal` definition to automatically return `Bool`

### DIFF
--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -226,7 +226,7 @@
 @bind h5t_copy(dtype_id::hid_t)::hid_t "Error copying datatype"
 @bind h5t_create(class_id::Cint, sz::Csize_t)::hid_t error("Error creating datatype of id ", class_id)
 @bind h5t_enum_insert(dtype_id::hid_t, name::Cstring, value::Ptr{Cvoid})::herr_t error("Error adding ", name, " to enum datatype")
-@bind h5t_equal(dtype_id1::hid_t, dtype_id2::hid_t)::hid_t "Error checking datatype equality"
+@bind h5t_equal(dtype_id1::hid_t, dtype_id2::hid_t)::htri_t "Error checking datatype equality"
 @bind h5t_get_array_dims(dtype_id::hid_t, dims::Ptr{hsize_t})::Cint "Error getting dimensions of array"
 @bind h5t_get_array_ndims(dtype_id::hid_t)::Cint "Error getting ndims of array"
 @bind h5t_get_class(dtype_id::hid_t)::Cint "Error getting class"

--- a/src/api.jl
+++ b/src/api.jl
@@ -891,9 +891,9 @@ function h5t_enum_insert(dtype_id, name, value)
 end
 
 function h5t_equal(dtype_id1, dtype_id2)
-    var"#status#" = ccall((:H5Tequal, libhdf5), hid_t, (hid_t, hid_t), dtype_id1, dtype_id2)
+    var"#status#" = ccall((:H5Tequal, libhdf5), htri_t, (hid_t, hid_t), dtype_id1, dtype_id2)
     var"#status#" < 0 && error("Error checking datatype equality")
-    return var"#status#"
+    return var"#status#" > 0
 end
 
 function h5t_get_array_dims(dtype_id, dims)


### PR DESCRIPTION
The change in #757 to `Base.:(==)(::Datatype, ::Datatype)` incorrectly
assumed that `h5t_equal` was already defined to return `htri_t`, so
it broke the return type of equality comparisons on datatypes.