### PR TITLE
Automatically convert C Int types to Julia's Int type for convenience

### DIFF
--- a/gen/bind_generator.jl
+++ b/gen/bind_generator.jl
@@ -56,7 +56,11 @@ function, and the Julia return type is inferred as one of the following possibil
 2. If `ReturnType === :htri_t`, the Julia function returns a boolean indicating whether
    the return value of the C function was zero (`false`) or positive (`true`).
 
-3. Otherwise, the C function return value is returned from the Julia function.
+3. Otherwise, the C function return value is returned from the Julia function, with the
+   following exceptions:
+
+   - If the return type is an C integer type compatible with Int, the return type is
+     converted to an Int.
 
 Furthermore, the C return value is interpreted to automatically generate error checks
 (only when `ErrorStringOrExpression` is provided):
@@ -148,6 +152,9 @@ macro bind(sig::Expr, err::Union{String,Expr,Nothing} = nothing)
     elseif rettype === :herr_t
         # Only used to indicate error status
         returnexpr = :(return nothing)
+    elseif rettype in (:Cint, :Csize_t)
+        # Convert to Int type
+        returnexpr = :(return Int($statsym))
     else
         # Returns a value
         returnexpr = :(return $statsym)

--- a/gen/bind_generator.jl
+++ b/gen/bind_generator.jl
@@ -152,7 +152,7 @@ macro bind(sig::Expr, err::Union{String,Expr,Nothing} = nothing)
     elseif rettype === :herr_t
         # Only used to indicate error status
         returnexpr = :(return nothing)
-    elseif rettype in (:Cint, :Csize_t)
+    elseif rettype === :Cint
         # Convert to Int type
         returnexpr = :(return Int($statsym))
     else

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1015,7 +1015,7 @@ function datatype(str::VLen{C}) where {C<:CharType}
     Datatype(h5t_vlen_create(type_id))
 end
 
-Base.sizeof(dtype::Datatype) = h5t_get_size(dtype)
+Base.sizeof(dtype::Datatype) = Int(h5t_get_size(dtype))
 
 # Get the dataspace of a dataset
 dataspace(dset::Dataset) = Dataspace(h5d_get_space(checkvalid(dset)))

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -139,21 +139,21 @@ const ScalarType = Union{BitsType,Reference}
 function _hdf5_type_map(class_id, is_signed, native_size)
     if class_id == H5T_INTEGER
         if is_signed == H5T_SGN_2
-            return native_size === Csize_t(1) ? Int8 :
-                   native_size === Csize_t(2) ? Int16 :
-                   native_size === Csize_t(4) ? Int32 :
-                   native_size === Csize_t(8) ? Int64 :
+            return native_size == 1 ? Int8 :
+                   native_size == 2 ? Int16 :
+                   native_size == 4 ? Int32 :
+                   native_size == 8 ? Int64 :
                    throw(KeyError(class_id, is_signed, native_size))
         else
-            return native_size === Csize_t(1) ? UInt8 :
-                   native_size === Csize_t(2) ? UInt16 :
-                   native_size === Csize_t(4) ? UInt32 :
-                   native_size === Csize_t(8) ? UInt64 :
+            return native_size == 1 ? UInt8 :
+                   native_size == 2 ? UInt16 :
+                   native_size == 4 ? UInt32 :
+                   native_size == 8 ? UInt64 :
                    throw(KeyError(class_id, is_signed, native_size))
         end
     else
-        return native_size === Csize_t(4) ? Float32 :
-               native_size === Csize_t(8) ? Float64 :
+        return native_size == 4 ? Float32 :
+               native_size == 8 ? Float64 :
                throw(KeyError(class_id, is_signed, native_size))
     end
 end
@@ -1049,7 +1049,7 @@ dataspace(sz1::Int, sz2::Int, sz3::Int...; max_dims::Union{Dims,Tuple{}}=()) = _
 
 function Base.ndims(obj::Union{Dataspace,Dataset,Attribute})
     dspace = obj isa Dataspace ? checkvalid(obj) : dataspace(obj)
-    ret = Int(h5s_get_simple_extent_ndims(dspace))
+    ret = h5s_get_simple_extent_ndims(dspace)
     obj isa Dataspace || close(dspace)
     return ret
 end
