### PR TITLE
Support `track_order`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,8 +26,9 @@ H5Zlz4 = "eb20ec05-5464-47b5-ba41-098e3c1068a3"
 H5Zzstd = "f6f2d980-1ec6-471c-a70d-0270e22f1103"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "MPI", "Distributed", "LinearAlgebra", "Pkg", "CRC32c", "FileIO"]
+test = ["Test", "MPI", "Distributed", "LinearAlgebra", "OrderedCollections", "Pkg", "CRC32c", "FileIO"]

--- a/docs/src/api_bindings.md
+++ b/docs/src/api_bindings.md
@@ -309,6 +309,7 @@ h5pl_size
 - [`h5p_create`](@ref h5p_create)
 - [`h5p_get_alignment`](@ref h5p_get_alignment)
 - [`h5p_get_alloc_time`](@ref h5p_get_alloc_time)
+- [`h5p_get_attr_creation_order`](@ref h5p_get_attr_creation_order)
 - [`h5p_get_char_encoding`](@ref h5p_get_char_encoding)
 - [`h5p_get_chunk`](@ref h5p_get_chunk)
 - [`h5p_get_class_name`](@ref h5p_get_class_name)
@@ -326,6 +327,7 @@ h5pl_size
 - [`h5p_get_filter_by_id`](@ref h5p_get_filter_by_id)
 - [`h5p_get_layout`](@ref h5p_get_layout)
 - [`h5p_get_libver_bounds`](@ref h5p_get_libver_bounds)
+- [`h5p_get_link_creation_order`](@ref h5p_get_link_creation_order)
 - [`h5p_get_local_heap_size_hint`](@ref h5p_get_local_heap_size_hint)
 - [`h5p_get_nfilters`](@ref h5p_get_nfilters)
 - [`h5p_get_obj_track_times`](@ref h5p_get_obj_track_times)
@@ -334,6 +336,7 @@ h5pl_size
 - [`h5p_remove_filter`](@ref h5p_remove_filter)
 - [`h5p_set_alignment`](@ref h5p_set_alignment)
 - [`h5p_set_alloc_time`](@ref h5p_set_alloc_time)
+- [`h5p_set_attr_creation_order`](@ref h5p_set_attr_creation_order)
 - [`h5p_set_char_encoding`](@ref h5p_set_char_encoding)
 - [`h5p_set_chunk`](@ref h5p_set_chunk)
 - [`h5p_set_chunk_cache`](@ref h5p_set_chunk_cache)
@@ -350,6 +353,7 @@ h5pl_size
 - [`h5p_set_fletcher32`](@ref h5p_set_fletcher32)
 - [`h5p_set_layout`](@ref h5p_set_layout)
 - [`h5p_set_libver_bounds`](@ref h5p_set_libver_bounds)
+- [`h5p_set_link_creation_order`](@ref h5p_set_link_creation_order)
 - [`h5p_set_local_heap_size_hint`](@ref h5p_set_local_heap_size_hint)
 - [`h5p_set_nbit`](@ref h5p_set_nbit)
 - [`h5p_set_obj_track_times`](@ref h5p_set_obj_track_times)
@@ -363,6 +367,7 @@ h5p_close
 h5p_create
 h5p_get_alignment
 h5p_get_alloc_time
+h5p_get_attr_creation_order
 h5p_get_char_encoding
 h5p_get_chunk
 h5p_get_class_name
@@ -380,6 +385,7 @@ h5p_get_filter
 h5p_get_filter_by_id
 h5p_get_layout
 h5p_get_libver_bounds
+h5p_get_link_creation_order
 h5p_get_local_heap_size_hint
 h5p_get_nfilters
 h5p_get_obj_track_times
@@ -388,6 +394,7 @@ h5p_modify_filter
 h5p_remove_filter
 h5p_set_alignment
 h5p_set_alloc_time
+h5p_set_attr_creation_order
 h5p_set_char_encoding
 h5p_set_chunk
 h5p_set_chunk_cache
@@ -404,6 +411,7 @@ h5p_set_filter
 h5p_set_fletcher32
 h5p_set_layout
 h5p_set_libver_bounds
+h5p_set_link_creation_order
 h5p_set_local_heap_size_hint
 h5p_set_nbit
 h5p_set_obj_track_times

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -157,6 +157,18 @@ g["mydataset"] = rand(3,5)
 write(g, "mydataset", rand(3,5))
 ```
 
+One can use the high level interface `load` and `save` from `FileIO`, where an optional `OrderedDict` can be passed.
+```julia
+using OrderedCollections, FileIO
+# write
+d = OrderedDict("z"=>1, "a"=>2)
+save("track_order.h5", d; track_order=true)
+# read
+dat = load("track_order.h5"; track_order=true, dict=OrderedDict())
+@show keys(dat)
+# 
+```
+
 ## Passing parameters
 
 It is often required to pass parameters to specific routines, which are collected

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -157,16 +157,17 @@ g["mydataset"] = rand(3,5)
 write(g, "mydataset", rand(3,5))
 ```
 
