### PR TITLE
fix error message on write_attribute

### DIFF
--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -35,7 +35,7 @@
 ###
 
 @bind h5a_close(id::hid_t)::herr_t "Error closing attribute"
-@bind h5a_create2(loc_id::hid_t, pathname::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t)::hid_t string("Error creating attribute ", h5a_get_name(loc_id), "/", pathname)
+@bind h5a_create2(loc_id::hid_t, attr_name::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t)::hid_t string("Error creating attribute ", attr_name, " for object ", h5i_get_name(loc_id))
 @bind h5a_create_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t, lapl_id::hid_t)::hid_t string("Error creating attribute ", attr_name, " for object ", obj_name)
 @bind h5a_delete(loc_id::hid_t, attr_name::Ptr{UInt8})::herr_t string("Error deleting attribute ", attr_name)
 @bind h5a_delete_by_idx(loc_id::hid_t, obj_name::Ptr{UInt8}, idx_type::Cint, order::Cint, n::hsize_t, lapl_id::hid_t)::herr_t string("Error deleting attribute ", n, " from object ", obj_name)
@@ -48,7 +48,7 @@
 @bind h5a_get_space(attr_id::hid_t)::hid_t "Error getting attribute dataspace"
 @bind h5a_get_type(attr_id::hid_t)::hid_t "Error getting attribute type"
 @bind h5a_iterate2(obj_id::hid_t, idx_type::Cint, order::Cint, n::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Any)::herr_t string("Error iterating attributes in object ", h5i_get_name(obj_id))
-@bind h5a_open(obj_id::hid_t, pathname::Ptr{UInt8}, aapl_id::hid_t)::hid_t string("Error opening attribute ", h5i_get_name(obj_id), "/", pathname)
+@bind h5a_open(obj_id::hid_t, attr_name::Ptr{UInt8}, aapl_id::hid_t)::hid_t string("Error opening attribute ", attr_name, " for object ", h5i_get_name(obj_id))
 @bind h5a_read(attr_id::hid_t, mem_type_id::hid_t, buf::Ptr{Cvoid})::herr_t string("Error reading attribute ", h5a_get_name(attr_id))
 @bind h5a_write(attr_hid::hid_t, mem_type_id::hid_t, buf::Ptr{Cvoid})::herr_t "Error writing attribute data"
 

--- a/src/api/functions.jl
+++ b/src/api/functions.jl
@@ -110,13 +110,13 @@ function h5a_close(id)
 end
 
 """
-    h5a_create(loc_id::hid_t, pathname::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t) -> hid_t
+    h5a_create(loc_id::hid_t, attr_name::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Acreate2`](https://portal.hdfgroup.org/display/HDF5/H5A_CREATE2).
 """
-function h5a_create(loc_id, pathname, type_id, space_id, acpl_id, aapl_id)
-    var"#status#" = ccall((:H5Acreate2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t, hid_t, hid_t, hid_t), loc_id, pathname, type_id, space_id, acpl_id, aapl_id)
-    var"#status#" < 0 && @h5error(string("Error creating attribute ", h5a_get_name(loc_id), "/", pathname))
+function h5a_create(loc_id, attr_name, type_id, space_id, acpl_id, aapl_id)
+    var"#status#" = ccall((:H5Acreate2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t, hid_t, hid_t, hid_t), loc_id, attr_name, type_id, space_id, acpl_id, aapl_id)
+    var"#status#" < 0 && @h5error(string("Error creating attribute ", attr_name, " for object ", h5i_get_name(loc_id)))
     return var"#status#"
 end
 
@@ -253,13 +253,13 @@ function h5a_iterate(obj_id, idx_type, order, n, op, op_data)
 end
 
 """
-    h5a_open(obj_id::hid_t, pathname::Ptr{UInt8}, aapl_id::hid_t) -> hid_t
+    h5a_open(obj_id::hid_t, attr_name::Ptr{UInt8}, aapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Aopen`](https://portal.hdfgroup.org/display/HDF5/H5A_OPEN).
 """
