### PR TITLE
Allow attributes on types

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -281,9 +281,9 @@ end
 Base.cconvert(::Type{hid_t}, attr::Attribute) = attr.id
 
 struct Attributes
-    parent::Union{File,Group,Dataset}
+    parent::Union{File,Object}
 end
-attributes(p::Union{File,Group,Dataset}) = Attributes(p)
+attributes(p::Union{File,Object}) = Attributes(p)
 
 # Methods for reference types
 function Reference(parent::Union{File,Group,Dataset}, name::AbstractString)

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -704,6 +704,12 @@ dtype = HDF5.Datatype(HDF5.h5t_copy(HDF5.H5T_IEEE_F64LE))
 commit_datatype(hfile, "type", dtype)
 @test sprint(show, dtype) == "HDF5.Datatype: /type H5T_IEEE_F64LE"
 
+dtypemeta = create_attribute(dtype, "dtypemeta", datatype(Bool), dataspace((1,)))
+@test sprint(show, dtypemeta) == "HDF5.Attribute: dtypemeta"
+
+dtypeattrs = attributes(dtype)
+@test sprint(show, dtypeattrs) == "Attributes of HDF5.Datatype: /type H5T_IEEE_F64LE"
+
 dspace_null = HDF5.Dataspace(HDF5.h5s_create(HDF5.H5S_NULL))
 dspace_scal = HDF5.Dataspace(HDF5.h5s_create(HDF5.H5S_SCALAR))
 dspace_norm = dataspace((100, 4))
@@ -734,6 +740,9 @@ close(prop)
 
 close(meta)
 @test sprint(show, meta) == "HDF5.Attribute: (invalid)"
+
+close(dtypemeta)
+@test sprint(show, dtypemeta) == "HDF5.Attribute: (invalid)"
 
 close(dset)
 @test sprint(show, dset) == "HDF5.Dataset: (invalid)"


### PR DESCRIPTION
HDF5 types can have attributes. This is currently not allowed by `HDF5.jl`. This small change to the type signature of `attributes` remedies this.