@@ -1724,7 +1724,7 @@ end
 function create_external_dataset(parent::Union{File,Group}, name::AbstractString, filepath::AbstractString, t, sz::Dims, offset::Integer=0)
     checkvalid(parent)
     dcpl  = create_property(H5P_DATASET_CREATE)
-    h5p_set_external(dcpl , filepath, Int(offset), prod(sz)*sizeof(t)) # TODO: allow H5F_UNLIMITED
+    h5p_set_external(dcpl , filepath, offset, prod(sz)*sizeof(t)) # TODO: allow H5F_UNLIMITED
     create_dataset(parent, name, datatype(t), dataspace(sz); dcpl=dcpl)
 end
 
@@ -1771,9 +1771,9 @@ function get_mem_compatible_jl_type(obj_type::Datatype)
         if h5t_is_variable_str(obj_type)
             return Cstring
         else
-            n = Int(h5t_get_size(obj_type))
-            pad = Int(h5t_get_strpad(obj_type))
-            return FixedString{n, pad}
+            N = h5t_get_size(obj_type)
+            PAD = h5t_get_strpad(obj_type)
+            return FixedString{N,PAD}
         end
     elseif class_id == H5T_INTEGER || class_id == H5T_FLOAT
         native_type = h5t_get_native_type(obj_type)

--- a/src/api.jl
+++ b/src/api.jl
@@ -372,7 +372,7 @@ end
 function h5i_dec_ref(obj_id)
     var"#status#" = ccall((:H5Idec_ref, libhdf5), Cint, (hid_t,), obj_id)
     var"#status#" < 0 && error("Error decementing reference")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5i_get_file_id(obj_id)
@@ -390,19 +390,19 @@ end
 function h5i_get_ref(obj_id)
     var"#status#" = ccall((:H5Iget_ref, libhdf5), Cint, (hid_t,), obj_id)
     var"#status#" < 0 && error("Error getting reference count")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5i_get_type(obj_id)
     var"#status#" = ccall((:H5Iget_type, libhdf5), Cint, (hid_t,), obj_id)
     var"#status#" < 0 && error("Error getting type")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5i_inc_ref(obj_id)
     var"#status#" = ccall((:H5Iinc_ref, libhdf5), Cint, (hid_t,), obj_id)
     var"#status#" < 0 && error("Error incrementing identifier refcount")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5i_is_valid(obj_id)
@@ -522,7 +522,7 @@ end
 function h5p_get_chunk(plist_id, n_dims, dims)
     var"#status#" = ccall((:H5Pget_chunk, libhdf5), Cint, (hid_t, Cint, Ptr{hsize_t}), plist_id, n_dims, dims)
     var"#status#" < 0 && error("Error getting chunk size")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5p_get_create_intermediate_group(lcpl_id, crt_intermed_group)
@@ -575,7 +575,7 @@ end
 function h5p_get_layout(plist_id)
     var"#status#" = ccall((:H5Pget_layout, libhdf5), Cint, (hid_t,), plist_id)
     var"#status#" < 0 && error("Error getting layout")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5p_get_libver_bounds(fapl_id, low, high)
@@ -797,19 +797,19 @@ end
 function h5s_get_simple_extent_dims(space_id, dims, maxdims)
     var"#status#" = ccall((:H5Sget_simple_extent_dims, libhdf5), Cint, (hid_t, Ptr{hsize_t}, Ptr{hsize_t}), space_id, dims, maxdims)
     var"#status#" < 0 && error("Error getting the dimensions for a dataspace")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5s_get_simple_extent_ndims(space_id)
     var"#status#" = ccall((:H5Sget_simple_extent_ndims, libhdf5), Cint, (hid_t,), space_id)
     var"#status#" < 0 && error("Error getting the number of dimensions for a dataspace")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5s_get_simple_extent_type(space_id)
     var"#status#" = ccall((:H5Sget_simple_extent_type, libhdf5), Cint, (hid_t,), space_id)
     var"#status#" < 0 && error("Error getting the dataspace type")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5s_get_select_hyper_nblocks(space_id)
@@ -827,7 +827,7 @@ end
 function h5s_get_select_type(space_id)
     var"#status#" = ccall((:H5Sget_select_type, libhdf5), Cint, (hid_t,), space_id)
     var"#status#" < 0 && error("Error getting the selection type")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5s_is_regular_hyperslab(space_id)
