### PR TITLE
Add test for FilterPipeline and UnknownFilter, fix bug

### DIFF
--- a/src/filters/filters.jl
+++ b/src/filters/filters.jl
@@ -303,7 +303,7 @@ function Base.getindex(f::FilterPipeline, ::Type{UnknownFilter}, i::Integer, cd_
     namebuf = Array{UInt8}(undef, 256)
     config = Ref{Cuint}()
     id = API.h5p_get_filter(f.plist, i-1, flags, cd_nelmts, cd_values, length(namebuf), namebuf, config)
-    if cd_nelmts[] < length(cd_values)
+    if cd_nelmts[] > length(cd_values)
         resize!(cd_values, cd_nelmts[])
         return getindex(f, UnknownFilter, i, cd_values)
     end

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -3,6 +3,8 @@ using HDF5.Filters
 using Test
 using H5Zblosc, H5Zlz4, H5Zbzip2, H5Zzstd
 
+using HDF5.Filters: UnknownFilter
+
 @testset "filter" begin
 
 # Create a new file

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -108,4 +108,17 @@ h5open(fn, "r") do f
     @test f["filtshufdef"][] == data
 end
 
+# Filter Pipeline test for UnknownFilter
+FILTERS_backup = copy(HDF5.Filters.FILTERS)
+empty!(HDF5.Filters.FILTERS)
+h5open(fn, "w") do f
+    data = collect(1:128)
+    filter = UnknownFilter(H5Z_FILTER_LZ4, 0, Cuint[0, 2, 4, 6, 8, 10], "Unknown LZ4", 0)
+    ds, dt = create_dataset(f, "data", data, chunk=(32,), filter=filter)
+    dcpl = HDF5.get_create_properties(ds)
+    pipeline = HDF5.Filters.FilterPipeline(dcpl)
+    @test pipeline[1].data == filter.data
+end
+merge!(HDF5.Filters.FILTERS, FILTERS_backup)
+
 end # @testset "filter"

--- a/test/filter.jl
+++ b/test/filter.jl
@@ -114,7 +114,7 @@ empty!(HDF5.Filters.FILTERS)
 h5open(fn, "w") do f
     data = collect(1:128)
     filter = UnknownFilter(H5Z_FILTER_LZ4, 0, Cuint[0, 2, 4, 6, 8, 10], "Unknown LZ4", 0)
-    ds, dt = create_dataset(f, "data", data, chunk=(32,), filter=filter)
+    ds, dt = create_dataset(f, "data", data, chunk=(32,), filters=filter)
     dcpl = HDF5.get_create_properties(ds)
     pipeline = HDF5.Filters.FilterPipeline(dcpl)
     @test pipeline[1].data == filter.data


### PR DESCRIPTION
I noticed that when playing with `UnknownFilter` that the data values displayed by the `FilterPipeline` would be complete gibberish. While it is possible that the set local function could alter the data, I eventually found there was a display bug.

```
julia> using HDF5, H5Zlz4

julia> FILTERS_backup = copy(HDF5.Filters.FILTERS)
Dict{Int32, Type{<:HDF5.Filters.Filter}} with 7 entries:
  5     => NBit
  4     => Szip
  6     => ScaleOffset
  2     => Shuffle
  32004 => Lz4Filter
  3     => Fletcher32
  1     => Deflate

julia> empty!(HDF5.Filters.FILTERS)
Dict{Int32, Type{<:HDF5.Filters.Filter}}()

julia> fn = tempname()
"C:\\Users\\KITTIS~1\\AppData\\Local\\Temp\\jl_g6SQbroy8s"

julia> f = h5open(fn, "w")
🗂️ HDF5.File: (read-write) C:\Users\KITTIS~1\AppData\Local\Temp\jl_g6SQbroy8s

julia>     data = collect(1:128);

julia>     filter = UnknownFilter(H5Z_FILTER_LZ4, 0, Cuint[0, 2, 4, 6, 8, 10], "Unknown LZ4", 0)
UnknownFilter(32004, 0x00000000, UInt32[0x00000000, 0x00000002, 0x00000004, 0x00000006, 0x00000008, 0x0000000a], "Unknown LZ4", 0x00000000)

julia>     ds, dt = create_dataset(f, "data", data, chunk=(32,), filter=filter)
(HDF5.Dataset: /data (file: C:\Users\KITTIS~1\AppData\Local\Temp\jl_g6SQbroy8s xfer_mode: 0), HDF5.Datatype: H5T_STD_I64LE)

julia>     dcpl = HDF5.get_create_properties(ds)
HDF5.DatasetCreateProperties(
  alloc_time      = :incremental,
  chunk           = (32,),
  filters         = HDF5.Filters.Filter[UnknownFilter(32004, 0x00000000, UInt32[0x71353038, 0x00000000, 0x00000000, 0x00000000, 0x00089804, 0x00000000], "HDF5 lz4 filter; see http://www.hdfgroup.org/services/contributions.html", 0x00000003)],
  layout          = :chunked,
  filter          = HDF5.Filters.Filter[UnknownFilter(32004, 0x00000000, UInt32[0x00000003, 0x00000000, 0x00000003, 0x00000000, 0x0c8e4b30, 0x00000000], "HDF5 lz4 filter; see http://www.hdfgroup.org/services/contributions.html", 0x00000003)],
  obj_track_times = true,
)

julia>     pipeline = HDF5.Filters.FilterPipeline(dcpl)
1-element HDF5.Filters.FilterPipeline{HDF5.DatasetCreateProperties}:
 UnknownFilter(32004, 0x00000000, UInt32[0x00000003, 0x00000000, 0x00000003, 0x00000000, 0x0cc67610, 0x00000000], "HDF5 lz4 filter; see http://www.hdfgroup.org/services/contributions.html", 0x00000003)

julia> pipeline[1]
UnknownFilter(32004, 0x00000000, UInt32[0x0e40aa68, 0x00000000, 0x00000000, 0x00000000, 0x00089804, 0x00000000], "HDF5 lz4 filter; see http://www.hdfgroup.org/services/contributions.html", 0x00000003)
```