-One can use the high level interface `load` and `save` from `FileIO`, where an optional `OrderedDict` can be passed.
+One can use the high level interface `load` and `save` from `FileIO`, where an optional `OrderedDict` can be passed (`track_order` inferred). Note that using `track_ordering=true` or passing an `OrderedDict` is a promise that the read file has been created with the appropriate ordering flags.
+
 ```julia
-using OrderedCollections, FileIO
-# write
-d = OrderedDict("z"=>1, "a"=>2)
-save("track_order.h5", d; track_order=true)
-# read
-dat = load("track_order.h5"; track_order=true, dict=OrderedDict())
-@show keys(dat)
-# 
+julia> using OrderedCollections, FileIO
+julia> save("track_order.h5", OrderedDict("z"=>1, "a"=>2, "g/f"=>3, "g/b"=>4))
+julia> load("track_order.h5"; dict=OrderedDict())
+OrderedDict{Any, Any} with 4 entries:
+  "z"   => 1
+  "a"   => 2
+  "g/f" => 3
+  "g/b" => 4
 ```
 
 ## Passing parameters

--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -169,6 +169,7 @@
 ### Property Interface
 ###
 
+# get
 @bind h5p_close(id::hid_t)::herr_t "Error closing property list"
 @bind h5p_create(cls_id::hid_t)::hid_t "Error creating property list"
 @bind h5p_get_alignment(fapl_id::hid_t, threshold::Ref{hsize_t}, alignment::Ref{hsize_t})::herr_t "Error getting alignment"
@@ -191,10 +192,12 @@
 @bind h5p_get_libver_bounds(fapl_id::hid_t, low::Ref{Cint}, high::Ref{Cint})::herr_t "Error getting library version bounds"
 @bind h5p_get_local_heap_size_hint(plist_id::hid_t, size_hint::Ref{Csize_t})::herr_t "Error getting local heap size hint"
 @bind h5p_get_nfilters(plist_id::hid_t)::Cint "Error getting nfilters"
-@bind h5p_get_obj_track_times(plist_id::hid_t, track_times::Ref{UInt8})::herr_t "Error setting object time tracking"
+@bind h5p_get_obj_track_times(plist_id::hid_t, track_times::Ref{UInt8})::herr_t "Error getting object time tracking"
 @bind h5p_get_userblock(plist_id::hid_t, len::Ptr{hsize_t})::herr_t "Error getting userblock"
-@bind h5p_modify_filter(plist_id::hid_t, filter_id::H5Z_filter_t, flags::Cuint, cd_nelmts::Csize_t, cd_values::Ptr{Cuint})::herr_t "Error modifying filter"
-@bind h5p_remove_filter(plist_id::hid_t, filter_id::H5Z_filter_t)::herr_t "Error removing filter"
+@bind h5p_get_attr_creation_order(plist_id::hid_t, crt_order_flags::Ptr{Cuint})::herr_t "Error getting attribute creation order"
+@bind h5p_get_link_creation_order(plist_id::hid_t, crt_order_flags::Ptr{Cuint})::herr_t "Error getting link creation order"
+
+# set
 @bind h5p_set_alignment(plist_id::hid_t, threshold::hsize_t, alignment::hsize_t)::herr_t "Error setting alignment"
 @bind h5p_set_alloc_time(plist_id::hid_t, alloc_time::Cint)::herr_t "Error setting allocation timing"
 @bind h5p_set_char_encoding(plist_id::hid_t, encoding::Cint)::herr_t "Error setting char encoding"
@@ -221,6 +224,12 @@
 @bind h5p_set_szip(plist_id::hid_t, options_mask::Cuint, pixels_per_block::Cuint)::herr_t "Error enabling szip filter"
 @bind h5p_set_userblock(plist_id::hid_t, len::hsize_t)::herr_t "Error setting userblock"
 @bind h5p_set_virtual(dcpl_id::hid_t, vspace_id::hid_t, src_file_name::Ptr{UInt8}, src_dset_name::Ptr{UInt8}, src_space_id::hid_t)::herr_t "Error setting virtual"
+@bind h5p_set_attr_creation_order(plist_id::hid_t, crt_order_flags::Cuint)::herr_t "Error setting attribute creation order"
+@bind h5p_set_link_creation_order(plist_id::hid_t, crt_order_flags::Cuint)::herr_t "Error setting link creation order"
+
+# others
+@bind h5p_modify_filter(plist_id::hid_t, filter_id::H5Z_filter_t, flags::Cuint, cd_nelmts::Csize_t, cd_values::Ptr{Cuint})::herr_t "Error modifying filter"
+@bind h5p_remove_filter(plist_id::hid_t, filter_id::H5Z_filter_t)::herr_t "Error removing filter"
 
 ###
 ### Plugin Interface

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -43,6 +43,9 @@ h5doc(name) = "[`$name`](https://portal.hdfgroup.org/display/HDF5/$(name))"
 include("api/api.jl")
 include("properties.jl")
 
