### PR TITLE
Fix nightly tests, add debugging

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,6 +75,8 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        env:
+          JULIA_DEBUG: Main
       - uses: julia-actions/julia-processcoverage@latest
       - uses: codecov/codecov-action@v1
         with:

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -11,7 +11,6 @@ function scatterf(src_buf, src_buf_bytes_used, op_data)
     A = [1,2,3,4]
     unsafe_store!(src_buf, pointer(A))
     unsafe_store!(src_buf_bytes_used, sizeof(A))
-    @debug "op_data: " opdata
     return HDF5.API.herr_t(0)
 end
 scatterf_bad(src_buf, src_buf_bytes_used, op_data) = HDF5.API.herr_t(-1)
@@ -19,7 +18,6 @@ function scatterf_data(src_buf, src_buf_bytes_used, op_data)
     A = [1,2,3,4]
     unsafe_store!(src_buf, pointer(A))
     unsafe_store!(src_buf_bytes_used, sizeof(A))
-    @debug "op_data: " opdata
     return HDF5.API.herr_t((op_data == 9)-1)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,4 +30,7 @@ if HDF5.has_parallel()
     include("mpio.jl")
 end
 
+# Clean up after all resources
+HDF5.API.h5_close()
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,24 +4,44 @@ using Pkg
 
 @info "libhdf5 v$(HDF5.API.h5_get_libversion())"
 
+# To debug HDF5.jl tests, uncomment the next line
+# ENV["JULIA_DEBUG"] = "Main"
+
 @testset "HDF5.jl" begin
 
+@debug "plain"
 include("plain.jl")
+@debug "compound"
 include("compound.jl")
+@debug "custom"
 include("custom.jl")
+@debug "reference"
 include("reference.jl")
+@debug "dataspace"
 include("dataspace.jl")
+@debug "hyperslab"
 include("hyperslab.jl")
+@debug "readremote"
 include("readremote.jl")
+@debug "extend_test"
 include("extend_test.jl")
+@debug "gc"
 include("gc.jl")
+@debug "external"
 include("external.jl")
+@debug "swmr"
 include("swmr.jl")
+@debug "mmap"
 include("mmap.jl")
+@debug "properties"
 include("properties.jl")
+@debug "table"
 include("table.jl")
+@debug "filter"
 include("filter.jl")
+@debug "chunkstorage"
 include("chunkstorage.jl")
+@debug "fileio"
 include("fileio.jl")
 
 using MPI

--- a/test/swmr.jl
+++ b/test/swmr.jl
@@ -5,7 +5,9 @@ using Test
 using Distributed
 
 if nprocs() == 1
-    addprocs(1)
+    procs = addprocs(1)
+else
+    procs = Int64[]
 end
 @everywhere using HDF5
 
@@ -114,4 +116,9 @@ end
 end
 
 rm(fname) # cleanup file created by swmr tests
+
+if nprocs() > 1
+    rmprocs(procs)
+end
+
 end # testset swmr


### PR DESCRIPTION
Cherry-picked from 740983ed4bc99ec56ba09aa1f6915d789066cec5

445e038: Use `rmprocs` to clean up added process, fix nightly stall
4fbcb99: Add debug messages to test, use h5_close after tests finish to clean up temp files
c1e5761: Enable debugging in Github Actions test step