### PR TITLE
Add some print-limiting heuristics to default show

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -683,16 +683,19 @@ Base.getindex(dset::Dataset, name::AbstractString) = open_attribute(dset, name)
 Base.getindex(x::Attributes, name::AbstractString) = open_attribute(x.parent, name)
 
 function Base.getindex(parent::Union{File,Group}, path::AbstractString; pv...)
+    # Faster than below if defaults are OK
+    isempty(pv) && return open_object(parent, path)
+
     obj_type = gettype(parent, path)
     if obj_type == H5I_DATASET
-        dapl = isempty(pv) ? DEFAULT_PROPERTIES : create_property(H5P_DATASET_ACCESS; pv...)
-        dxpl = isempty(pv) ? DEFAULT_PROPERTIES : create_property(H5P_DATASET_XFER; pv...)
+        dapl = create_property(H5P_DATASET_ACCESS; pv...)
+        dxpl = create_property(H5P_DATASET_XFER; pv...)
         return open_dataset(parent, path, dapl, dxpl)
     elseif obj_type == H5I_GROUP
-        gapl = isempty(pv) ? DEFAULT_PROPERTIES : create_property(H5P_GROUP_ACCESS; pv...)
+        gapl = create_property(H5P_GROUP_ACCESS; pv...)
         return open_group(parent, path, gapl)
     else#if obj_type == H5I_DATATYPE # only remaining choice
-        tapl = isempty(pv) ? DEFAULT_PROPERTIES : create_property(H5P_DATATYPE_ACCESS; pv...)
+        tapl = create_property(H5P_DATATYPE_ACCESS; pv...)
         return open_datatype(parent, path, tapl)
     end
 end

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -922,8 +922,8 @@ Base.haskey(dset::Union{Dataset,Datatype}, path::AbstractString) = h5a_exists(ch
 group_info(obj::Union{Group,File}) = h5g_get_info(checkvalid(obj))
 object_info(obj::Union{File,Object}) = h5o_get_info(checkvalid(obj))
 
-Base.length(obj::Union{Group,File}) = h5g_get_num_objs(checkvalid(obj))
-Base.length(x::Attributes) = object_info(x.parent).num_attrs
+Base.length(obj::Union{Group,File}) = Int(h5g_get_num_objs(checkvalid(obj)))
+Base.length(x::Attributes) = Int(object_info(x.parent).num_attrs)
 
 Base.isempty(x::Union{Group,File}) = length(x) == 0
 Base.eltype(dset::Union{Dataset,Attribute}) = get_jl_type(dset)


### PR DESCRIPTION
This is a partial fix for #786, with the more efficient key iteration in #787 also required to avoid a very long pause on my MAT v7.3 file test case (though it does not actually finish printing, which is a significant improvement in itself).

I'm open to suggestions for whether these heuristics are sufficient and what the thresholds should be set to.

(A future TODO is to replace the `_tree_children` list building and loops with direct iteration via `h5a_iterate` and `h5l_iterate`, which should be more efficient yet.)