### PR TITLE
make iterators safe for error handling

### DIFF
--- a/src/api/error.jl
+++ b/src/api/error.jl
@@ -51,10 +51,7 @@ function Base.showerror(io::IO, err::H5Error)
     print(io, "$(typeof(err)): ", err.msg)
     print(io, "\nlibhdf5 Stacktrace:")
     h5e_walk(err, H5E_WALK_UPWARD) do n, errptr
-        n += 1
-        if SHORT_ERROR[] && 1 < n < n_total
-            return nothing
-        end
+        n += 1 # 1-based indexing
         errval = unsafe_load(errptr)
         print(io, "\n", lpad("[$n] ", 4 + ndigits(n_total)))
         if errval.func_name != C_NULL
@@ -67,9 +64,13 @@ function Base.showerror(io::IO, err::H5Error)
         if errval.desc != C_NULL
             printstyled(io, "\n", " "^(4 + ndigits(n_total)), unsafe_string(errval.desc), color=:light_black)
         end
-        if SHORT_ERROR[] && n == 1 && n_total > 2
-            print(io, "\n", lpad("⋮", 2 + ndigits(n_total)))
+        if SHORT_ERROR[]
+            if n_total > 1
+                print(io, "\n", lpad("⋮", 2 + ndigits(n_total)))
+            end
+            return true # stop iterating
         end
+        return false
     end
     return nothing
 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -1,0 +1,88 @@
+using HDF5, Test
+
+@testset "h5a_iterate" begin
+    filename = tempname()
+    f = h5open(filename, "w")
+
+    write_attribute(f, "a", 1)
+    write_attribute(f, "b", 2)
+
+    # iterate over attributes
+    names = String[]
+    @test HDF5.API.h5a_iterate(f, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_INC) do loc, name, info
+        push!(names, unsafe_string(name))
+        return false
+    end == 2
+    @test names == ["a", "b"]
+
+    # iterate over attributes in reverse
+    names = String[]
+    @test HDF5.API.h5a_iterate(f, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_DEC) do loc, name, info
+        push!(names, unsafe_string(name))
+        return false
+    end == 2
+    @test names == ["b", "a"]
+
+    # only iterate once
+    names = String[]
+    @test HDF5.API.h5a_iterate(f, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_INC) do loc, name, info
+        push!(names, unsafe_string(name))
+        return true
+    end == 1
+    @test names == ["a"]
+
+    # HDF5 error
+    @test_throws HDF5.H5Error HDF5.API.h5a_iterate(f, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_INC) do loc, name, info
+      return -1
+    end
+
+    # Julia error
+    @test_throws AssertionError HDF5.API.h5a_iterate(f, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_INC) do loc, name, info
+      @assert false
+    end
+
+end
+
+@testset "h5l_iterate" begin
+
+    filename = tempname()
+    f = h5open(filename, "w")
+
+    create_group(f, "a")
+    create_group(f, "b")
+
+    # iterate over groups
+    names = String[]
+    @test HDF5.API.h5l_iterate(f, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_INC) do loc, name, info
+        push!(names, unsafe_string(name))
+        return false
+    end == 2
+    @test names == ["a", "b"]
+
+    # iterate over attributes in reverse
+    names = String[]
+    @test HDF5.API.h5l_iterate(f, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_DEC) do loc, name, info
+        push!(names, unsafe_string(name))
+        return false
+    end == 2
+    @test names == ["b", "a"]
+
+    # only iterate once
+    names = String[]
+    @test HDF5.API.h5l_iterate(f, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_INC) do loc, name, info
+        push!(names, unsafe_string(name))
+        return true
+    end == 1
+    @test names == ["a"]
+
+    # HDF5 error
+    @test_throws HDF5.H5Error HDF5.API.h5l_iterate(f, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_INC) do loc, name, info
+        return -1
+    end
+
+    # Julia error
+    @test_throws AssertionError HDF5.API.h5l_iterate(f, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_INC) do loc, name, info
+        @assert false
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,8 @@ Pkg.develop(PackageSpec(path=joinpath(filter_path, "H5Zzstd")))
 
 @debug "plain"
 include("plain.jl")
+@debug "api"
+include("api.jl")
 @debug "compound"
 include("compound.jl")
 @debug "custom"


### PR DESCRIPTION
This makes some minor changes to the iterator API functions:
- the callbacks can now return any integer type, or a bool
- errors from the callback are trapped and safely propagated back to the main process (doing this at the moment could leave the library in an invalid state: see https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/#Creating-C-Compatible-Julia-Function-Pointers and https://discourse.julialang.org/t/what-happens-when-you-throw-an-error-from-a-cfunction/71510?u=simonbyrne): this was partially done in https://github.com/JuliaIO/HDF5.jl/pull/948#discussion_r889711496, but I figured it would be better to do this in a new PR
- there was an opportunity for a small optimization in the error stack printing function