@@ -899,31 +899,31 @@ end
 function h5t_get_array_dims(dtype_id, dims)
     var"#status#" = ccall((:H5Tget_array_dims2, libhdf5), Cint, (hid_t, Ptr{hsize_t}), dtype_id, dims)
     var"#status#" < 0 && error("Error getting dimensions of array")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5t_get_array_ndims(dtype_id)
     var"#status#" = ccall((:H5Tget_array_ndims, libhdf5), Cint, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting ndims of array")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5t_get_class(dtype_id)
     var"#status#" = ccall((:H5Tget_class, libhdf5), Cint, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting class")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5t_get_cset(dtype_id)
     var"#status#" = ccall((:H5Tget_cset, libhdf5), Cint, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting character set encoding")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5t_get_ebias(dtype_id)
     var"#status#" = ccall((:H5Tget_ebias, libhdf5), Csize_t, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting datatype floating point exponent bias")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5t_get_fields(dtype_id, spos, epos, esize, mpos, msize)
@@ -935,18 +935,18 @@ end
 function h5t_get_member_class(dtype_id, index)
     var"#status#" = ccall((:H5Tget_member_class, libhdf5), Cint, (hid_t, Cuint), dtype_id, index)
     var"#status#" < 0 && error("Error getting class of compound datatype member #", index)
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5t_get_member_index(dtype_id, membername)
     var"#status#" = ccall((:H5Tget_member_index, libhdf5), Cint, (hid_t, Ptr{UInt8}), dtype_id, membername)
     var"#status#" < 0 && error("Error getting index of compound datatype member \"", membername, "\"")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5t_get_member_offset(dtype_id, index)
     var"#status#" = ccall((:H5Tget_member_offset, libhdf5), Csize_t, (hid_t, Cuint), dtype_id, index)
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5t_get_member_type(dtype_id, index)
@@ -964,25 +964,25 @@ end
 function h5t_get_nmembers(dtype_id)
     var"#status#" = ccall((:H5Tget_nmembers, libhdf5), Cint, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting the number of members")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5t_get_sign(dtype_id)
     var"#status#" = ccall((:H5Tget_sign, libhdf5), Cint, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting sign")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5t_get_size(dtype_id)
     var"#status#" = ccall((:H5Tget_size, libhdf5), Csize_t, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting size")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5t_get_strpad(dtype_id)
     var"#status#" = ccall((:H5Tget_strpad, libhdf5), Cint, (hid_t,), dtype_id)
     var"#status#" < 0 && error("Error getting string padding")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5t_get_super(dtype_id)
@@ -1090,7 +1090,7 @@ end
 function h5ds_get_num_scales(did, idx)
     var"#status#" = ccall((:H5DSget_num_scales, libhdf5_hl), Cint, (hid_t, Cuint), did, idx)
     var"#status#" < 0 && error("Error getting number of scales")
-    return var"#status#"
+    return Int(var"#status#")
 end
 
 function h5ds_get_scale_name(did, name, size)

--- a/src/api.jl
+++ b/src/api.jl
@@ -922,7 +922,7 @@ end
 
 function h5t_get_ebias(dtype_id)
     var"#status#" = ccall((:H5Tget_ebias, libhdf5), Csize_t, (hid_t,), dtype_id)
-    return Int(var"#status#")
+    return var"#status#"
 end
 
 function h5t_get_fields(dtype_id, spos, epos, esize, mpos, msize)
@@ -945,7 +945,7 @@ end
 
 function h5t_get_member_offset(dtype_id, index)
     var"#status#" = ccall((:H5Tget_member_offset, libhdf5), Csize_t, (hid_t, Cuint), dtype_id, index)
-    return Int(var"#status#")
+    return var"#status#"
 end
 
 function h5t_get_member_type(dtype_id, index)
@@ -974,7 +974,7 @@ end
 
 function h5t_get_size(dtype_id)
     var"#status#" = ccall((:H5Tget_size, libhdf5), Csize_t, (hid_t,), dtype_id)
-    return Int(var"#status#")
+    return var"#status#"
 end
 
 function h5t_get_strpad(dtype_id)


### PR DESCRIPTION
Admittedly this had less of an impact on simplifying the code base as I originally hoped, but it does overall enhance usability with Julia since `Int` is the canonical integer type, so I think it's a good change. 