### PR TITLE
Fix #863, support mmapping complex arrays

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1431,6 +1431,7 @@ end
 
 # Reading with mmap
 ismmappable(::Type{<:ScalarType}) = true
+ismmappable(::Type{Complex{T}}) where {T<:BitsType} = true
 ismmappable(::Type) = false
 ismmappable(obj::Dataset, ::Type{T}) where {T} = ismmappable(T) && iscontiguous(obj)
 ismmappable(obj::Dataset) = ismmappable(obj, get_jl_type(obj))


### PR DESCRIPTION
Fixes #863 by recognizing support for mmapping complex arrays when complex support is enabled:

```julia
julia> fid = h5open(fname, "w")
🗂️ HDF5.File: (read-write) /tmp/jl_VR9RG4

julia> fid["mygroup/mat"] = randn(ComplexF32, 5, 5)
5×5 Matrix{ComplexF32}:
 -0.0206494+0.15139im    -0.30275-0.766282im   0.218359-1.37796im     -1.19865+0.938592im     0.250951-0.155142im
    1.24434+0.336309im  0.0119998+0.36218im   -0.758139-0.601466im    0.758801+1.10978im     -0.218485-0.349157im
   0.447418+0.648992im   0.902971+0.638549im   -1.12687+0.810113im   -0.843926-0.0984118im    0.292523-0.580734im
   0.468736+1.44492im   -0.394601+0.467676im   -0.28411+0.57623im    -0.413753-1.66715im      -1.18591-0.588491im
 -0.0403372-1.30409im   -0.723688-0.137791im   0.229186-0.0161388im    1.28278+0.38183im    -0.0560287-1.97241im

julia> close(fid)

julia> fid = h5open(fname, "r+")
🗂️ HDF5.File: (read-write) /tmp/jl_VR9RG4
└─ 📂 mygroup
   └─ 🔢 mat

julia> read(fid["mygroup/mat"]) == HDF5.readmmap(fid["mygroup/mat"])
true
```