-function h5a_open(obj_id, pathname, aapl_id)
-    var"#status#" = ccall((:H5Aopen, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t), obj_id, pathname, aapl_id)
-    var"#status#" < 0 && @h5error(string("Error opening attribute ", h5i_get_name(obj_id), "/", pathname))
+function h5a_open(obj_id, attr_name, aapl_id)
+    var"#status#" = ccall((:H5Aopen, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t), obj_id, attr_name, aapl_id)
+    var"#status#" < 0 && @h5error(string("Error opening attribute ", attr_name, " for object ", h5i_get_name(obj_id)))
     return var"#status#"
 end
 


### PR DESCRIPTION
the error message was calling `h5a_get_name` on an object, not an attribute.

Previously:
```
julia> using HDF5

julia> filename = tempname();

julia> f = h5open(filename, "w");

julia> write_attribute(f, "a", 2)

julia> write_attribute(f, "a", 3)
ERROR: HDF5.API.H5Error: Error getting attribute name
libhdf5 Stacktrace:
 [1] H5Aget_name: Invalid arguments to routine/Inappropriate type
     not an attribute
Stacktrace:
  [1] macro expansion
    @ ~/src/HDF5.jl/src/api/error.jl:18 [inlined]
  [2] h5a_get_name(attr_id::HDF5.File, buf_size::Int64, buf::Ptr{Nothing})
    @ HDF5.API ~/src/HDF5.jl/src/api/functions.jl:207
  [3] h5a_get_name(attr_id::HDF5.File)
    @ HDF5.API ~/src/HDF5.jl/src/api/helpers.jl:38
  [4] macro expansion
    @ ~/src/HDF5.jl/src/api/error.jl:18 [inlined]
  [5] h5a_create(loc_id::HDF5.File, pathname::String, type_id::HDF5.Datatype, space_id::HDF5.Dataspace, acpl_id::HDF5.AttributeCreateProperties, aapl_id::Int64)
    @ HDF5.API ~/src/HDF5.jl/src/api/functions.jl:119
  [6] create_attribute
    @ ~/src/HDF5.jl/src/attributes.jl:101 [inlined]
  [7] create_attribute(parent::HDF5.File, name::String, data::Int64; pv::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ HDF5 ~/src/HDF5.jl/src/attributes.jl:94
  [8] create_attribute
    @ ~/src/HDF5.jl/src/attributes.jl:91 [inlined]
  [9] write_attribute(parent::HDF5.File, name::String, data::Int64; pv::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ HDF5 ~/src/HDF5.jl/src/attributes.jl:130
 [10] write_attribute(parent::HDF5.File, name::String, data::Int64)
    @ HDF5 ~/src/HDF5.jl/src/attributes.jl:130
 [11] top-level scope
    @ REPL[8]:1
```


Now:
```
julia> using HDF5

julia> filename = tempname();

julia> f = h5open(filename, "w");

julia> write_attribute(f, "a", 2)

julia> write_attribute(f, "a", 3)
ERROR: HDF5.API.H5Error: Error creating attribute a for object /
libhdf5 Stacktrace:
 [1] H5A__create: Attribute/Object already exists
     attribute already exists
  ⋮
 [5] H5Acreate2: Attribute/Unable to initialize object
     unable to create attribute
Stacktrace:
 [1] macro expansion
   @ ~/src/HDF5.jl/src/api/error.jl:18 [inlined]
 [2] h5a_create(loc_id::HDF5.File, attr_name::String, type_id::HDF5.Datatype, space_id::HDF5.Dataspace, acpl_id::HDF5.AttributeCreateProperties, aapl_id::Int64)
   @ HDF5.API ~/src/HDF5.jl/src/api/functions.jl:119
 [3] create_attribute
   @ ~/src/HDF5.jl/src/attributes.jl:101 [inlined]
 [4] create_attribute(parent::HDF5.File, name::String, data::Int64; pv::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ HDF5 ~/src/HDF5.jl/src/attributes.jl:94
 [5] create_attribute
   @ ~/src/HDF5.jl/src/attributes.jl:91 [inlined]
 [6] write_attribute(parent::HDF5.File, name::String, data::Int64; pv::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ HDF5 ~/src/HDF5.jl/src/attributes.jl:130
 [7] write_attribute(parent::HDF5.File, name::String, data::Int64)
   @ HDF5 ~/src/HDF5.jl/src/attributes.jl:130
 [8] top-level scope
   @ REPL[5]:1
```