### PR TITLE
Change ccall wrapper signature of `h5a_iterate` and `h5l_iterate`

### DIFF
--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -45,7 +45,7 @@
 @bind h5a_get_name_by_idx(loc_id::hid_t, obj_name::Cstring, index_type::Cint, order::Cint, idx::hsize_t, name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t)::Cssize_t "Error getting attribute name"
 @bind h5a_get_space(attr_id::hid_t)::hid_t "Error getting attribute dataspace"
 @bind h5a_get_type(attr_id::hid_t)::hid_t "Error getting attribute type"
-@bind h5a_iterate2(obj_id::hid_t, idx_type::Cint, order::Cint, n::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Ptr{Cvoid})::herr_t error("Error iterating attributes in object ", h5i_get_name(obj_id))
+@bind h5a_iterate2(obj_id::hid_t, idx_type::Cint, order::Cint, n::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Any)::herr_t error("Error iterating attributes in object ", h5i_get_name(obj_id))
 @bind h5a_open(obj_id::hid_t, pathname::Ptr{UInt8}, aapl_id::hid_t)::hid_t error("Error opening attribute ", h5i_get_name(obj_id), "/", pathname)
 @bind h5a_read(attr_id::hid_t, mem_type_id::hid_t, buf::Ptr{Cvoid})::herr_t error("Error reading attribute ", h5a_get_name(attr_id))
 @bind h5a_write(attr_hid::hid_t, mem_type_id::hid_t, buf::Ptr{Cvoid})::herr_t "Error writing attribute data"
@@ -133,8 +133,8 @@
 @bind h5l_get_name_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_field::Cint, order::Cint, n::hsize_t, name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t)::Cssize_t "Error getting object name"
 # libhdf5 v1.10 provides the name H5Literate
 # libhdf5 v1.12 provides the same under H5Literate1, and a newer interface on H5Literate2
-@bind h5l_iterate(group_id::hid_t, idx_type::Cint, order::Cint, idx::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Ptr{Cvoid})::herr_t error("Error iterating through links in group ", h5i_get_name(group_id)) (nothing, v"1.12")
-@bind h5l_iterate1(group_id::hid_t, idx_type::Cint, order::Cint, idx::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Ptr{Cvoid})::herr_t error("Error iterating through links in group ", h5i_get_name(group_id)) (v"1.12", nothing)
+@bind h5l_iterate(group_id::hid_t, idx_type::Cint, order::Cint, idx::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Any)::herr_t error("Error iterating through links in group ", h5i_get_name(group_id)) (nothing, v"1.12")
+@bind h5l_iterate1(group_id::hid_t, idx_type::Cint, order::Cint, idx::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Any)::herr_t error("Error iterating through links in group ", h5i_get_name(group_id)) (v"1.12", nothing)
 
 ###
 ### Object Interface

--- a/src/api.jl
+++ b/src/api.jl
@@ -242,12 +242,12 @@ function h5a_get_type(attr_id)
 end
 
 """
-    h5a_iterate(obj_id::hid_t, idx_type::Cint, order::Cint, n::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Ptr{Cvoid})
+    h5a_iterate(obj_id::hid_t, idx_type::Cint, order::Cint, n::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Any)
 
 See `libhdf5` documentation for [`H5Aiterate2`](https://portal.hdfgroup.org/display/HDF5/H5A_ITERATE2).
 """
 function h5a_iterate(obj_id, idx_type, order, n, op, op_data)
-    var"#status#" = ccall((:H5Aiterate2, libhdf5), herr_t, (hid_t, Cint, Cint, Ptr{hsize_t}, Ptr{Cvoid}, Ptr{Cvoid}), obj_id, idx_type, order, n, op, op_data)
+    var"#status#" = ccall((:H5Aiterate2, libhdf5), herr_t, (hid_t, Cint, Cint, Ptr{hsize_t}, Ptr{Cvoid}, Any), obj_id, idx_type, order, n, op, op_data)
     var"#status#" < 0 && error("Error iterating attributes in object ", h5i_get_name(obj_id))
     return nothing
 end
@@ -859,12 +859,12 @@ end
 
 @static if _libhdf5_build_ver < v"1.12"
     @doc """
-        h5l_iterate(group_id::hid_t, idx_type::Cint, order::Cint, idx::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Ptr{Cvoid})
+        h5l_iterate(group_id::hid_t, idx_type::Cint, order::Cint, idx::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Any)
 
     See `libhdf5` documentation for [`H5Literate`](https://portal.hdfgroup.org/display/HDF5/H5L_ITERATE).
     """
     function h5l_iterate(group_id, idx_type, order, idx, op, op_data)
