### PR TITLE
Add move_link

### DIFF
--- a/docs/src/api_bindings.md
+++ b/docs/src/api_bindings.md
@@ -14,7 +14,7 @@ This page documents the function names and nominal C argument types of the API w
 have bindings in this package.
 Note that in many cases, high-level data types are valid arguments through automatic
 `ccall` conversions.
-For instance, `HDF5Datatype` objects will be automatically converted to their `hid_t` ID
+For instance, `HDF5.Datatype` objects will be automatically converted to their `hid_t` ID
 by Julia's `cconvert`+`unsafe_convert` `ccall` rules.
 
 There are additional helper wrappers (often for out-argument functions) which are not
@@ -247,6 +247,7 @@ h5i_is_valid
 - [`h5l_get_info`](@ref h5l_get_info)
 - [`h5l_get_name_by_idx`](@ref h5l_get_name_by_idx)
 - [`h5l_iterate`](@ref h5l_iterate)
+- [`h5l_move`](@ref h5l_move)
 ```@docs
 h5l_create_external
 h5l_create_hard
@@ -256,6 +257,7 @@ h5l_exists
 h5l_get_info
 h5l_get_name_by_idx
 h5l_iterate
+h5l_move
 ```
 
 ---

--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -145,6 +145,7 @@
 @bind h5l_create_hard(obj_loc_id::hid_t, obj_name::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)::herr_t string("Error creating hard link ", link_name, " pointing to ", obj_name)
 @bind h5l_create_soft(target_path::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)::herr_t string("Error creating soft link ", link_name, " pointing to ", target_path)
 @bind h5l_delete(obj_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t)::herr_t string("Error deleting ", h5i_get_name(obj_id), "/", pathname)
+@bind h5l_move(src_obj_id::hid_t, src_name::Ptr{UInt8}, dest_obj_id::hid_t, dest_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)::herr_t string("Error moving ", h5i_get_name(src_obj_id), "/", src_name, " to ", h5i_get_name(dest_obj_id), "/", dest_name)
 @bind h5l_exists(loc_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t)::htri_t string("Cannot determine whether ", pathname, " exists")
 @bind h5l_get_info(link_loc_id::hid_t, link_name::Ptr{UInt8}, link_buf::Ptr{H5L_info_t}, lapl_id::hid_t)::herr_t string("Error getting info for link ", link_name)
 @bind h5l_get_name_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_field::Cint, order::Cint, n::hsize_t, name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t)::Cssize_t "Error getting object name"

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -15,7 +15,7 @@ h5open, h5read, h5write, h5rewrite, h5writeattr, h5readattr,
 create_attribute, open_attribute, read_attribute, write_attribute, delete_attribute, attributes,
 create_dataset, open_dataset, read_dataset, write_dataset,
 create_group, open_group,
-copy_object, open_object, delete_object, move_object,
+copy_object, open_object, delete_object, move_link,
 create_datatype, commit_datatype, open_datatype,
 create_property,
 group_info, object_info,
