### PR TITLE
show undefined integer

### DIFF
--- a/src/api/types.jl
+++ b/src/api/types.jl
@@ -318,17 +318,17 @@ const H5T_VLEN         = hid_t(9)
 const H5T_ARRAY        = hid_t(10)
 
 # Byte orders (C enum H5T_order_t)
-const H5T_ORDER_ERROR = -1, # error
-const H5T_ORDER_LE    = 0,  # little endian
-const H5T_ORDER_BE    = 1,  # bit endian
-const H5T_ORDER_VAX   = 2,  # VAX mixed endian
-const H5T_ORDER_MIXED = 3,  # Compound type with mixed member orders
-const H5T_ORDER_NONE  = 4   # no particular order (strings, bits,..)
+const H5T_ORDER_ERROR = -1 # error
+const H5T_ORDER_LE    = 0  # little endian
+const H5T_ORDER_BE    = 1  # bit endian
+const H5T_ORDER_VAX   = 2  # VAX mixed endian
+const H5T_ORDER_MIXED = 3  # Compound type with mixed member orders
+const H5T_ORDER_NONE  = 4  # no particular order (strings, bits,..)
 
 # Floating-point normalization schemes (C enum H5T_norm_t)
-const H5T_NORM_ERROR   = -1, # error
-const H5T_NORM_IMPLIED = 0,  # msb of mantissa isn't stored, always 1
-const H5T_NORM_MSBSET  = 1,  # msb of mantissa is always 1
+const H5T_NORM_ERROR   = -1 # error
+const H5T_NORM_IMPLIED = 0  # msb of mantissa isn't stored, always 1
+const H5T_NORM_MSBSET  = 1  # msb of mantissa is always 1
 const H5T_NORM_NONE    = 2   # not normalized
 
 # Character types
@@ -339,7 +339,7 @@ const H5T_CSET_UTF8    = 1
 const H5T_SGN_ERROR    = Cint(-1) # error
 const H5T_SGN_NONE     = Cint(0)  # unsigned
 const H5T_SGN_2        = Cint(1)  # 2's complement
-const H5T_NSGN         = Cint(2)        # sentinel: this must be last!
+const H5T_NSGN         = Cint(2)  # sentinel: this must be last!
 
 # Search directions
 const H5T_DIR_ASCEND   = 1

--- a/test/datatype.jl
+++ b/test/datatype.jl
@@ -26,15 +26,15 @@ end
     io = IOBuffer()
     show(io, DT)
     str = String(take!(io))
-    @test contains(str, "undefined integer")
-    @test contains(str, "size: 3 bytes")
-    @test contains(str, "precision: 12 bits")
-    @test contains(str, "offset: 12 bits")
-    @test contains(str, "order: little endian byte order")
+    @test match(r"undefined integer", str) !== nothing
+    @test match(r"size: 3 bytes", str) !== nothing
+    @test match(r"precision: 12 bits", str) !== nothing
+    @test match(r"offset: 12 bits", str) !== nothing
+    @test match(r"order: little endian byte order", str) !== nothing
 
     HDF5.API.h5t_set_order(DT, HDF5.API.H5T_ORDER_BE)
     @test HDF5.API.h5t_get_order(DT) == HDF5.API.H5T_ORDER_BE
     show(io, DT)
     str = String(take!(io))
-    @test contains(str, "order: big endian byte order")
+    @test match(r"order: big endian byte order", str) !== nothing
 end

--- a/test/datatype.jl
+++ b/test/datatype.jl
@@ -1,0 +1,40 @@
+using HDF5
+using Test
+
+function create_h5_uint24()
+    dt = HDF5.API.h5t_copy(HDF5.API.H5T_STD_U32LE)
+    HDF5.API.h5t_set_size(dt, 3)
+    HDF5.API.h5t_set_precision(dt, 24)
+    return HDF5.Datatype(dt)
+end
+
+@testset "Datatypes" begin
+    DT = create_h5_uint24()
+    @test HDF5.API.h5t_get_size(DT) == 3
+    @test HDF5.API.h5t_get_precision(DT) == 24
+    @test HDF5.API.h5t_get_offset(DT) == 0
+    @test HDF5.API.h5t_get_order(DT) == HDF5.API.H5T_ORDER_LE
+
+    HDF5.API.h5t_set_precision(DT, 12)
+    @test HDF5.API.h5t_get_precision(DT) == 12
+    @test HDF5.API.h5t_get_offset(DT) == 0
+
+    HDF5.API.h5t_set_offset(DT, 12)
+    @test HDF5.API.h5t_get_precision(DT) == 12
+    @test HDF5.API.h5t_get_offset(DT) == 12
+
+    io = IOBuffer()
+    show(io, DT)
+    str = String(take!(io))
+    @test contains(str, "undefined integer")
+    @test contains(str, "size: 3 bytes")
+    @test contains(str, "precision: 12 bits")
+    @test contains(str, "offset: 12 bits")
+    @test contains(str, "order: little endian byte order")
+
+    HDF5.API.h5t_set_order(DT, HDF5.API.H5T_ORDER_BE)
+    @test HDF5.API.h5t_get_order(DT) == HDF5.API.H5T_ORDER_BE
+    show(io, DT)
+    str = String(take!(io))
+    @test contains(str, "order: big endian byte order")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,8 @@ include("custom.jl")
 include("reference.jl")
 @debug "dataspace"
 include("dataspace.jl")
+@debug "datatype"
+include("datatype.jl")
 @debug "hyperslab"
 include("hyperslab.jl")
 @debug "readremote"


### PR DESCRIPTION
This pull request:
1. Corrects some constant definitions in types.jl
2. Shows type properties for "undefined integer"

```
julia> function create_h5_uint24()
             dt = HDF5.API.h5t_copy(HDF5.API.H5T_STD_U32LE)
             HDF5.API.h5t_set_size(dt, 3)
             HDF5.API.h5t_set_precision(dt, 24)
             return HDF5.Datatype(dt)
       end
create_h5_uint24 (generic function with 1 method)

julia> DT = create_h5_uint24()
HDF5.Datatype: undefined integer
         size: 3 bytes
    precision: 24 bits
       offset: 0 bits
        order: little endian byte order

julia> HDF5.API.h5t_set_precision(DT, 12)

julia> DT
HDF5.Datatype: undefined integer
         size: 3 bytes
    precision: 12 bits
       offset: 0 bits
        order: little endian byte order

julia> HDF5.API.h5t_set_offset(DT, 12)

julia> DT
HDF5.Datatype: undefined integer
         size: 3 bytes
    precision: 12 bits
       offset: 12 bits
        order: little endian byte order
```