### PR TITLE
Add create_dataset convenience forms for dataspace

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -611,6 +611,8 @@ end
 create_dataset(parent::Union{File,Group}, path::Union{AbstractString,Nothing}, dtype::Datatype, dspace_dims::Dims; pv...) = create_dataset(checkvalid(parent), path, dtype, dataspace(dspace_dims); pv...)
 create_dataset(parent::Union{File,Group}, path::Union{AbstractString,Nothing}, dtype::Datatype, dspace_dims::Tuple{Dims,Dims}; pv...) = create_dataset(checkvalid(parent), path, dtype, dataspace(dspace_dims[1], max_dims=dspace_dims[2]); pv...)
 create_dataset(parent::Union{File,Group}, path::Union{AbstractString,Nothing}, dtype::Type, dspace_dims::Tuple{Dims,Dims}; pv...) = create_dataset(checkvalid(parent), path, datatype(dtype), dataspace(dspace_dims[1], max_dims=dspace_dims[2]); pv...)
+create_dataset(parent::Union{File,Group}, path::Union{AbstractString,Nothing}, dtype::Type, dspace_dims::Dims; pv...) = create_dataset(checkvalid(parent), path, datatype(dtype), dataspace(dspace_dims); pv...)
+create_dataset(parent::Union{File,Group}, path::Union{AbstractString,Nothing}, dtype::Type, dspace_dims::Int...; pv...) = create_dataset(checkvalid(parent), path, datatype(dtype), dataspace(dspace_dims); pv...)
 
 # Note that H5Tcreate is very different; H5Tcommit is the analog of these others
 create_datatype(class_id, sz) = Datatype(API.h5t_create(class_id, sz))

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -423,6 +423,17 @@ Wr = h5read(fn, "newgroup/W")
 close(f)
 rm(fn)
 
+# Test dataspace convenience versions of create_dataset
+try
+    h5open(fn, "w") do f
+        create_dataset(f, "test", Int, (128, 32))
+        create_dataset(f, "test2", Float64, 128, 64)
+        @test size(f["test"])  == (128, 32)
+        @test size(f["test2"]) == (128, 64)
+    end
+finally
+    rm(fn)
+end
 
 @testset "h5d_fill" begin
     val = 5


### PR DESCRIPTION
This pull requests adds some convenience forms for `create_dataset` when specifying a dataspace. It allows the dimensions to specified as a single tuple or as `Int`s. For example, 

```julia
    h5open(fn, "w") do f
        create_dataset(f, "test", Int, (128, 32))
        create_dataset(f, "test2", Float64, 128, 64)
    end
```