### PR TITLE
Check if object exists before create_(dataset|group)

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -704,7 +704,9 @@ end
 function create_group(parent::Union{File,Group}, path::AbstractString,
                   lcpl::Properties=_link_properties(path),
                   gcpl::Properties=DEFAULT_PROPERTIES)
-    Group(h5g_create(checkvalid(parent), path, lcpl, gcpl, H5P_DEFAULT), file(parent))
+    checkvalid(parent)
+    haskey(parent, path) && error("cannot create group: object \"", path, "\" already exists at ", name(parent))
+    Group(h5g_create(parent, path, lcpl, gcpl, H5P_DEFAULT), file(parent))
 end
 
 function create_dataset(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace::Dataspace,
@@ -718,6 +720,8 @@ function create_dataset(parent::Union{File,Group}, path::AbstractString, dtype::
     dcpl = isempty(pv) ? DEFAULT_PROPERTIES : create_property(H5P_DATASET_CREATE; pv...)
     dxpl = isempty(pv) ? DEFAULT_PROPERTIES : create_property(H5P_DATASET_XFER; pv...)
     dapl = isempty(pv) ? DEFAULT_PROPERTIES : create_property(H5P_DATASET_ACCESS; pv...)
+    checkvalid(parent)
+    haskey(parent, path) && error("cannot create dataset: object \"", path, "\" already exists at ", name(parent))
     Dataset(h5d_create(checkvalid(parent), path, dtype, dspace, _link_properties(path), dcpl, dapl), file(parent), dxpl)
 end
 create_dataset(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace_dims::Dims; pv...) = create_dataset(checkvalid(parent), path, dtype, dataspace(dspace_dims); pv...)

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -722,7 +722,7 @@ function create_dataset(parent::Union{File,Group}, path::AbstractString, dtype::
     dapl = isempty(pv) ? DEFAULT_PROPERTIES : create_property(H5P_DATASET_ACCESS; pv...)
     checkvalid(parent)
     haskey(parent, path) && error("cannot create dataset: object \"", path, "\" already exists at ", name(parent))
-    Dataset(h5d_create(checkvalid(parent), path, dtype, dspace, _link_properties(path), dcpl, dapl), file(parent), dxpl)
+    Dataset(h5d_create(parent, path, dtype, dspace, _link_properties(path), dcpl, dapl), file(parent), dxpl)
 end
 create_dataset(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace_dims::Dims; pv...) = create_dataset(checkvalid(parent), path, dtype, dataspace(dspace_dims); pv...)
 create_dataset(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace_dims::Tuple{Dims,Dims}; pv...) = create_dataset(checkvalid(parent), path, dtype, dataspace(dspace_dims[1], max_dims=dspace_dims[2]); pv...)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -1167,3 +1167,21 @@ end
         @test read(d) == ref
     end
 end
+
+@testset "Object Exists" begin
+
+hfile = h5open(tempname(), "w")
+g1 = create_group(hfile, "group1")
+@test_throws ErrorException create_group(hfile, "group1")
+create_group(g1, "group1a")
+@test_throws ErrorException create_group(hfile, "/group1/group1a")
+@test_throws ErrorException create_group(g1, "group1a")
+
+create_dataset(hfile, "dset1", 1)
+create_dataset(hfile, "/group1/dset1", 1)
+
+@test_throws ErrorException create_dataset(hfile, "dset1", 1)
+@test_throws ErrorException create_dataset(hfile, "group1", 1)
+@test_throws ErrorException create_dataset(g1, "dset1", 1)
+
+end


### PR DESCRIPTION
This gets rid of the nasty HDF5 library error print out. 