### PR TITLE
Add env sync for windows

### DIFF
--- a/src/windows.jl
+++ b/src/windows.jl
@@ -1,0 +1,20 @@
+# Windows specific methods
+
+function win_setenv(key, value)
+    ccall(:_wputenv_s, Cint, (Cwstring,Cwstring), key, value)
+end
+function win_sync_hdf5_plugin_path()
+    # Fix https://github.com/JuliaIO/HDF5.jl/issues/905
+    win_setenv("HDF5_PLUGIN_PATH", ENV["HDF5_PLUGIN_PATH"])
+end
+function win_sync_hdf5_env()
+    # Issue #905, JuliaLang/julia#44054
+    for (key, value) in ENV
+        if startswith(key, "HDF5")
+            win_setenv(key, value)
+        end
+    end
+end
+
+# We do this here since we load HDF5 during precompilation
+win_sync_hdf5_env()

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -1,7 +1,12 @@
 # Windows specific methods
 
 function win_setenv(key, value)
-    ccall(:_wputenv_s, Cint, (Cwstring,Cwstring), key, value)
+    errno = ccall(:_wputenv_s, Cint, (Cwstring,Cwstring), key, value)
+    if errno != 0
+        # Expect errno == EINVAL (22)
+        error("win_setenv failed with key=\"$key\" and value=\"$value\"")
+    end
+    nothing
 end
 function win_sync_hdf5_plugin_path()
     # Fix https://github.com/JuliaIO/HDF5.jl/issues/905
@@ -11,7 +16,11 @@ function win_sync_hdf5_env()
     # Issue #905, JuliaLang/julia#44054
     for (key, value) in ENV
         if startswith(key, "HDF5")
-            win_setenv(key, value)
+            try
+                win_setenv(key, value)
+            catch
+                @warn "Could not set environmental for HDF5" key value
+            end
         end
     end
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaIO/HDF5.jl/issues/905

Due to See https://github.com/JuliaLang/julia/issues/44054, the HDF5 library does not see environmental variables changed by assigning values to `ENV` while on Windows.

To fix this, set all environmental variables starting with HDF5 using [`_wputenv_s`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/putenv-s-wputenv-s?view=msvc-170) on `__init__` while on Windows.