### PR TITLE
Support BITSHUFFLE option of Blosc >= v0.7.3

### DIFF
--- a/filters/H5Zblosc/Project.toml
+++ b/filters/H5Zblosc/Project.toml
@@ -8,5 +8,5 @@ HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 
 [compat]
 HDF5 = "0.16"
-Blosc = "0.7.1"
+Blosc = "0.7.3"
 julia = "1.3"

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -59,6 +59,11 @@ for (name, filter) in compressionFilters
 
 end
 
+ds = create_dataset(
+    f, "blosc_bitshuffle", datatype(data), dataspace(data),
+    chunk=(100,100), filters=BloscFilter(shuffle=H5Zblosc.BITSHUFFLE)
+)
+write(ds, data)
 
 # Close and re-open file for reading
 close(f)
@@ -74,7 +79,8 @@ for name in keys(f)
         if startswith(name, "shuffle+")
             @test filters[1] isa Shuffle
             @test filters[2] isa compressionFilters[name[9:end]]
-        elseif haskey(compressionFilters, name)
+        elseif haskey(compressionFilters, name) || name == "blosc_bitshuffle"
+            name = replace(name, r"_.*"=>"")
             @test filters[1] isa compressionFilters[name]
         end
     end


### PR DESCRIPTION
Blosc 0.7.3 now treats the blosc "shuffle" option as an Integer rather
than a Bool.  This allows the use of all three of blosc's shuffling
options: no shuffling (0), byte shuffling (1), or bit shuffling (2).
The `shuffle` field of the BloscFilter struct is not restricted to Bool,
but it was effectively being converted to Bool via `!=(0)` in the
`blosc_filter()` function of the H5Zblosc plugin before passing to the
`blosc_compress()` function.  This prevented the use of bit shuffling
because `2 != 0` is `true` which is the same as 1 (byte shuffling).

The H5Zblosc plugin no longer converts the given value to Bool and also
validates the value against the three supported shuffle option values.
These values are also imported into the H5Zblosc module so users can
refer to them as one of:

- H5Zblosc.NOSHUFFLE
- H5Zblosc.SHUFFLE
- H5Zblosc.BITSHUFFLE

closes https://github.com/JuliaIO/HDF5.jl/issues/285