### PR TITLE
Fix attribute docs for attrs and rename_attribute, export it.

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -12,7 +12,7 @@ import Mmap
 export
 @read, @write,
 h5open, h5read, h5write, h5rewrite, h5writeattr, h5readattr,
-create_attribute, open_attribute, read_attribute, write_attribute, delete_attribute, attributes, attrs,
+create_attribute, open_attribute, read_attribute, write_attribute, delete_attribute, rename_attribute, attributes, attrs,
 create_dataset, open_dataset, read_dataset, write_dataset,
 create_group, open_group,
 copy_object, open_object, delete_object, move_link,

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -196,6 +196,7 @@ end
 struct AttributeDict <: AbstractDict{String,Any}
     parent::Object
 end
+AttributeDict(file::File) = AttributeDict(open_group(file, "."))
 
 """
     attrs(object::Union{File,Group,Dataset,Datatype})
@@ -210,8 +211,6 @@ delete!(attrs(object), "name") # delete an attribute
 keys(attrs(object))            # list the attribute names
 ```
 """
-AttributeDict(file::File) = AttributeDict(open_group(file, "."))
-
 function attrs(parent)
     return AttributeDict(parent)
 end


### PR DESCRIPTION
`rename_attribute` was not exported so Documenter could not find it's docstring.

The docstring for `attrs` got dissociated from the method.
