### PR TITLE
Add `filter` keyword argument to create_dataset

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1927,6 +1927,8 @@ end
 
 # Set a single filter
 function set_filter(p::Properties, filter_id, flags, cd_values...)
+    # Passing cd_values as Cuint[] allocates less than passing as
+    # Ref{NTuple{N,Cuint}} (and it is compatible with Julia 1.3)
     h5p_set_filter(p::Properties, filter_id, flags, length(cd_values), Cuint[cd_values...])
 end
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1927,13 +1927,13 @@ end
 
 # Set a single filter
 function set_filter(p::Properties, filter_id, flags, cd_values...)
-    h5p_set_filter(p::Properties, filter_id, flags, length(cd_values), Ref(UInt32.(cd_values)))
+    h5p_set_filter(p::Properties, filter_id, flags, length(cd_values), Ref(Cuint.(cd_values)))
 end
 
 # Set multiple filters
-function set_filter(p::Properties, filter::Tuple, more_filters...)
+function set_filter(p::Properties, filter::Tuple, additional_filters...)
     set_filter(p::Properties, filter...)
-    for f in more_filters
+    for f in additional_filters
       set_filter(p::Properties, f...)
     end
 end

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -840,6 +840,7 @@ function _prop_set!(p::Properties, name::Symbol, val, check::Bool = true)
                name === :compress    ? h5p_set_deflate(p, val...) :
                name === :deflate     ? h5p_set_deflate(p, val...) :
                name === :external    ? h5p_set_external(p, val...) :
+               name === :filter      ? set_filter(p, val...) :
                name === :layout      ? h5p_set_layout(p, val...) :
                name === :shuffle     ? h5p_set_shuffle(p, val...) :
                name === :track_times ? h5p_set_obj_track_times(p, val...) : # H5P_OBJECT_CREATE
@@ -1922,6 +1923,10 @@ function get_chunk(dset::Dataset)
         close(p)
     end
     ret
+end
+
+function set_filter(p::Properties, filter_id, flags, cd_values...)
+    h5p_set_filter(p::Properties, filter_id, flags, length(cd_values), Ref(UInt32.(cd_values)))
 end
 
 get_alignment(p::Properties)     = h5p_get_alignment(checkvalid(p))

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1925,8 +1925,17 @@ function get_chunk(dset::Dataset)
     ret
 end
 
+# Set a single filter
 function set_filter(p::Properties, filter_id, flags, cd_values...)
     h5p_set_filter(p::Properties, filter_id, flags, length(cd_values), Ref(UInt32.(cd_values)))
+end
+
+# Set multiple filters
+function set_filter(p::Properties, filter::Tuple, more_filters...)
+    set_filter(p::Properties, filter...)
+    for f in more_filters
+      set_filter(p::Properties, f...)
+    end
 end
 
 get_alignment(p::Properties)     = h5p_get_alignment(checkvalid(p))

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1927,7 +1927,7 @@ end
 
 # Set a single filter
 function set_filter(p::Properties, filter_id, flags, cd_values...)
-    h5p_set_filter(p::Properties, filter_id, flags, length(cd_values), Ref(Cuint.(cd_values)))
+    h5p_set_filter(p::Properties, filter_id, flags, length(cd_values), Cuint[cd_values...])
 end
 
 # Set multiple filters

--- a/src/api_types.jl
+++ b/src/api_types.jl
@@ -336,6 +336,7 @@ const H5T_NATIVE_DOUBLE   = _read_const(:H5T_NATIVE_DOUBLE_g)
 const H5T_VARIABLE = reinterpret(UInt, -1)
 
 # Filter constants
+const H5Z_FLAG_MANDATORY = 0x0000
 const H5Z_FLAG_OPTIONAL = 0x0001
 const H5Z_FLAG_REVERSE = 0x0100
 const H5Z_CLASS_T_VERS = 1

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -1,0 +1,56 @@
+using HDF5
+using Test
+
+@testset "filter" begin
+
+H5Z_FILTER_DEFLATE = 1
+H5Z_FILTER_SHUFFLE = 2
+
+# Create a new file
+fn = tempname()
+
+# Create test data
+data = rand(1000, 1000)
+
+# Open temp file for writing
+f = h5open(fn, "w")
+
+# Create datasets
+dsdeflate = create_dataset(f, "deflate", datatype(data), dataspace(data),
+                           chunk=(100, 100), compress=3)
+
+dsshufdef = create_dataset(f, "shufdef", datatype(data), dataspace(data),
+                           chunk=(100, 100), shuffle=(), compress=3)
+
+dsfiltdef = create_dataset(f, "filtdef", datatype(data), dataspace(data),
+                           chunk=(100, 100), filter=(H5Z_FILTER_DEFLATE,0,3))
+
+dsfiltshufdef = create_dataset(f, "filtshufdef", datatype(data), dataspace(data),
+                               chunk=(100, 100), filter=((H5Z_FILTER_SHUFFLE,0),
+                                                         (H5Z_FILTER_DEFLATE,0,3)))
+
+# Write data
+write(dsdeflate, data)
+write(dsshufdef, data)
+write(dsfiltdef, data)
+write(dsfiltshufdef, data)
+
+# Close and re-open file for reading
+close(f)
+f = h5open(fn)
+
+# Read dataseta
+datadeflate = f["deflate"][]
+datashufdef = f["shufdef"][]
+datafiltdef = f["filtdef"][]
+datafiltshufdef = f["filtshufdef"][]
+
+close(f)
+
+# Test for equality
+@test datadeflate == data
+@test datashufdef == data
+@test datafiltdef == data
+@test datafiltshufdef == data
+
+end # @testset "filter"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ include("swmr.jl")
 include("mmap.jl")
 include("properties.jl")
 include("table.jl")
+include("filter.jl")
 
 try
     using MPI


### PR DESCRIPTION
This allows `create_dataset` to create a dataset with a user-defined
filter by setting the `filter` keyword to a Tuple of integers that
describe and configure the filter.  For example, to use a filter
specified by `filter_id=32013`, `flags=0`, `cd_nelmts=3`, and
`cd_values=(2,0,8)`:

    ds, dt = create_dataset(h5, "data", data,
                            chunk=(256,1,256),
                            filter=(32013,0,2,0,8))

Note that `cd_nelmts` is not included explicitly.  It is inferred from
the length of the Tuple.