+const IDX_TYPE = Ref(API.H5_INDEX_NAME)
+const ORDER = Ref(API.H5_ITER_INC)
+
 ### Generic H5DataStore interface ###
 
 # Common methods that could be applicable to any interface for reading/writing variables from a file, e.g. HDF5, JLD, or MAT files.
@@ -272,7 +275,7 @@ end
 
 """
     function h5open(f::Function, args...; swmr=false, pv...)
-
+-
 Apply the function f to the result of `h5open(args...;kwargs...)` and close the resulting
 `HDF5.File` upon completion. For example with a `do` block:
 
@@ -550,8 +553,11 @@ end
 
 function create_group(parent::Union{File,Group}, path::AbstractString,
                   lcpl::LinkCreateProperties=_link_properties(path),
-                  gcpl::GroupCreateProperties=GroupCreateProperties())
+                  gcpl::GroupCreateProperties=GroupCreateProperties();
+                  pv...)
     haskey(parent, path) && error("cannot create group: object \"", path, "\" already exists at ", name(parent))
+    pv = setproperties!(gcpl; pv...)
+    isempty(pv) || error("invalid keyword options $pv")
     Group(API.h5g_create(parent, path, lcpl, gcpl, API.H5P_DEFAULT), file(parent))
 end
 
@@ -686,7 +692,7 @@ name(attr::Attribute) = API.h5a_get_name(attr)
 function Base.keys(x::Union{Group,File})
     checkvalid(x)
     children = sizehint!(String[], length(x))
-    API.h5l_iterate(x, API.H5_INDEX_NAME, API.H5_ITER_INC) do _, name, _
+    API.h5l_iterate(x, IDX_TYPE[], ORDER[]) do _, name, _
         push!(children, unsafe_string(name))
         return API.herr_t(0)
     end
@@ -696,7 +702,7 @@ end
 function Base.keys(x::Attributes)
     checkvalid(x.parent)
     children = sizehint!(String[], length(x))
-    API.h5a_iterate(x.parent, API.H5_INDEX_NAME, API.H5_ITER_INC) do _, attr_name, _
+    API.h5a_iterate(x.parent, IDX_TYPE[], ORDER[]) do _, attr_name, _
         push!(children, unsafe_string(attr_name))
         return API.herr_t(0)
     end
@@ -708,7 +714,7 @@ function Base.iterate(parent::Union{File,Group}, iter = (1,nothing))
     n, prev_obj = iter
     prev_obj ≢ nothing && close(prev_obj)
     n > length(parent) && return nothing
-    obj = h5object(API.h5o_open_by_idx(checkvalid(parent), ".", API.H5_INDEX_NAME, API.H5_ITER_INC, n-1, API.H5P_DEFAULT), parent)
+    obj = h5object(API.h5o_open_by_idx(checkvalid(parent), ".", IDX_TYPE[], ORDER[], n-1, API.H5P_DEFAULT), parent)
     return (obj, (n+1,obj))
 end
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1670,7 +1670,9 @@ function __init__()
     ASCII_ATTRIBUTE_PROPERTIES.char_encoding = :ascii
     UTF8_ATTRIBUTE_PROPERTIES.char_encoding = :utf8
 
-    @require FileIO="5789e2e9-d7fb-5bc7-8068-2c6fae9b9549" include("fileio.jl")
+    @require FileIO="5789e2e9-d7fb-5bc7-8068-2c6fae9b9549" begin
+        @require OrderedCollections="bac558e1-5e72-5ebc-8fee-abe8a469f55d" include("fileio.jl")
+    end
     @require H5Zblosc="c8ec2601-a99c-407f-b158-e79c03c2f5f7" begin
         set_blosc!(p::Properties, val::Bool) = val && push!(Filters.FilterPipeline(p), H5Zblosc.BloscFilter())
         set_blosc!(p::Properties, level::Integer) = push!(Filters.FilterPipeline(p), H5Zblosc.BloscFilter(level=level))

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -275,7 +275,7 @@ end
 
 """
     function h5open(f::Function, args...; swmr=false, pv...)
--
+
 Apply the function f to the result of `h5open(args...;kwargs...)` and close the resulting
 `HDF5.File` upon completion. For example with a `do` block:
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -276,7 +276,7 @@ end
 """
     function h5open(f::Function, args...; swmr=false, pv...)
 
-Apply the function f to the result of `h5open(args...;kwargs...)` and close the resulting
+Apply the function f to the result of `h5open(args...; kwargs...)` and close the resulting
 `HDF5.File` upon completion. For example with a `do` block:
 
     h5open("foo.h5","w") do h5

--- a/src/api/functions.jl
+++ b/src/api/functions.jl
@@ -1400,7 +1400,7 @@ See `libhdf5` documentation for [`H5Pget_obj_track_times`](https://portal.hdfgro
 """
 function h5p_get_obj_track_times(plist_id, track_times)
     var"#status#" = ccall((:H5Pget_obj_track_times, libhdf5), herr_t, (hid_t, Ref{UInt8}), plist_id, track_times)
