### PR TITLE
RFC: Use fewer objects in h5open and read

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1292,7 +1292,7 @@ function generic_read(obj::DatasetOrAttribute, filetype::Datatype, ::Type{T}, I.
     else
         buf = Array{T}(undef, sz...)
     end
-    memspace = dataspace(sz)
+    memspace = isempty(I) ? dspace : dataspace(sz)
 
     if obj isa Dataset
         h5d_read(obj, memtype, memspace, dspace, obj.xfer, buf)


### PR DESCRIPTION
This PR closes most of the performance gap identified in reads from #752. The changes are:

1. Reuse the `Datatype` identified in each of the untyped `read()` functions when handing off to the generic typed-read. This is accomplished by renaming the generic `read()` to `_read()` and giving it both the HDF5 `Datatype` and the Julia `Type` as arguments.
2. Only create a new in-memory `Dataspace` if a hyperslab is being selected; otherwise, reuse the file `Dataspace`.
3. Only create the file access property list once in `h5open`, and only create a create-file property list if non-default options are being set (and close it if one was created).

![image](https://user-images.githubusercontent.com/2965436/101415021-ca083d00-38ac-11eb-9959-e1b5009113b0.png)

Part of the performance gap appears to be due to libhdf5 v1.12 being a bit slower than v1.10, but if the library version is forced back to v1.10, each of the operations are on-par or faster than with HDF5.jl v0.13.7.

The RFC comes from the renaming of `read()` — I'm not sure just hiding the generic read as `_read()` is really the best option since it does make specializing on particular types require overloading the internal `_read` instead of public `read` if special data handling is required (as demonstrated by the `_read(..., ::Type{Opaque})` case). Ultimately, though, it does seems some sort of similar structuring will be desired to retain the performance; might just need to iterate on the exact restructuring a bit.

(Note that the first commit is from #747 since both that PR and the changes here modify the opaque read method.)