### PR TITLE
Define AttibuteDict

### DIFF
--- a/docs/src/api_bindings.md
+++ b/docs/src/api_bindings.md
@@ -60,7 +60,9 @@ h5_set_free_list_limits
 - [`h5a_get_type`](@ref h5a_get_type)
 - [`h5a_iterate`](@ref h5a_iterate)
 - [`h5a_open`](@ref h5a_open)
+- [`h5a_open_by_idx`](@ref h5a_open_by_idx)
 - [`h5a_read`](@ref h5a_read)
+- [`h5a_rename`](@ref h5a_rename)
 - [`h5a_write`](@ref h5a_write)
 ```@docs
 h5a_close
@@ -78,7 +80,9 @@ h5a_get_space
 h5a_get_type
 h5a_iterate
 h5a_open
+h5a_open_by_idx
 h5a_read
+h5a_rename
 h5a_write
 ```
 

--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -49,7 +49,9 @@
 @bind h5a_get_type(attr_id::hid_t)::hid_t "Error getting attribute type"
 @bind h5a_iterate2(obj_id::hid_t, idx_type::Cint, order::Cint, n::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Any)::herr_t string("Error iterating attributes in object ", h5i_get_name(obj_id))
 @bind h5a_open(obj_id::hid_t, pathname::Ptr{UInt8}, aapl_id::hid_t)::hid_t string("Error opening attribute ", h5i_get_name(obj_id), "/", pathname)
+@bind h5a_open_by_idx(obj_id::hid_t, pathname::Ptr{UInt8}, idx_type::Cint, order::Cint, n::hsize_t, aapl_id::hid_t, lapl_id::hid_t)::hid_t string("Error opening attribute ", n, " of ", h5i_get_name(obj_id), "/", pathname)
 @bind h5a_read(attr_id::hid_t, mem_type_id::hid_t, buf::Ptr{Cvoid})::herr_t string("Error reading attribute ", h5a_get_name(attr_id))
+@bind h5a_rename(loc_id::hid_t, old_attr_name::Cstring, new_attr_name::Cstring)::herr_t string("Could not rename attribute")
 @bind h5a_write(attr_hid::hid_t, mem_type_id::hid_t, buf::Ptr{Cvoid})::herr_t "Error writing attribute data"
 
 ###

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -12,7 +12,7 @@ import Mmap
 export
 @read, @write,
 h5open, h5read, h5write, h5rewrite, h5writeattr, h5readattr,
-create_attribute, open_attribute, read_attribute, write_attribute, delete_attribute, attributes,
+create_attribute, open_attribute, read_attribute, write_attribute, delete_attribute, attributes, attrs,
 create_dataset, open_dataset, read_dataset, write_dataset,
 create_group, open_group,
 copy_object, open_object, delete_object, move_link,