@@ -863,9 +863,9 @@ delete_object(obj::Object) = delete_object(parent(obj), ascii(split(name(obj),"/
 copy_object(src_parent::Union{File,Group}, src_path::AbstractString, dst_parent::Union{File,Group}, dst_path::AbstractString) = API.h5o_copy(checkvalid(src_parent), src_path, checkvalid(dst_parent), dst_path, API.H5P_DEFAULT, _link_properties(dst_path))
 copy_object(src_obj::Object, dst_parent::Union{File,Group}, dst_path::AbstractString) = API.h5o_copy(checkvalid(src_obj), ".", checkvalid(dst_parent), dst_path, API.H5P_DEFAULT, _link_properties(dst_path))
 
-# Move objects
-move_object(src::Union{File,Group}, src_name::AbstractString, dest::Union{File,Group}, dest_name::AbstractString=src_name, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = h5l_move(checkvalid(src), src_name, checkvalid(dest), dest_name, lcpl, lapl)
-move_object(parent::Union{File,Group}, src_name::AbstractString, dest_name::AbstractString, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = h5l_move(checkvalid(parent), src_name, parent, dest_name, lcpl, lapl)
+# Move links
+move_link(src::Union{File,Group}, src_name::AbstractString, dest::Union{File,Group}, dest_name::AbstractString=src_name, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = h5l_move(checkvalid(src), src_name, checkvalid(dest), dest_name, lcpl, lapl)
+move_link(parent::Union{File,Group}, src_name::AbstractString, dest_name::AbstractString, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = h5l_move(checkvalid(parent), src_name, parent, dest_name, lcpl, lapl)
 
 # Assign syntax: obj[path] = value
 # Creates a dataset unless obj is a dataset, in which case it creates an attribute

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -864,7 +864,7 @@ copy_object(src_parent::Union{File,Group}, src_path::AbstractString, dst_parent:
 copy_object(src_obj::Object, dst_parent::Union{File,Group}, dst_path::AbstractString) = API.h5o_copy(checkvalid(src_obj), ".", checkvalid(dst_parent), dst_path, API.H5P_DEFAULT, _link_properties(dst_path))
 
 # Move objects
-move_object(src::Union{File,Group}, src_name::AbstractString, dest::Union{File,Group}, dest_name::AbstractString, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = h5l_move(checkvalid(src), src_name, checkvalid(dest), dest_name, lcpl, lapl)
+move_object(src::Union{File,Group}, src_name::AbstractString, dest::Union{File,Group}, dest_name::AbstractString=src_name, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = h5l_move(checkvalid(src), src_name, checkvalid(dest), dest_name, lcpl, lapl)
 move_object(parent::Union{File,Group}, src_name::AbstractString, dest_name::AbstractString, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = h5l_move(checkvalid(parent), src_name, parent, dest_name, lcpl, lapl)
 
 # Assign syntax: obj[path] = value

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -864,8 +864,11 @@ copy_object(src_parent::Union{File,Group}, src_path::AbstractString, dst_parent:
 copy_object(src_obj::Object, dst_parent::Union{File,Group}, dst_path::AbstractString) = API.h5o_copy(checkvalid(src_obj), ".", checkvalid(dst_parent), dst_path, API.H5P_DEFAULT, _link_properties(dst_path))
 
 # Move links
-move_link(src::Union{File,Group}, src_name::AbstractString, dest::Union{File,Group}, dest_name::AbstractString=src_name, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = API.h5l_move(checkvalid(src), src_name, checkvalid(dest), dest_name, lcpl, lapl)
-move_link(parent::Union{File,Group}, src_name::AbstractString, dest_name::AbstractString, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = API.h5l_move(checkvalid(parent), src_name, parent, dest_name, lcpl, lapl)
+move_link(src::Union{File,Group}, src_name::AbstractString, dest::Union{File,Group}, dest_name::AbstractString=src_name, lapl::LinkAccessProperties = LinkAccessProperties(), lcpl::LinkCreateProperties = LinkCreateProperties()) =
+    API.h5l_move(checkvalid(src), src_name, checkvalid(dest), dest_name, lcpl, lapl)
+
+move_link(parent::Union{File,Group}, src_name::AbstractString, dest_name::AbstractString, lapl::LinkAccessProperties = LinkAccessProperties(), lcpl::LinkCreateProperties = LinkCreateProperties())  =
+    API.h5l_move(checkvalid(parent), src_name, parent, dest_name, lcpl, lapl)
 
 # Assign syntax: obj[path] = value
 # Creates a dataset unless obj is a dataset, in which case it creates an attribute

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -864,8 +864,8 @@ copy_object(src_parent::Union{File,Group}, src_path::AbstractString, dst_parent:
 copy_object(src_obj::Object, dst_parent::Union{File,Group}, dst_path::AbstractString) = API.h5o_copy(checkvalid(src_obj), ".", checkvalid(dst_parent), dst_path, API.H5P_DEFAULT, _link_properties(dst_path))
 
 # Move links
-move_link(src::Union{File,Group}, src_name::AbstractString, dest::Union{File,Group}, dest_name::AbstractString=src_name, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = h5l_move(checkvalid(src), src_name, checkvalid(dest), dest_name, lcpl, lapl)
-move_link(parent::Union{File,Group}, src_name::AbstractString, dest_name::AbstractString, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = h5l_move(checkvalid(parent), src_name, parent, dest_name, lcpl, lapl)
+move_link(src::Union{File,Group}, src_name::AbstractString, dest::Union{File,Group}, dest_name::AbstractString=src_name, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = API.h5l_move(checkvalid(src), src_name, checkvalid(dest), dest_name, lcpl, lapl)
+move_link(parent::Union{File,Group}, src_name::AbstractString, dest_name::AbstractString, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = API.h5l_move(checkvalid(parent), src_name, parent, dest_name, lcpl, lapl)
 
 # Assign syntax: obj[path] = value
 # Creates a dataset unless obj is a dataset, in which case it creates an attribute

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -15,7 +15,7 @@ h5open, h5read, h5write, h5rewrite, h5writeattr, h5readattr,
 create_attribute, open_attribute, read_attribute, write_attribute, delete_attribute, attributes,
 create_dataset, open_dataset, read_dataset, write_dataset,
 create_group, open_group,
-copy_object, open_object, delete_object,
+copy_object, open_object, delete_object, move_object,
 create_datatype, commit_datatype, open_datatype,
 create_property,
 group_info, object_info,
@@ -862,6 +862,10 @@ delete_object(obj::Object) = delete_object(parent(obj), ascii(split(name(obj),"/
 # Copy objects
 copy_object(src_parent::Union{File,Group}, src_path::AbstractString, dst_parent::Union{File,Group}, dst_path::AbstractString) = API.h5o_copy(checkvalid(src_parent), src_path, checkvalid(dst_parent), dst_path, API.H5P_DEFAULT, _link_properties(dst_path))
 copy_object(src_obj::Object, dst_parent::Union{File,Group}, dst_path::AbstractString) = API.h5o_copy(checkvalid(src_obj), ".", checkvalid(dst_parent), dst_path, API.H5P_DEFAULT, _link_properties(dst_path))
+
+# Move objects
+move_object(src::Union{File,Group}, src_name::AbstractString, dest::Union{File,Group}, dest_name::AbstractString, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = h5l_move(checkvalid(src), src_name, checkvalid(dest), dest_name, lcpl, lapl)
+move_object(parent::Union{File,Group}, src_name::AbstractString, dest_name::AbstractString, lapl::Properties=DEFAULT_PROPERTIES, lcpl::Properties=DEFAULT_PROPERTIES) = h5l_move(checkvalid(parent), src_name, parent, dest_name, lcpl, lapl)
 
 # Assign syntax: obj[path] = value
 # Creates a dataset unless obj is a dataset, in which case it creates an attribute

--- a/src/api/functions.jl
+++ b/src/api/functions.jl
@@ -1016,6 +1016,17 @@ function h5l_delete(obj_id, pathname, lapl_id)
 end
 
 """
+    h5l_move(src_obj_id::hid_t, src_name::Ptr{UInt8}, dest_obj_id::hid_t, dest_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)
+See `libhdf5` documentation for [`H5Lmove`](https://portal.hdfgroup.org/display/HDF5/H5L_MOVE).
+"""
+function h5l_move(src_obj_id, src_name, dest_obj_id, dest_name, lcpl_id, lapl_id)
+    var"#status#" = ccall((:H5Lmove, libhdf5), herr_t, (hid_t, Ptr{UInt8}, hid_t, Ptr{UInt8}, hid_t, hid_t),
+            src_obj_id, src_name, dest_obj_id, dest_name, lcpl_id, lapl_id)
+    var"#status#" < 0 && @h5error(string("Error moving ", h5i_get_name(src_obj_id), "/", src_name, " to ", h5i_get_name(dest_obj_id), "/", dest_name))
+    return nothing
+end
+
+"""
     h5l_exists(loc_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t) -> Bool
 
 See `libhdf5` documentation for [`H5Lexists`](https://portal.hdfgroup.org/display/HDF5/H5L_EXISTS).

--- a/src/api/functions.jl
+++ b/src/api/functions.jl
@@ -1017,11 +1017,11 @@ end
 
 """
     h5l_move(src_obj_id::hid_t, src_name::Ptr{UInt8}, dest_obj_id::hid_t, dest_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)
+
 See `libhdf5` documentation for [`H5Lmove`](https://portal.hdfgroup.org/display/HDF5/H5L_MOVE).
 """
 function h5l_move(src_obj_id, src_name, dest_obj_id, dest_name, lcpl_id, lapl_id)
-    var"#status#" = ccall((:H5Lmove, libhdf5), herr_t, (hid_t, Ptr{UInt8}, hid_t, Ptr{UInt8}, hid_t, hid_t),
-            src_obj_id, src_name, dest_obj_id, dest_name, lcpl_id, lapl_id)
+    var"#status#" = ccall((:H5Lmove, libhdf5), herr_t, (hid_t, Ptr{UInt8}, hid_t, Ptr{UInt8}, hid_t, hid_t), src_obj_id, src_name, dest_obj_id, dest_name, lcpl_id, lapl_id)
     var"#status#" < 0 && @h5error(string("Error moving ", h5i_get_name(src_obj_id), "/", src_name, " to ", h5i_get_name(dest_obj_id), "/", dest_name))
     return nothing
 end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -285,6 +285,19 @@ delete_object(fr, "deleteme")
 @test !haskey(fr, "deleteme")
 close(fr)
 
+# Test object move
+h5open(fn, "r+") do io
+  io["moveme"] = [1,2,3]
+  create_group(io, "moveto")
+end
+
+h5open(fn, "r+") do io
+  @test haskey(io, "moveme")
+  @test haskey(io, "moveto") && !haskey(io, "moveto/moveme")
+  move_object(io, "moveme", io["moveto"])
+  @test haskey(io, "moveto/moveme") && !haskey(io, "moveme")
+end
+
 # Test the h5read interface
 Wr = h5read(fn, "newgroup/W")
 @test Wr == W

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -294,7 +294,7 @@ end
 h5open(fn, "r+") do io
   @test haskey(io, "moveme")
   @test haskey(io, "moveto") && !haskey(io, "moveto/moveme")
-  move_object(io, "moveme", io["moveto"])
+  move_link(io, "moveme", io["moveto"])
   @test haskey(io, "moveto/moveme") && !haskey(io, "moveme")
 end
 


### PR DESCRIPTION
Move a link to a new location in the file. If source is a hard link, this effectively renames the object (also #330).
Maybe `move_link` would be a better name

I would like to add a version that copies and deletes an object if the source and destination files are different, but I'm not sure how to check this. HDF5 has an internal `H5F_same_shared` for this purpose.