### PR TITLE
remove eval in front of requires blocks

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1611,8 +1611,8 @@ function __init__()
     ASCII_ATTRIBUTE_PROPERTIES.char_encoding = :ascii
     UTF8_ATTRIBUTE_PROPERTIES.char_encoding = :utf8
 
-    @require FileIO="5789e2e9-d7fb-5bc7-8068-2c6fae9b9549" @eval include("fileio.jl")
-    @require H5Zblosc="c8ec2601-a99c-407f-b158-e79c03c2f5f7" @eval begin
+    @require FileIO="5789e2e9-d7fb-5bc7-8068-2c6fae9b9549" include("fileio.jl")
+    @require H5Zblosc="c8ec2601-a99c-407f-b158-e79c03c2f5f7" begin
         set_blosc!(p::Properties, val::Bool) = val && push!(Filters.FilterPipeline(p), H5Zblosc.BloscFilter())
         set_blosc!(p::Properties, level::Integer) = push!(Filters.FilterPipeline(p), H5Zblosc.BloscFilter(level=level))
     end

--- a/src/drivers/drivers.jl
+++ b/src/drivers/drivers.jl
@@ -42,7 +42,7 @@ function set_driver!(p::Properties, ::POSIX)
 end
 
 function __init__()
-    @require MPI="da04e1cc-30fd-572f-bb4f-1f8673147195" @eval include("mpio.jl")
+    @require MPI="da04e1cc-30fd-572f-bb4f-1f8673147195" include("mpio.jl")
 end
 
 end # module


### PR DESCRIPTION
Having the `@eval` there makes the `@require` pattern matching for `include` fail and the pacakge thereby is unusuable when used together with PackageCompiler (example log: https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/dd0c14b_vs_dd0c14b/YaoQX.primary.log)

```
┌ Warning: Error requiring `MPI` from `HDF5`
│   exception =
│    LoadError: SystemError: opening file "/home/pkgeval/.julia/packages/HDF5/pIJra/src/mpio.jl": No such file or directory
│    Stacktrace:
│      [1] systemerror(p::String, errno::Int32; extrainfo::Nothing)
```
