### PR TITLE
Perf: return empty string instead of nothing in split1

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -704,7 +704,7 @@ end
 # Path manipulation
 function split1(path::AbstractString)
     ind = findfirst('/', path)
-    isnothing(ind) && return path, nothing
+    isnothing(ind) && return path, ""
     if ind == 1 # matches root group
         return "/", path[2:end]
     else
@@ -914,7 +914,7 @@ function Base.haskey(parent::Union{File,Group}, path::AbstractString, lapl::Prop
         return false
     end
     exists = true
-    if !isnothing(rest) && !isempty(rest)
+    if !isempty(rest)
         obj = parent[first]
         exists = haskey(obj, rest, lapl)
         close(obj)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -872,10 +872,10 @@ end # show tests
 
 @testset "split1" begin
 
-@test HDF5.split1("a") == ("a", nothing)
+@test HDF5.split1("a") == ("a", "")
 @test HDF5.split1("/a/b/c") == ("/", "a/b/c")
 @test HDF5.split1("a/b/c") == ("a", "b/c")
-@test HDF5.split1(GenericString("a")) == ("a", nothing)
+@test HDF5.split1(GenericString("a")) == ("a", "")
 @test HDF5.split1(GenericString("/a/b/c")) == ("/", "a/b/c")
 @test HDF5.split1(GenericString("a/b/c")) == ("a", "b/c")
 

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -872,6 +872,7 @@ end # show tests
 
 @testset "split1" begin
 
+@test HDF5.split1("/") == ("/", "")
 @test HDF5.split1("a") == ("a", "")
 @test HDF5.split1("/a/b/c") == ("/", "a/b/c")
 @test HDF5.split1("a/b/c") == ("a", "b/c")
@@ -908,6 +909,7 @@ hfile = h5open(fn, "w")
 group1 = create_group(hfile, "group1")
 group2 = create_group(group1, "group2")
 
+@test haskey(hfile, "/")
 @test haskey(hfile, GenericString("group1"))
 @test !haskey(hfile, GenericString("groupna"))
 @test haskey(hfile, "group1/group2")


### PR DESCRIPTION
Minor perf enhancement (reduces a single allocation). I see no specific reason to return nothing.