### PR TITLE
Support Base.getindex(::Attribute, I...)

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1182,10 +1182,10 @@ function Base.read(obj::DatasetOrAttribute)
     return val
 end
 
-function Base.getindex(dset::Dataset, I...)
-    dtype = datatype(dset)
+function Base.getindex(obj::DatasetOrAttribute, I...)
+    dtype = datatype(obj)
     T = get_jl_type(dtype)
-    val = generic_read(dset, dtype, T, I...)
+    val = generic_read(obj, dtype, T, I...)
     close(dtype)
     return val
 end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -78,12 +78,17 @@ write(f, "empty_array_of_strings", empty_array_of_strings)
 # attributes
 species = [["N", "C"]; ["A", "B"]]
 attributes(f)["species"] = species
+@test read(attributes(f)["species"]) == species
+@test attributes(f)["species"][] == species
 C∞ = 42
 attributes(f)["C∞"] = C∞
 dset = f["salut"]
 @test !isempty(dset)
 label = "This is a string"
 attributes(dset)["typeinfo"] = label
+@test read(attributes(dset)["typeinfo"]) == label
+@test attributes(dset)["typeinfo"][] == label
+@test dset["typeinfo"][] == label
 close(dset)
 # Scalar reference values in attributes
 attributes(f)["ref_test"] = HDF5.Reference(f, "empty_array_of_strings")


### PR DESCRIPTION
Widen the type of the first parameter from...

    Base.getindex(dset::Dataset, I...)

...to...

    Base.getindex(obj::DatasetOrAttribute, I...)

`DatasetOrAttribute` is already defined and supported elsewhere.  Most
importantly, `generic_read` already accepts that Union type.

The allows one to access attribute values using syntax like:

    h5file["dataset"]["attribute"][]

rather than having to call `read` directly like:

    read(h5file["dataset"]["attribute"])

Fixes #838