### PR TITLE
HDF5 Type order precision offset

### DIFF
--- a/docs/src/api_bindings.md
+++ b/docs/src/api_bindings.md
@@ -502,6 +502,9 @@ h5s_set_extent_simple
 - [`h5t_get_member_type`](@ref h5t_get_member_type)
 - [`h5t_get_native_type`](@ref h5t_get_native_type)
 - [`h5t_get_nmembers`](@ref h5t_get_nmembers)
+- [`h5t_get_offset`](@ref h5t_get_offset)
+- [`h5t_get_order`](@ref h5t_get_order)
+- [`h5t_get_precision`](@ref h5t_get_precision)
 - [`h5t_get_sign`](@ref h5t_get_sign)
 - [`h5t_get_size`](@ref h5t_get_size)
 - [`h5t_get_strpad`](@ref h5t_get_strpad)
@@ -514,6 +517,8 @@ h5s_set_extent_simple
 - [`h5t_set_cset`](@ref h5t_set_cset)
 - [`h5t_set_ebias`](@ref h5t_set_ebias)
 - [`h5t_set_fields`](@ref h5t_set_fields)
+- [`h5t_set_offset`](@ref h5t_set_offset)
+- [`h5t_set_order`](@ref h5t_set_order)
 - [`h5t_set_precision`](@ref h5t_set_precision)
 - [`h5t_set_size`](@ref h5t_set_size)
 - [`h5t_set_strpad`](@ref h5t_set_strpad)
@@ -541,6 +546,9 @@ h5t_get_member_offset
 h5t_get_member_type
 h5t_get_native_type
 h5t_get_nmembers
+h5t_get_offset
+h5t_get_order
+h5t_get_precision
 h5t_get_sign
 h5t_get_size
 h5t_get_strpad
@@ -553,6 +561,8 @@ h5t_open
 h5t_set_cset
 h5t_set_ebias
 h5t_set_fields
+h5t_set_offset
+h5t_set_order
 h5t_set_precision
 h5t_set_size
 h5t_set_strpad

--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -285,10 +285,19 @@
 @bind h5t_close(dtype_id::hid_t)::herr_t "Error closing datatype"
 @bind h5t_committed(dtype_id::hid_t)::htri_t "Error determining whether datatype is committed"
 @bind h5t_commit2(loc_id::hid_t, name::Ptr{UInt8}, dtype_id::hid_t, lcpl_id::hid_t, tcpl_id::hid_t, tapl_id::hid_t)::herr_t "Error committing type"
+# @bind h5t_commit_anon
+# @bind h5t_compiler_conv
 @bind h5t_copy(dtype_id::hid_t)::hid_t "Error copying datatype"
 @bind h5t_create(class_id::Cint, sz::Csize_t)::hid_t string("Error creating datatype of id ", class_id)
+# @bind h5t_decode
+# @bind h5t_detect_class
+# @bind h5t_encode
+# @bind h5t_enum_create
 @bind h5t_enum_insert(dtype_id::hid_t, name::Cstring, value::Ptr{Cvoid})::herr_t string("Error adding ", name, " to enum datatype")
+# @bind h5t_enum_nameof
+# @bind h5t_enum_valueof
 @bind h5t_equal(dtype_id1::hid_t, dtype_id2::hid_t)::htri_t "Error checking datatype equality"
+# @bind ht5_find
 @bind h5t_get_array_dims2(dtype_id::hid_t, dims::Ptr{hsize_t})::Cint "Error getting dimensions of array"
 @bind h5t_get_array_ndims(dtype_id::hid_t)::Cint "Error getting ndims of array"
 @bind h5t_get_class(dtype_id::hid_t)::Cint "Error getting class"
@@ -297,28 +306,45 @@
 @bind h5t_get_fields(dtype_id::hid_t, spos::Ref{Csize_t}, epos::Ref{Csize_t}, esize::Ref{Csize_t}, mpos::Ref{Csize_t}, msize::Ref{Csize_t})::herr_t "Error getting datatype floating point bit positions"
 @bind h5t_get_member_class(dtype_id::hid_t, index::Cuint)::Cint string("Error getting class of compound datatype member #", index)
 @bind h5t_get_member_index(dtype_id::hid_t, membername::Ptr{UInt8})::Cint string("Error getting index of compound datatype member \"", membername, "\"")
