### PR TITLE
Delete straggling create_dataset method

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -707,12 +707,6 @@ function create_group(parent::Union{File,Group}, path::AbstractString,
     Group(h5g_create(checkvalid(parent), path, lcpl, gcpl, H5P_DEFAULT), file(parent))
 end
 
-function create_dataset(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace::Dataspace,
-                  lcpl::Properties, dcpl::Properties,
-                  dapl::Properties, dxpl::Properties)
-    Dataset(h5d_create(checkvalid(parent), path, dtype, dspace, lcpl, dcpl, dapl), file(parent), dxpl)
-end
-
 # Setting dset creation properties with name/value pairs
 function create_dataset(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace::Dataspace; pv...)
     dcpl = isempty(pv) ? DEFAULT_PROPERTIES : create_property(H5P_DATASET_CREATE; pv...)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -447,4 +447,5 @@ end
 ### Changed in PR#776
 @deprecate create_dataset(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace::Dataspace,
 lcpl::Properties, dcpl::Properties,
-dapl::Properties, dxpl::Properties) create_dataset(parent, path, dtype, dspace; lcpl=lcpl, dcpl=dcpl, dapl=dapl, dxpl=dxpl) false
+dapl::Properties, dxpl::Properties) HDF5.Dataset(
+        HDF5.h5d_create(parent, path, dtype, dspace, lcpl, dcpl, dapl), HDF5.file(parent), dxpl)) false

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -446,6 +446,4 @@ end
 
 ### Changed in PR#776
 @deprecate create_dataset(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace::Dataspace,
-lcpl::Properties, dcpl::Properties,
-dapl::Properties, dxpl::Properties) HDF5.Dataset(
-        HDF5.h5d_create(parent, path, dtype, dspace, lcpl, dcpl, dapl), HDF5.file(parent), dxpl)) false
+    lcpl::Properties, dcpl::Properties, dapl::Properties, dxpl::Properties) HDF5.Dataset(HDF5.h5d_create(parent, path, dtype, dspace, lcpl, dcpl, dapl), HDF5.file(parent), dxpl) false

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -438,3 +438,13 @@ end
 @deprecate t_create create_datatype
 @deprecate t_open   open_datatype
 @deprecate t_commit commit_datatype
+
+
+###
+### v0.15 deprecations
+###
+
+### Changed in PR#776
+@deprecate create_dataset(parent::Union{File,Group}, path::AbstractString, dtype::Datatype, dspace::Dataspace,
+lcpl::Properties, dcpl::Properties,
+dapl::Properties, dxpl::Properties) create_dataset(parent, path, dtype, dspace; lcpl=lcpl, dcpl=dcpl, dapl=dapl, dxpl=dxpl) false


### PR DESCRIPTION
Not sure if we really need a deprecation for this, but looks like it accidentally snuck in v0.14.

EDIT: yes we do, looks like JLD is using this. (Finally good use of the integration testing)

Altough the failure there is mem map failure not anything related to the deprecation AFAIK.