### PR TITLE
Fixup return type error checks for Csize_t

### DIFF
--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -231,7 +231,7 @@
 @bind h5t_get_array_ndims(dtype_id::hid_t)::Cint "Error getting ndims of array"
 @bind h5t_get_class(dtype_id::hid_t)::Cint "Error getting class"
 @bind h5t_get_cset(dtype_id::hid_t)::Cint "Error getting character set encoding"
-@bind h5t_get_ebias(dtype_id::hid_t)::Csize_t "Error getting datatype floating point exponent bias"
+@bind h5t_get_ebias(dtype_id::hid_t)::Csize_t # does not error
 @bind h5t_get_fields(dtype_id::hid_t, spos::Ref{Csize_t}, epos::Ref{Csize_t}, esize::Ref{Csize_t}, mpos::Ref{Csize_t}, msize::Ref{Csize_t})::herr_t "Error getting datatype floating point bit positions"
 @bind h5t_get_member_class(dtype_id::hid_t, index::Cuint)::Cint error("Error getting class of compound datatype member #", index)
 @bind h5t_get_member_index(dtype_id::hid_t, membername::Ptr{UInt8})::Cint error("Error getting index of compound datatype member \"", membername, "\"")
@@ -240,7 +240,7 @@
 @bind h5t_get_native_type(dtype_id::hid_t, direction::Cint)::hid_t "Error getting native type"
 @bind h5t_get_nmembers(dtype_id::hid_t)::Cint "Error getting the number of members"
 @bind h5t_get_sign(dtype_id::hid_t)::Cint "Error getting sign"
-@bind h5t_get_size(dtype_id::hid_t)::Csize_t "Error getting size"
+@bind h5t_get_size(dtype_id::hid_t)::Csize_t # does not error
 @bind h5t_get_strpad(dtype_id::hid_t)::Cint "Error getting string padding"
 @bind h5t_get_super(dtype_id::hid_t)::hid_t "Error getting super type"
 @bind h5t_insert(dtype_id::hid_t, fieldname::Ptr{UInt8}, offset::Csize_t, field_id::hid_t)::herr_t error("Error adding field ", fieldname, " to compound datatype")

--- a/gen/bind_generator.jl
+++ b/gen/bind_generator.jl
@@ -128,7 +128,7 @@ macro bind(sig::Expr, err::Union{String,Expr,Nothing} = nothing)
     errexpr = err isa String ? :(error($err)) : err
     if errexpr === nothing
         # pass through
-    elseif rettype === :haddr_t|| rettype === :hsize_t
+    elseif rettype === :haddr_t || rettype === :hsize_t
         # Error typically indicated by negative values, but some return types are unsigned
         # integers. From `H5public.h`:
         #   ADDR_UNDEF => (haddr_t)(-1)

--- a/src/api.jl
+++ b/src/api.jl
@@ -922,7 +922,6 @@ end
 
 function h5t_get_ebias(dtype_id)
     var"#status#" = ccall((:H5Tget_ebias, libhdf5), Csize_t, (hid_t,), dtype_id)
-    var"#status#" < 0 && error("Error getting datatype floating point exponent bias")
     return var"#status#"
 end
 
@@ -975,7 +974,6 @@ end
 
 function h5t_get_size(dtype_id)
     var"#status#" = ccall((:H5Tget_size, libhdf5), Csize_t, (hid_t,), dtype_id)
-    var"#status#" < 0 && error("Error getting size")
     return var"#status#"
 end
 


### PR DESCRIPTION
According to the docs, these will either return the corresponding values or set the value to 0. Checking < 0 also doesn't make sense since the return values are `Csize_t` (unsigned)