+# @bind h5t_get_member_name(dtype_id::hid_t, index::Cuint)::Cstring string("Error getting name of compound datatype member #", index) # See below
 @bind h5t_get_member_offset(dtype_id::hid_t, index::Cuint)::Csize_t "Error getting offset of compound datatype #$(index)"
 @bind h5t_get_member_type(dtype_id::hid_t, index::Cuint)::hid_t string("Error getting type of compound datatype member #", index)
+# @bind h5t_get_member_value
 @bind h5t_get_native_type(dtype_id::hid_t, direction::Cint)::hid_t "Error getting native type"
 @bind h5t_get_nmembers(dtype_id::hid_t)::Cint "Error getting the number of members"
+# @bind h5t_get_norm
+@bind h5t_get_offset(dtype_id::hid_t)::Cint "Error getting offset"
+@bind h5t_get_order(dtype_id::hid_t)::Cint "Error getting order"
+# @bind h5t_get_pad(dtype_id::hid_t, lsb::Ptr{H5T_pad_t}, msb::Ptr{H5T_pad_t})::herr_t "Error getting pad"
+@bind h5t_get_precision(dtype_id::hid_t)::Csize_t "Error getting precision"
 @bind h5t_get_sign(dtype_id::hid_t)::Cint "Error getting sign"
 @bind h5t_get_size(dtype_id::hid_t)::Csize_t "Error getting type size"
 @bind h5t_get_strpad(dtype_id::hid_t)::Cint "Error getting string padding"
 @bind h5t_get_super(dtype_id::hid_t)::hid_t "Error getting super type"
+# @bind h5t_get_tag(type_id::hid_t)::Cstring "Error getting datatype opaque tag" # See below
 @bind h5t_insert(dtype_id::hid_t, fieldname::Ptr{UInt8}, offset::Csize_t, field_id::hid_t)::herr_t string("Error adding field ", fieldname, " to compound datatype")
 @bind h5t_is_variable_str(type_id::hid_t)::htri_t "Error determining whether string is of variable length"
 @bind h5t_lock(type_id::hid_t)::herr_t "Error locking type"
 @bind h5t_open2(loc_id::hid_t, name::Ptr{UInt8}, tapl_id::hid_t)::hid_t string("Error opening type ", h5i_get_name(loc_id), "/", name)
+# @bind h5t_pack
+# @bind h5t_reclaim
+# @bind h5t_refresh
+# @bind h5t_register
 @bind h5t_set_cset(dtype_id::hid_t, cset::Cint)::herr_t "Error setting character set in datatype"
 @bind h5t_set_ebias(dtype_id::hid_t, ebias::Csize_t)::herr_t "Error setting datatype floating point exponent bias"
 @bind h5t_set_fields(dtype_id::hid_t, spos::Csize_t, epos::Csize_t, esize::Csize_t, mpos::Csize_t, msize::Csize_t)::herr_t "Error setting datatype floating point bit positions"
+# @bind h5t_set_inpad(dtype_id::hid_t, inpad::H5T_pad_t)::herr_t "Error setting inpad"
+# @bind h5t_set_norm(dtype_id::hid_t, norm::H5T_norm_t)::herr_t "Error setting mantissa"
+@bind h5t_set_offset(dtype_id::hid_t, offset::Csize_t)::herr_t "Error setting offset"
+@bind h5t_set_order(dtype_id::hid_t, order::Cint)::herr_t "Error setting order"
 @bind h5t_set_precision(dtype_id::hid_t, sz::Csize_t)::herr_t "Error setting precision of datatype"
 @bind h5t_set_size(dtype_id::hid_t, sz::Csize_t)::herr_t "Error setting size of datatype"
 @bind h5t_set_strpad(dtype_id::hid_t, sz::Cint)::herr_t "Error setting size of datatype"
 @bind h5t_set_tag(dtype_id::hid_t, tag::Cstring)::herr_t "Error setting opaque tag"