--- a/src/api/functions.jl
+++ b/src/api/functions.jl
@@ -264,6 +264,17 @@ function h5a_open(obj_id, pathname, aapl_id)
 end
 
 """
+    h5a_open_by_idx(obj_id::hid_t, pathname::Ptr{UInt8}, idx_type::Cint, order::Cint, n::hsize_t, aapl_id::hid_t, lapl_id::hid_t) -> hid_t
+
+See `libhdf5` documentation for [`H5Aopen_by_idx`](https://portal.hdfgroup.org/display/HDF5/H5A_OPEN_BY_IDX).
+"""
+function h5a_open_by_idx(obj_id, pathname, idx_type, order, n, aapl_id, lapl_id)
+    var"#status#" = ccall((:H5Aopen_by_idx, libhdf5), hid_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t, hid_t, hid_t), obj_id, pathname, idx_type, order, n, aapl_id, lapl_id)
+    var"#status#" < 0 && @h5error(string("Error opening attribute ", n, " of ", h5i_get_name(obj_id), "/", pathname))
+    return var"#status#"
+end
+
+"""
     h5a_read(attr_id::hid_t, mem_type_id::hid_t, buf::Ptr{Cvoid})
 
 See `libhdf5` documentation for [`H5Aread`](https://portal.hdfgroup.org/display/HDF5/H5A_READ).
@@ -271,6 +282,17 @@ See `libhdf5` documentation for [`H5Aread`](https://portal.hdfgroup.org/display/
 function h5a_read(attr_id, mem_type_id, buf)
     var"#status#" = ccall((:H5Aread, libhdf5), herr_t, (hid_t, hid_t, Ptr{Cvoid}), attr_id, mem_type_id, buf)
     var"#status#" < 0 && @h5error(string("Error reading attribute ", h5a_get_name(attr_id)))
+    return nothing
+end
+
+"""
+    h5a_rename(loc_id::hid_t, old_attr_name::Cstring, new_attr_name::Cstring)
+
+See `libhdf5` documentation for [`H5Arename`](https://portal.hdfgroup.org/display/HDF5/H5A_RENAME).
+"""
+function h5a_rename(loc_id, old_attr_name, new_attr_name)
+    var"#status#" = ccall((:H5Arename, libhdf5), herr_t, (hid_t, Cstring, Cstring), loc_id, old_attr_name, new_attr_name)
+    var"#status#" < 0 && @h5error(string("Could not rename attribute"))
     return nothing
 end
 

--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -53,7 +53,11 @@ end
 # `@cfunction` with `$f`.
 # This helper translates between the two preferred forms for each respective language.
 function h5a_iterate_helper(loc_id::hid_t, attr_name::Ptr{Cchar}, ainfo::Ptr{H5A_info_t}, @nospecialize(f::Any))::herr_t
-    return f(loc_id, attr_name, ainfo)
+    try
+        return herr_t(f(loc_id, attr_name, ainfo))
+    catch e
+        return herr_t(-1)
+    end
 end
 
 """

--- a/src/show.jl
+++ b/src/show.jl
@@ -63,6 +63,16 @@ function Base.show(io::IO, attr::Attributes)
     print(io, "Attributes of ", attr.parent)
 end
 
+Base.show(io::IO, attrdict::AttributeDict) = summary(io, attrdict)
+function Base.summary(io::IO, attrdict::AttributeDict)
+    print(io, "AttributeDict of ", attrdict.parent)
+    if isvalid(attrdict.parent)
+        n = length(attrdict)
+        print(io, " with ", n, n == 1 ? " attribute" : " attributes")
+    end
+end
+
+
 const ENDIAN_DICT  = Dict(
     API.H5T_ORDER_LE    => "little endian byte order",
     API.H5T_ORDER_BE    => "big endian byte order",
@@ -189,9 +199,9 @@ _tree_head(io::IO, obj) = print(io, _tree_icon(obj), " ", obj)
 _tree_head(io::IO, obj::Datatype) = print(io, _tree_icon(obj), " HDF5.Datatype: ", name(obj))
 
 _tree_count(parent::Union{File,Group}, attributes::Bool) =
-    length(parent) + (attributes ? length(HDF5.attributes(parent)) : 0)
+    length(parent) + (attributes ? length(HDF5.attrs(parent)) : 0)
 _tree_count(parent::Dataset, attributes::Bool) =
-    attributes ? length(HDF5.attributes(parent)) : 0
+    attributes ? length(HDF5.attrs(parent)) : 0
 _tree_count(parent::Attributes, _::Bool) = length(parent)
 _tree_count(parent::Union{Attribute,Datatype}, _::Bool) = 0
 

--- a/test/attributes.jl
+++ b/test/attributes.jl
@@ -1,0 +1,37 @@
+using HDF5, Test
+
+
+filename = tempname()
+f = h5open(filename, "w")
+
+@test attrs(f) isa HDF5.AttributeDict
+
+attrs(f)["a"] = 1
+@test attrs(f)["a"] == 1
+
+attrs(f)["b"] = [2,3]
+@test attrs(f)["b"] == [2,3]
+@test length(attrs(f)) == 2
+@test sort(keys(attrs(f))) == ["a", "b"]
+
+# overwrite: same type
+attrs(f)["a"] = 4
+@test attrs(f)["a"] == 4
+@test length(attrs(f)) == 2
+@test sort(keys(attrs(f))) == ["a", "b"]
+
+# overwrite: different size
+attrs(f)["b"] = [4,5,6]
+@test attrs(f)["b"] == [4,5,6]
+@test length(attrs(f)) == 2
+@test sort(keys(attrs(f))) == ["a", "b"]
+
+# overwrite: different type
+attrs(f)["b"] = "a string"
+@test attrs(f)["b"] == "a string"
+@test length(attrs(f)) == 2
+@test sort(keys(attrs(f))) == ["a", "b"]
+
+delete!(attrs(f), "a")
+@test length(attrs(f)) == 1
+@test sort(keys(attrs(f))) == ["b"]

--- a/test/gc.jl
+++ b/test/gc.jl
@@ -58,7 +58,7 @@ for i = 1:10
     d = file["d"]
     ds = dataspace(d)
     g = file["g"]
-    a = attributes(file)["a"]
+    a = open_attribute(file, "a")
     @gcvalid dt ds d g a
     close(file)
 end

--- a/test/properties.jl
+++ b/test/properties.jl
@@ -28,7 +28,7 @@ h5open(fn, "w";
                  fill_time = :never,
                  obj_track_times = false,
                  kwargs...)
-    attributes(d)["metadata"] = "test"
+    attrs(d)["metadata"] = "test"
 
     flush(hfile)
 
@@ -36,7 +36,7 @@ h5open(fn, "w";
     fapl = HDF5.get_access_properties(hfile)
     gcpl = HDF5.get_create_properties(hfile["group"])
     dcpl = HDF5.get_create_properties(hfile["group/dataset"])
-    acpl = HDF5.get_create_properties(attributes(hfile["group/dataset"])["metadata"])
+    acpl = HDF5.get_create_properties(open_attribute(hfile["group/dataset"], "metadata"))
 
     # Retrievability of properties
     @test isvalid(fcpl)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,8 @@ include("dataspace.jl")
 include("datatype.jl")
 @debug "hyperslab"
 include("hyperslab.jl")
+@debug "attributes"
+include("attributes.jl")
 @debug "readremote"
 include("readremote.jl")
 @debug "extend_test"

--- a/test/swmr.jl
+++ b/test/swmr.jl
@@ -92,7 +92,7 @@ end
 # create datasets and attributes before staring swmr writing
 function prep_h5_file(h5)
     d = create_dataset(h5, "foo", datatype(Int), ((1,), (100,)), chunk=(1,))
-    attributes(h5)["bar"] = "bar"
+    attrs(h5)["bar"] = "bar"
     g = create_group(h5, "group")
 end
 


### PR DESCRIPTION
This follows on from https://github.com/JuliaIO/HDF5.jl/pull/943#issuecomment-1140504666

It defines `attrs(obj)` which returns an `AttibuteDict`: this is mostly the same as `Attributes` object, except:
- it is a subtype of `AbstractDict{String, Any}`, and supports the relevant features (`keys`, `pairs`, `values`)
- `getindex` will `read` instead of returning an `Attribute`
- it supports `delete!`
- it supports overwriting attributes

TODO:
- [ ] update docs
- [ ] deprecate `attributes`