-    var"#status#" < 0 && @h5error("Error setting object time tracking")
+    var"#status#" < 0 && @h5error("Error getting object time tracking")
     return nothing
 end
 
@@ -1416,24 +1416,24 @@ function h5p_get_userblock(plist_id, len)
 end
 
 """
-    h5p_modify_filter(plist_id::hid_t, filter_id::H5Z_filter_t, flags::Cuint, cd_nelmts::Csize_t, cd_values::Ptr{Cuint})
+    h5p_get_attr_creation_order(plist_id::hid_t, crt_order_flags::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pmodify_filter`](https://portal.hdfgroup.org/display/HDF5/H5P_MODIFY_FILTER).
+See `libhdf5` documentation for [`H5Pget_attr_creation_order`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_ATTR_CREATION_ORDER).
 """
-function h5p_modify_filter(plist_id, filter_id, flags, cd_nelmts, cd_values)
-    var"#status#" = ccall((:H5Pmodify_filter, libhdf5), herr_t, (hid_t, H5Z_filter_t, Cuint, Csize_t, Ptr{Cuint}), plist_id, filter_id, flags, cd_nelmts, cd_values)
-    var"#status#" < 0 && @h5error("Error modifying filter")
+function h5p_get_attr_creation_order(plist_id, crt_order_flags)
+    var"#status#" = ccall((:H5Pget_attr_creation_order, libhdf5), herr_t, (hid_t, Ptr{Cuint}), plist_id, crt_order_flags)
+    var"#status#" < 0 && @h5error("Error getting attribute creation order")
     return nothing
 end
 
 """
-    h5p_remove_filter(plist_id::hid_t, filter_id::H5Z_filter_t)
+    h5p_get_link_creation_order(plist_id::hid_t, crt_order_flags::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Premove_filter`](https://portal.hdfgroup.org/display/HDF5/H5P_REMOVE_FILTER).
+See `libhdf5` documentation for [`H5Pget_link_creation_order`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_LINK_CREATION_ORDER).
 """
-function h5p_remove_filter(plist_id, filter_id)
-    var"#status#" = ccall((:H5Premove_filter, libhdf5), herr_t, (hid_t, H5Z_filter_t), plist_id, filter_id)
-    var"#status#" < 0 && @h5error("Error removing filter")
+function h5p_get_link_creation_order(plist_id, crt_order_flags)
+    var"#status#" = ccall((:H5Pget_link_creation_order, libhdf5), herr_t, (hid_t, Ptr{Cuint}), plist_id, crt_order_flags)
+    var"#status#" < 0 && @h5error("Error getting link creation order")
     return nothing
 end
 