+# @bind h5t_unregister
 @bind h5t_vlen_create(base_type_id::hid_t)::hid_t "Error creating vlen type"
 # The following are not automatically wrapped since they have requirements about freeing
-# the memory that is returned from the calls.
+# the memory that is returned from the calls. They are implemented via api_helpers.jl
 #@bind h5t_get_member_name(dtype_id::hid_t, index::Cuint)::Cstring string("Error getting name of compound datatype member #", index)
 #@bind h5t_get_tag(type_id::hid_t)::Cstring "Error getting datatype opaque tag"
 

--- a/src/api/functions.jl
+++ b/src/api/functions.jl
@@ -2331,6 +2331,39 @@ function h5t_get_nmembers(dtype_id)
 end
 
 """
+    h5t_get_offset(dtype_id::hid_t) -> Int
+
+See `libhdf5` documentation for [`H5Tget_offset`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_OFFSET).
+"""
+function h5t_get_offset(dtype_id)
+    var"#status#" = ccall((:H5Tget_offset, libhdf5), Cint, (hid_t,), dtype_id)
+    var"#status#" < 0 && @h5error("Error getting offset")
+    return Int(var"#status#")
+end
+
+"""
+    h5t_get_order(dtype_id::hid_t) -> Int
+
+See `libhdf5` documentation for [`H5Tget_order`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_ORDER).
+"""
+function h5t_get_order(dtype_id)
+    var"#status#" = ccall((:H5Tget_order, libhdf5), Cint, (hid_t,), dtype_id)
+    var"#status#" < 0 && @h5error("Error getting order")
+    return Int(var"#status#")
+end
+
+"""
+    h5t_get_precision(dtype_id::hid_t) -> Csize_t
+
+See `libhdf5` documentation for [`H5Tget_precision`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_PRECISION).
+"""
+function h5t_get_precision(dtype_id)
+    var"#status#" = ccall((:H5Tget_precision, libhdf5), Csize_t, (hid_t,), dtype_id)
+    @h5error "Error getting precision"
+    return var"#status#"
+end
+
+"""
     h5t_get_sign(dtype_id::hid_t) -> Int
 
 See `libhdf5` documentation for [`H5Tget_sign`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_SIGN).
@@ -2448,6 +2481,28 @@ See `libhdf5` documentation for [`H5Tset_fields`](https://portal.hdfgroup.org/di
 function h5t_set_fields(dtype_id, spos, epos, esize, mpos, msize)
     var"#status#" = ccall((:H5Tset_fields, libhdf5), herr_t, (hid_t, Csize_t, Csize_t, Csize_t, Csize_t, Csize_t), dtype_id, spos, epos, esize, mpos, msize)
     var"#status#" < 0 && @h5error("Error setting datatype floating point bit positions")
+    return nothing
+end
+
+"""
+    h5t_set_offset(dtype_id::hid_t, offset::Csize_t)
+
+See `libhdf5` documentation for [`H5Tset_offset`](https://portal.hdfgroup.org/display/HDF5/H5T_SET_OFFSET).
+"""
+function h5t_set_offset(dtype_id, offset)
+    var"#status#" = ccall((:H5Tset_offset, libhdf5), herr_t, (hid_t, Csize_t), dtype_id, offset)
+    var"#status#" < 0 && @h5error("Error setting offset")
+    return nothing
+end
+
+"""
+    h5t_set_order(dtype_id::hid_t, order::Cint)
+
+See `libhdf5` documentation for [`H5Tset_order`](https://portal.hdfgroup.org/display/HDF5/H5T_SET_ORDER).
+"""
+function h5t_set_order(dtype_id, order)
+    var"#status#" = ccall((:H5Tset_order, libhdf5), herr_t, (hid_t, Cint), dtype_id, order)
+    var"#status#" < 0 && @h5error("Error setting order")
     return nothing
 end
 

--- a/src/api/types.jl
+++ b/src/api/types.jl
@@ -304,6 +304,7 @@ const H5S_SEL_HYPERSLABS = 2
 const H5S_SEL_ALL        = 3
 
 # type classes (C enum H5T_class_t)
+const H5T_NO_CLASS     = hid_t(-1)
 const H5T_INTEGER      = hid_t(0)
 const H5T_FLOAT        = hid_t(1)
 const H5T_TIME         = hid_t(2)  # not supported by HDF5 library
@@ -316,13 +317,29 @@ const H5T_ENUM         = hid_t(8)
 const H5T_VLEN         = hid_t(9)
 const H5T_ARRAY        = hid_t(10)
 
+# Byte orders (C enum H5T_order_t)
+const H5T_ORDER_ERROR = -1, # error
+const H5T_ORDER_LE    = 0,  # little endian
+const H5T_ORDER_BE    = 1,  # bit endian
+const H5T_ORDER_VAX   = 2,  # VAX mixed endian
+const H5T_ORDER_MIXED = 3,  # Compound type with mixed member orders
+const H5T_ORDER_NONE  = 4   # no particular order (strings, bits,..)
+
+# Floating-point normalization schemes (C enum H5T_norm_t)
+const H5T_NORM_ERROR   = -1, # error
+const H5T_NORM_IMPLIED = 0,  # msb of mantissa isn't stored, always 1
+const H5T_NORM_MSBSET  = 1,  # msb of mantissa is always 1
+const H5T_NORM_NONE    = 2   # not normalized
+
 # Character types
 const H5T_CSET_ASCII   = 0
 const H5T_CSET_UTF8    = 1
 
 # Sign types (C enum H5T_sign_t)
+const H5T_SGN_ERROR = Cint(-1) # error
 const H5T_SGN_NONE     = Cint(0)  # unsigned
 const H5T_SGN_2        = Cint(1)  # 2's complement
+const H5T_NSGN = Cint(2)        # sentinel: this must be last!
 
 # Search directions
 const H5T_DIR_ASCEND   = 1

--- a/src/show.jl
+++ b/src/show.jl
@@ -68,6 +68,9 @@ function Base.show(io::IO, dtype::Datatype)
     if isvalid(dtype)
         API.h5t_committed(dtype) && print(io, name(dtype), " ")
         print(io, API.h5lt_dtype_to_text(dtype))
+        precision = Int(API.h5t_get_precision(dtype))
+        size = Int(API.h5t_get_size(dtype))
+        print(io, " ($size byte size with $precision bit precision)")
     else
         # Note that API.h5i_is_valid returns `false` on the built-in datatypes (e.g. API.H5T_NATIVE_INT),
         # apparently because they have refcounts of 0 yet are always valid. Just temporarily turn

--- a/src/show.jl
+++ b/src/show.jl
@@ -68,9 +68,6 @@ function Base.show(io::IO, dtype::Datatype)
     if isvalid(dtype)
         API.h5t_committed(dtype) && print(io, name(dtype), " ")
         print(io, API.h5lt_dtype_to_text(dtype))
-        precision = Int(API.h5t_get_precision(dtype))
-        size = Int(API.h5t_get_size(dtype))
-        print(io, " ($size byte size with $precision bit precision)")
     else
         # Note that API.h5i_is_valid returns `false` on the built-in datatypes (e.g. API.H5T_NATIVE_INT),
         # apparently because they have refcounts of 0 yet are always valid. Just temporarily turn


### PR DESCRIPTION
This pull request expands the options to create types with different orders (endianness), precision, and offsets.

<strike>It also changes how unknown types are printed.</strike>

```julia
using HDF5

function create_h5_uint24()
    dt = HDF5.API.h5t_copy(HDF5.API.H5T_STD_U32LE)
    HDF5.API.h5t_set_size(dt, 3)
    HDF5.API.h5t_set_precision(dt, 24)
    return HDF5.Datatype(dt)
end
```