-        var"#status#" = ccall((:H5Literate, libhdf5), herr_t, (hid_t, Cint, Cint, Ptr{hsize_t}, Ptr{Cvoid}, Ptr{Cvoid}), group_id, idx_type, order, idx, op, op_data)
+        var"#status#" = ccall((:H5Literate, libhdf5), herr_t, (hid_t, Cint, Cint, Ptr{hsize_t}, Ptr{Cvoid}, Any), group_id, idx_type, order, idx, op, op_data)
         var"#status#" < 0 && error("Error iterating through links in group ", h5i_get_name(group_id))
         return nothing
     end
@@ -872,12 +872,12 @@ end
 
 @static if v"1.12" ≤ _libhdf5_build_ver
     @doc """
-        h5l_iterate(group_id::hid_t, idx_type::Cint, order::Cint, idx::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Ptr{Cvoid})
+        h5l_iterate(group_id::hid_t, idx_type::Cint, order::Cint, idx::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Any)
 
     See `libhdf5` documentation for [`H5Literate1`](https://portal.hdfgroup.org/display/HDF5/H5L_ITERATE1).
     """
     function h5l_iterate(group_id, idx_type, order, idx, op, op_data)
-        var"#status#" = ccall((:H5Literate1, libhdf5), herr_t, (hid_t, Cint, Cint, Ptr{hsize_t}, Ptr{Cvoid}, Ptr{Cvoid}), group_id, idx_type, order, idx, op, op_data)
+        var"#status#" = ccall((:H5Literate1, libhdf5), herr_t, (hid_t, Cint, Cint, Ptr{hsize_t}, Ptr{Cvoid}, Any), group_id, idx_type, order, idx, op, op_data)
         var"#status#" < 0 && error("Error iterating through links in group ", h5i_get_name(group_id))
         return nothing
     end

--- a/src/api_helpers.jl
+++ b/src/api_helpers.jl
@@ -68,15 +68,7 @@ julia> HDF5.h5a_iterate(obj, HDF5.H5_INDEX_NAME, HDF5.H5_ITER_INC) do loc, name,
 function h5a_iterate(@nospecialize(f), obj_id, idx_type, order, idx = 0)
     idxref = Ref{hsize_t}(idx)
     fptr = @cfunction(h5a_iterate_helper, herr_t, (hid_t, Ptr{Cchar}, Ptr{H5A_info_t}, Any))
-    userf = Ref{Any}(f)
-    if VERSION < v"1.6.0-DEV.1038"
-        # unsafe_convert(Ptr{Cvoid}, ::RefValue{Any}) returns pointer to RefValue instead
-        # of data --- see JuliaLang/julia#37591
-        userfptr = unsafe_load(Ptr{Ptr{Cvoid}}(unsafe_convert(Ptr{Any}, userf)))
-        GC.@preserve userf h5a_iterate(obj_id, idx_type, order, idxref, fptr, userfptr)
-    else
-        GC.@preserve userf h5a_iterate(obj_id, idx_type, order, idxref, fptr, userf)
-    end
+    h5a_iterate(obj_id, idx_type, order, idxref, fptr, f)
     return idxref[]
 end
 
@@ -204,15 +196,7 @@ julia> HDF5.h5l_iterate(hfile, HDF5.H5_INDEX_NAME, HDF5.H5_ITER_INC) do group, n
 function h5l_iterate(@nospecialize(f), group_id, idx_type, order, idx = 0)
     idxref = Ref{hsize_t}(idx)
     fptr = @cfunction(h5l_iterate_helper, herr_t, (hid_t, Ptr{Cchar}, Ptr{H5L_info_t}, Any))
-    userf = Ref{Any}(f)
-    if VERSION < v"1.6.0-DEV.1038"
-        # unsafe_convert(Ptr{Cvoid}, ::RefValue{Any}) returns pointer to RefValue instead
-        # of data --- see JuliaLang/julia#37591
-        userfptr = unsafe_load(Ptr{Ptr{Cvoid}}(unsafe_convert(Ptr{Any}, userf)))
-        GC.@preserve userf h5l_iterate(group_id, idx_type, order, idxref, fptr, userfptr)
-    else
-        GC.@preserve userf h5l_iterate(group_id, idx_type, order, idxref, fptr, userf)
-    end
+    h5l_iterate(group_id, idx_type, order, idxref, fptr, f)
     return idxref[]
 end
 


### PR DESCRIPTION
Addresses comment from https://github.com/JuliaIO/HDF5.jl/pull/812#discussion_r575495220.

Fixes #814.