### PR TITLE
Add Core driver to docs

### DIFF
--- a/docs/src/properties.md
+++ b/docs/src/properties.md
@@ -42,6 +42,7 @@ CurrentModule = HDF5.Drivers
 ```
 
 ```@docs
+Core
 POSIX
 MPIO
 ```


### PR DESCRIPTION
`HDF5.Drivers.Core` was previously not listed in the documentation.