### PR TITLE
Add fapl and fcpl keywords to manually enter property lists into h5open

### DIFF
--- a/test/plain.jl
+++ b/test/plain.jl
@@ -1226,7 +1226,7 @@ ext_prop = HDF5.API.h5p_get_external(dcpl)
 @test ext_prop.size == 10*20*sizeof(Int)
 dapl = HDF5.get_access_properties(dset)
 dapl.efile_prefix = "efile_test"
-@test HDF5.h5p_get_efile_prefix(dapl) == "efile_test"
+@test HDF5.API.h5p_get_efile_prefix(dapl) == "efile_test"
 close(hfile)
 
 end


### PR DESCRIPTION
Add fapl and fcpl keywords to manually enter property lists into `h5open`, similar to the style employed for `create_dataset`.

Also fix a deprecation warning for `HDF5.h5p_set_efile_prefix`