@@ -1720,6 +1720,50 @@ See `libhdf5` documentation for [`H5Pset_virtual`](https://portal.hdfgroup.org/d
 function h5p_set_virtual(dcpl_id, vspace_id, src_file_name, src_dset_name, src_space_id)
     var"#status#" = ccall((:H5Pset_virtual, libhdf5), herr_t, (hid_t, hid_t, Ptr{UInt8}, Ptr{UInt8}, hid_t), dcpl_id, vspace_id, src_file_name, src_dset_name, src_space_id)
     var"#status#" < 0 && @h5error("Error setting virtual")
+    return nothing
+end
+
+"""
+    h5p_set_attr_creation_order(plist_id::hid_t, crt_order_flags::Cuint)
+
+See `libhdf5` documentation for [`H5Pset_attr_creation_order`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_ATTR_CREATION_ORDER).
+"""
+function h5p_set_attr_creation_order(plist_id, crt_order_flags)
+    var"#status#" = ccall((:H5Pset_attr_creation_order, libhdf5), herr_t, (hid_t, Cuint), plist_id, crt_order_flags)
+    var"#status#" < 0 && @h5error("Error setting attribute creation order")
+    return nothing
+end
+
+"""
+    h5p_set_link_creation_order(plist_id::hid_t, crt_order_flags::Cuint)
+
+See `libhdf5` documentation for [`H5Pset_link_creation_order`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_LINK_CREATION_ORDER).
+"""
+function h5p_set_link_creation_order(plist_id, crt_order_flags)
+    var"#status#" = ccall((:H5Pset_link_creation_order, libhdf5), herr_t, (hid_t, Cuint), plist_id, crt_order_flags)
+    var"#status#" < 0 && @h5error("Error setting link creation order")
+    return nothing
+end
+
+"""
+    h5p_modify_filter(plist_id::hid_t, filter_id::H5Z_filter_t, flags::Cuint, cd_nelmts::Csize_t, cd_values::Ptr{Cuint})
+
+See `libhdf5` documentation for [`H5Pmodify_filter`](https://portal.hdfgroup.org/display/HDF5/H5P_MODIFY_FILTER).
+"""
+function h5p_modify_filter(plist_id, filter_id, flags, cd_nelmts, cd_values)
+    var"#status#" = ccall((:H5Pmodify_filter, libhdf5), herr_t, (hid_t, H5Z_filter_t, Cuint, Csize_t, Ptr{Cuint}), plist_id, filter_id, flags, cd_nelmts, cd_values)
+    var"#status#" < 0 && @h5error("Error modifying filter")
+    return nothing
+end
+
+"""
+    h5p_remove_filter(plist_id::hid_t, filter_id::H5Z_filter_t)
+
+See `libhdf5` documentation for [`H5Premove_filter`](https://portal.hdfgroup.org/display/HDF5/H5P_REMOVE_FILTER).
+"""
+function h5p_remove_filter(plist_id, filter_id)
+    var"#status#" = ccall((:H5Premove_filter, libhdf5), herr_t, (hid_t, H5Z_filter_t), plist_id, filter_id)
+    var"#status#" < 0 && @h5error("Error removing filter")
     return nothing
 end
 

--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -423,6 +423,18 @@ function h5p_get_class_name(pcid)
     return s
 end
 
+function h5p_get_attr_creation_order(p)
+    attr = Ref{UInt32}()
+    h5p_get_attr_creation_order(p, attr)
+    return attr[]
+end
+
+function h5p_get_link_creation_order(p)
+    link = Ref{UInt32}()
+    h5p_get_link_creation_order(p, link)
+    return link[]
+end
+
 ###
 ### Plugin Interface
 ###

--- a/src/api/types.jl
+++ b/src/api/types.jl
@@ -269,6 +269,9 @@ const H5PL_TYPE_FILTER = 0
 const H5PL_TYPE_VOL = 1
 const H5PL_TYPE_NONE = 2
 
+const H5P_CRT_ORDER_TRACKED = 1
+const H5P_CRT_ORDER_INDEXED = 2
+
 # Reference constants
 const H5R_OBJECT         = 0
 const H5R_DATASET_REGION = 1

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -1,6 +1,6 @@
 import .FileIO
 
-function loadtodict!(d::Dict, g::Union{File,Group}, prefix::String="")
+function loadtodict!(d::AbstractDict, g::Union{File,Group}, prefix::String="")
     for k in keys(g)
         v = g[k]
         if v isa Group

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -12,29 +12,55 @@ function loadtodict!(d::AbstractDict, g::Union{File,Group}, prefix::String="")
     return d
 end
 
+_set_track_order(kwargs) = if get(kwargs, :track_order, false)
+    prev = IDX_TYPE[]
+    IDX_TYPE[] = HDF5.API.H5_INDEX_CRT_ORDER
+    true, prev
+else
+    false, nothing
+end
+
+function _restore_track_order(saved)
+    restore, prev = saved
+    restore && (IDX_TYPE[] = prev)
+    nothing
+end
+
 # load with just a filename returns a flat dictionary containing all the variables
 function fileio_load(f::FileIO.File{FileIO.format"HDF5"}; kwargs...)
-    h5open(FileIO.filename(f), "r"; kwargs...) do file
-        loadtodict!(Dict{String,Any}(), file)
+    kw = Dict(kwargs)
+    d = pop!(kw, :dict, Dict{String,Any}())
+    saved = _set_track_order(kw)
+    out = h5open(FileIO.filename(f), "r"; kw...) do file
+        loadtodict!(d, file)
     end
+    _restore_track_order(saved)
+    out
 end
 
 # when called with explicitly requested variable names, return each one
 function fileio_load(f::FileIO.File{FileIO.format"HDF5"}, varname::AbstractString; kwargs...)
-    h5open(FileIO.filename(f), "r"; kwargs...) do file
+    saved = _set_track_order(kwargs)
+    out = h5open(FileIO.filename(f), "r"; kwargs...) do file
         read(file, varname)
     end
+    _restore_track_order(saved)
+    out
 end
 
 function fileio_load(f::FileIO.File{FileIO.format"HDF5"}, varnames::AbstractString...; kwargs...)
-    h5open(FileIO.filename(f), "r"; kwargs...) do file
+    saved = _set_track_order(kwargs)
+    out = h5open(FileIO.filename(f), "r"; kwargs...) do file
         map(var -> read(file, var), varnames)
     end
+    _restore_track_order(saved)
+    out
 end
 
 # save all the key-value pairs in the dict as top-level variables
 function fileio_save(f::FileIO.File{FileIO.format"HDF5"}, dict::AbstractDict; kwargs...)
-    h5open(FileIO.filename(f), "w"; kwargs...) do file
+    saved = _set_track_order(kwargs)
+    out = h5open(FileIO.filename(f), "w"; kwargs...) do file
         for (k,v) in dict
             if !isa(k, AbstractString)
                 throw(ArgumentError("keys must be strings (the names of variables), got $k"))
@@ -42,4 +68,6 @@ function fileio_save(f::FileIO.File{FileIO.format"HDF5"}, dict::AbstractDict; kw
             write(file, String(k), v)
         end
     end
+    _restore_track_order(saved)
+    out
 end

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -12,15 +12,15 @@ function loadtodict!(d::AbstractDict, g::Union{File,Group}, prefix::String="")
     return d
 end
 
-_set_track_order(kwargs) = if get(kwargs, :track_order, false)
+_change_iteration_order(kwargs) = if get(kwargs, :track_order, false)
     prev = IDX_TYPE[]
-    IDX_TYPE[] = HDF5.API.H5_INDEX_CRT_ORDER
+    IDX_TYPE[] = HDF5.API.H5_INDEX_CRT_ORDER  # index (iterate) on creation order
     true, prev
 else
     false, nothing
 end
 
-_restore_track_order(restore, prev) = (restore && (IDX_TYPE[] = prev); nothing)
+_restore_iteration_order(restore, prev) = (restore && (IDX_TYPE[] = prev); nothing)
 
 # load with just a filename returns a flat dictionary containing all the variables
 function fileio_load(f::FileIO.File{FileIO.format"HDF5"}; kwargs...)
@@ -28,33 +28,29 @@ function fileio_load(f::FileIO.File{FileIO.format"HDF5"}; kwargs...)
     d = pop!(kwargs, :dict, Dict{String,Any}())
 
     # infer `track_order` from Dict type
-    (track_order = isa(d, OrderedDict)) && get!(kwargs, :track_order, track_order)
+    if (track_order = isa(d, OrderedDict))
+        get!(kwargs, :track_order, track_order)
+    end
 
-    saved = _set_track_order(kwargs)
+    saved = _change_iteration_order(kwargs)
     out = h5open(FileIO.filename(f), "r"; kwargs...) do file
         loadtodict!(d, file)
     end
-    _restore_track_order(saved...)
+    _restore_iteration_order(saved...)
     out
 end
 
 # when called with explicitly requested variable names, return each one
 function fileio_load(f::FileIO.File{FileIO.format"HDF5"}, varname::AbstractString; kwargs...)
-    saved = _set_track_order(kwargs)
-    out = h5open(FileIO.filename(f), "r"; kwargs...) do file
+    h5open(FileIO.filename(f), "r"; kwargs...) do file
         read(file, varname)
     end
-    _restore_track_order(saved...)
-    out
 end
 
 function fileio_load(f::FileIO.File{FileIO.format"HDF5"}, varnames::AbstractString...; kwargs...)
-    saved = _set_track_order(kwargs)
-    out = h5open(FileIO.filename(f), "r"; kwargs...) do file
+    h5open(FileIO.filename(f), "r"; kwargs...) do file
         map(var -> read(file, var), varnames)
     end
-    _restore_track_order(saved...)
-    out
 end
 
 # save all the key-value pairs in the dict as top-level variables

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -253,6 +253,21 @@ function class_setproperty!(::Type{ObjectCreateProperties}, p::Properties, name:
     class_setproperty!(superclass(ObjectCreateProperties), p, name, val)
 end
 
+function get_track_order(p::Properties)
+    attr = Ref{UInt32}()
+    API.h5p_get_attr_creation_order(p, attr)
+    link = Ref{UInt32}()
+    API.h5p_get_link_creation_order(p, link)
+    attr[] != 0 && link[] != 0
+end
+
+function set_track_order(p::Properties, val::Bool)
+    crt_order_flags = val ? (HDF5.API.H5P_CRT_ORDER_TRACKED | HDF5.API.H5P_CRT_ORDER_INDEXED) : 0
+    API.h5p_set_link_creation_order(p, crt_order_flags)
+    API.h5p_set_attr_creation_order(p, crt_order_flags)
+    nothing
+end
+
 """
     GroupCreateProperties(;kws...)
 
@@ -261,20 +276,23 @@ Properties used when creating a new `Group`. Inherits from
 
 - `local_heap_size_hint :: Integer`: the anticipated maximum local heap size in
   bytes. See $(h5doc("H5P_SET_LOCAL_HEAP_SIZE_HINT")).
-
+- `track_order :: Bool`: tracks the group creation order.
 """
 @propertyclass GroupCreateProperties API.H5P_GROUP_CREATE
 superclass(::Type{GroupCreateProperties}) = ObjectCreateProperties
 
 class_propertynames(::Type{GroupCreateProperties}) = (
     :local_heap_size_hint,
+    :track_order,
     )
 function class_getproperty(::Type{GroupCreateProperties}, p::Properties, name::Symbol)
     name === :local_heap_size_hint ? API.h5p_get_local_heap_size_hint(p) :
+    name === :track_order ? get_track_order(p) :
     class_getproperty(superclass(GroupCreateProperties), p, name)
 end
 function class_setproperty!(::Type{GroupCreateProperties}, p::Properties, name::Symbol, val)
     name === :local_heap_size_hint ? API.h5p_set_local_heap_size_hint(p, val) :
+    name === :track_order ? set_track_order(p, val) :
     class_setproperty!(superclass(GroupCreateProperties), p, name, val)
 end
 
@@ -287,7 +305,7 @@ Properties used when creating a new `File`. Inherits from
 - `userblock :: Integer`: user block size in bytes. The default user block size
   is 0; it may be set to any power of 2 equal to 512 or greater (512, 1024,
   2048, etc.). See $(h5doc("H5P_SET_USERBLOCK")).
-
+- `track_order :: Bool`: tracks the file creation order.
 """
 @propertyclass FileCreateProperties API.H5P_FILE_CREATE
 superclass(::Type{FileCreateProperties}) = ObjectCreateProperties
@@ -295,13 +313,16 @@ superclass(::Type{FileCreateProperties}) = ObjectCreateProperties
 
 class_propertynames(::Type{FileCreateProperties}) = (
     :userblock,
+    :track_order,
     )
 function class_getproperty(::Type{FileCreateProperties}, p::Properties, name::Symbol)
     name === :userblock   ? API.h5p_get_userblock(p) :
+    name === :track_order ? get_track_order(p) :
     class_getproperty(superclass(FileCreateProperties), p, name)
 end
 function class_setproperty!(::Type{FileCreateProperties}, p::Properties, name::Symbol, val)
     name === :userblock   ? API.h5p_set_userblock(p, val) :
+    name === :track_order ? set_track_order(p, val) : 
     class_setproperty!(superclass(FileCreateProperties), p, name, val)
 end
 

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -253,13 +253,7 @@ function class_setproperty!(::Type{ObjectCreateProperties}, p::Properties, name:
     class_setproperty!(superclass(ObjectCreateProperties), p, name, val)
 end
 
-function get_track_order(p::Properties)
-    attr = Ref{UInt32}()
-    API.h5p_get_attr_creation_order(p, attr)
-    link = Ref{UInt32}()
-    API.h5p_get_link_creation_order(p, link)
-    attr[] != 0 && link[] != 0
-end
+get_track_order(p::Properties) = API.h5p_get_link_creation_order(p) != 0 && API.h5p_get_attr_creation_order(p) != 0
 
 function set_track_order(p::Properties, val::Bool)
     crt_order_flags = val ? (HDF5.API.H5P_CRT_ORDER_TRACKED | HDF5.API.H5P_CRT_ORDER_INDEXED) : 0

--- a/src/show.jl
+++ b/src/show.jl
@@ -208,7 +208,7 @@ function _show_tree(io::IO, obj::Union{File,Group,Dataset,Datatype,Attributes,At
 
     if attributes && !isa(obj, Attribute)
         obj′ = obj isa Attributes ? obj.parent : obj
-        API.h5a_iterate(obj′, API.H5_INDEX_NAME, API.H5_ITER_INC) do _, cname, _
+        API.h5a_iterate(obj′, IDX_TYPE[], ORDER[]) do _, cname, _
             depth_check() && return API.herr_t(1)
 
             name = unsafe_string(cname)
@@ -221,7 +221,7 @@ function _show_tree(io::IO, obj::Union{File,Group,Dataset,Datatype,Attributes,At
 
     typeof(obj) <: Union{File, Group} || return nothing
 
-    API.h5l_iterate(obj, API.H5_INDEX_NAME, API.H5_ITER_INC) do loc_id, cname, _
+    API.h5l_iterate(obj, IDX_TYPE[], ORDER[]) do loc_id, cname, _
         depth_check() && return API.herr_t(1)
 
         name = unsafe_string(cname)

--- a/test/fileio.jl
+++ b/test/fileio.jl
@@ -53,7 +53,7 @@ let fn = tempname() * ".h5"
 end
 
 let fn = tempname() * ".h5"
-  save(fn, OrderedDict("b"=>1, "a"=>2, "G/z"=>3, "G/f"=>4); track_order=true)
+  save(fn, OrderedDict("b"=>1, "a"=>2, "G/z"=>3, "G/f"=>4))
 
   dat = load(fn; dict=OrderedDict())
 

--- a/test/fileio.jl
+++ b/test/fileio.jl
@@ -48,17 +48,8 @@ h5open(fn, "w"; track_order=true) do io
   write(g, "f", 4)
 end
 
-
-idx_type = HDF5.IDX_TYPE[]  # save
-HDF5.IDX_TYPE[] = HDF5.API.H5_INDEX_CRT_ORDER
-
 # read
-d = OrderedDict()
-h5open(fn, "r"; track_order=true) do io
-  HDF5.loadtodict!(d, io)
-end
+dat = load(fn; track_order=true, dict=OrderedDict())
 
-@test all(keys(d) .== ["b", "a", "G/z", "G/f"])
-
-HDF5.IDX_TYPE[] = idx_type  # restore
+@test all(keys(dat) .== ["b", "a", "G/z", "G/f"])
 end

--- a/test/fileio.jl
+++ b/test/fileio.jl
@@ -16,7 +16,7 @@ close(hfile);
 data = Dict("A" => 1.0, "B"=> [1,2,3], "G/A"=>collect(-3:4), "G1/G2/A"=>"hello")
 @test load(fn) == data
 @test load(fn, "A") == 1.0
-@test load(fn, "A","B") == (1.0, [1,2,3])
+@test load(fn, "A", "B") == (1.0, [1,2,3])
 @test load(fn, "G/A") == collect(-3:4)
 
 rm(fn)

--- a/test/fileio.jl
+++ b/test/fileio.jl
@@ -35,25 +35,30 @@ end
 @testset "track order" begin
 fn = tempname() * ".h5"
 
-idx_type = HDF5.IDX_TYPE[]  # save
-HDF5.IDX_TYPE[] = HDF5.API.H5_INDEX_CRT_ORDER
-
+# write
 h5open(fn, "w"; track_order=true) do io
   fcpl = HDF5.get_create_properties(io)
   @test fcpl.track_order
   io["b"] = 1
   io["a"] = 2
   g = create_group(io, "G"; track_order=true)
-  write(g, "c", 1)
-  write(g, "a", 2)
+  gcpl = HDF5.get_create_properties(io["G"])
+  @test gcpl.track_order
+  write(g, "z", 3)
+  write(g, "f", 4)
 end
 
+
+idx_type = HDF5.IDX_TYPE[]  # save
+HDF5.IDX_TYPE[] = HDF5.API.H5_INDEX_CRT_ORDER
+
+# read
 d = OrderedDict()
 h5open(fn, "r"; track_order=true) do io
   HDF5.loadtodict!(d, io)
 end
 
-@test all(keys(d) .== ["b", "a", "G/c", "G/a"])
+@test all(keys(d) .== ["b", "a", "G/z", "G/f"])
 
 HDF5.IDX_TYPE[] = idx_type  # restore
 end

--- a/test/fileio.jl
+++ b/test/fileio.jl
@@ -47,7 +47,7 @@ let fn = tempname() * ".h5"
     write(g, "f", 4)
   end
 
-  dat = load(fn; track_order=true, dict=OrderedDict())
+  dat = load(fn; dict=OrderedDict())  # `track_order` is inferred from `OrderedDict`
 
   @test all(keys(dat) .== ["b", "a", "G/z", "G/f"])
 end
@@ -55,7 +55,7 @@ end
 let fn = tempname() * ".h5"
   save(fn, OrderedDict("b"=>1, "a"=>2, "G/z"=>3, "G/f"=>4); track_order=true)
 
-  dat = load(fn; track_order=true, dict=OrderedDict())
+  dat = load(fn; dict=OrderedDict())
 
   @test all(keys(dat) .== ["b", "a", "G/z", "G/f"])
 end

--- a/test/fileio.jl
+++ b/test/fileio.jl
@@ -1,5 +1,6 @@
-using HDF5, FileIO, Test
+using HDF5, OrderedCollections, FileIO, Test
 
+@testset "fileio" begin
 fn = tempname() * ".h5"
 
 hfile = h5open(fn, "w")
@@ -29,3 +30,30 @@ read(fr, "A") == 1.0
 close(fr)
 
 rm(fn)
+end
+
+@testset "track order" begin
+fn = tempname() * ".h5"
+
+idx_type = HDF5.IDX_TYPE[]  # save
+HDF5.IDX_TYPE[] = HDF5.API.H5_INDEX_CRT_ORDER
+
+h5open(fn, "w"; track_order=true) do io
+  fcpl = HDF5.get_create_properties(io)
+  @test fcpl.track_order
+  io["b"] = 1
+  io["a"] = 2
+  g = create_group(io, "G"; track_order=true)
+  write(g, "c", 1)
+  write(g, "a", 2)
+end
+
+d = OrderedDict()
+h5open(fn, "r"; track_order=true) do io
+  HDF5.loadtodict!(d, io)
+end
+
+@test all(keys(d) .== ["b", "a", "G/c", "G/a"])
+
+HDF5.IDX_TYPE[] = idx_type  # restore
+end


### PR DESCRIPTION
This is a proposition for supporting `track_order` in `write`s and `read`s.

Since `Dict` in julia does not preserve ordering, reading a file with the correct order is a bit tricky and I have to use `OrderedDict`s, ~~and `const  global`s `IDX_TYPE` and `ORDER`~~. Comments for enhancing this `PR` are very welcome.

Related: https://github.com/h5py/h5py/issues/1471.

**write**
```julia
using HDF5

h5open("track_order.h5", "w"; track_order=true) do io
  io["b"] = 1
  io["a"] = 2
  g = create_group(io, "G"; track_order=true)
  write(g, "z", 3)
  write(g, "f", 4)
end
```

_alternatively_
```julia
using OrderedCollections, FileIO

save("track_order.h5", OrderedDict("b"=>1, "a"=>2, "G/z"=>3, "G/f"=>4))
```

**read Julia**
```julia
using OrderedCollections, FileIO

d = load("track_order.h5"; dict=OrderedDict())  # `track_order` is inferred from `OrderedDict`

@show keys(d)
```
_output_
```julia
keys(d) = Any["b", "a", "G/z", "G/f"]
```

(without `track_order`: `Any["G/f", "G/z", "a", "b"]`)

**read Python**
```python
import h5py

with h5py.File("track_order.h5", "r", track_order=True) as f:
    print(f["/"].keys())
    print(f["G"].keys())
```
_output_
```python
<KeysViewHDF5 ['b', 'a', 'G']>
<KeysViewHDF5 ['z', 'f']>
```