### PR TITLE
Fix #896

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -53,14 +53,12 @@ function set_shuffle!(p::Properties, ::Tuple{})
     set_shuffle!(p, true)
 end
 
-### Fix Issue #896
+### Changed in PR #902
 import Base: append!, push!
 import .Filters: UnknownFilter
-
 @deprecate append!(filters::Filters.FilterPipeline, extra::NTuple{N, Integer}) where N append!(filters, [UnknownFilter(extra...)])
 @deprecate push!(p::Filters.FilterPipeline, f::NTuple{N, Integer}) where N push!(p, UnknownFilter(f...))
 @deprecate UnknownFilter(t::Tuple) UnknownFilter(t...)
-# End Fix Issue #896
 
 # see src/properties.jl for the following deprecated keywords
 # :compress

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -53,6 +53,15 @@ function set_shuffle!(p::Properties, ::Tuple{})
     set_shuffle!(p, true)
 end
 
+### Fix Issue #896
+import Base: append!, push!
+import .Filters: UnknownFilter
+
+@deprecate append!(filters::Filters.FilterPipeline, extra::NTuple{N, Integer}) where N append!(filters, [UnknownFilter(extra...)])
+@deprecate push!(p::Filters.FilterPipeline, f::NTuple{N, Integer}) where N push!(p, UnknownFilter(f...))
+@deprecate UnknownFilter(t::Tuple) UnknownFilter(t...)
+# End Fix Issue #896
+
 # see src/properties.jl for the following deprecated keywords
 # :compress
 # :fapl_mpio

--- a/src/filters/filters.jl
+++ b/src/filters/filters.jl
@@ -309,14 +309,6 @@ function Base.push!(p::FilterPipeline, f::UnknownFilter)
     end
 end
 
-# Fix Issue #896
-import Base: append!, push!
-
-@deprecate append!(filters::FilterPipeline, extra::NTuple{N, Integer}) where N append!(filters, [UnknownFilter(extra...)])
-@deprecate push!(p::FilterPipeline, f::NTuple{N, Integer}) where N push!(p, UnknownFilter(f...))
-@deprecate UnknownFilter(t::Tuple) UnknownFilter(t...)
-# End Fix Issue #896
-
 include("builtin.jl")
 
 end # module

--- a/src/filters/filters.jl
+++ b/src/filters/filters.jl
@@ -291,13 +291,13 @@ function Base.delete!(filters::FilterPipeline, ::Type{F}) where {F<:Filter}
     API.h5p_remove_filter(filters.plist, filterid(F))
     return filters
 end
-function Base.append!(filters::FilterPipeline, extra)
+function Base.append!(filters::FilterPipeline, extra::Union{AbstractVector{<:Filter}, NTuple{N, Filter} where N})
     for filter in extra
         push!(filters, filter)
     end
     return filters
 end
-function Base.append!(filters::FilterPipeline, extra::Tuple)
+function Base.append!(filters::FilterPipeline, extra::NTuple{N, Integer}) where N
     push!(filters, extra)
 end
 function Base.push!(p::FilterPipeline, f::F) where F <: Filter

--- a/src/filters/filters.jl
+++ b/src/filters/filters.jl
@@ -210,6 +210,10 @@ struct UnknownFilter <: Filter
     name::String
     config::Cuint
 end
+function UnknownFilter(filter_id, flags, data::Integer...)
+    UnknownFilter(filter_id, flags, Cuint[data...], "Unknown Filter with id $filter_id", 0)
+end
+UnknownFilter(t::Tuple) = UnknownFilter(t...)
 filterid(filter::UnknownFilter) = filter.filter_id
 filtername(filter::UnknownFilter) = filter.name
 filtername(::Type{UnknownFilter}) = "Unknown Filter"
@@ -293,6 +297,9 @@ function Base.append!(filters::FilterPipeline, extra)
     end
     return filters
 end
+function Base.append!(filters::FilterPipeline, extra::Tuple)
+    push!(filters, extra)
+end
 function Base.push!(p::FilterPipeline, f::F) where F <: Filter
     ref = Ref(f)
     GC.@preserve ref begin
@@ -304,6 +311,9 @@ function Base.push!(p::FilterPipeline, f::UnknownFilter)
     GC.@preserve f begin
         API.h5p_set_filter(p.plist, f.filter_id, f.flags, length(f.data), pointer(f.data))
     end
+end
+function Base.push!(p::FilterPipeline, f::Tuple)
+    push!(p, UnknownFilter(f))
 end
 
 include("builtin.jl")


### PR DESCRIPTION
Create additional methods to interpret a `Tuple` as an `UnknownFilter`.