### PR TITLE
Avoid calling non-public h5fd_xxx_init() functions

### DIFF
--- a/src/drivers/drivers.jl
+++ b/src/drivers/drivers.jl
@@ -85,8 +85,12 @@ function set_driver!(p::Properties, ::POSIX)
 end
 
 function __init__()
-    DRIVERS[API.h5fd_core_init()] = Core
-    DRIVERS[API.h5fd_sec2_init()] = POSIX
+    fapl = HDF5.FileAccessProperties(fclose_degree=:default)
+    API.h5p_set_fapl_core(fapl, 4096, false)
+    DRIVERS[API.h5p_get_driver(fapl)] = Core
+    API.h5p_set_fapl_sec2(fapl)
+    DRIVERS[API.h5p_get_driver(fapl)] = POSIX
+    close(fapl)
     @require MPI="da04e1cc-30fd-572f-bb4f-1f8673147195" include("mpio.jl")
 end
 

--- a/src/drivers/drivers.jl
+++ b/src/drivers/drivers.jl
@@ -5,6 +5,7 @@ export POSIX
 import ..API
 import ..HDF5: HDF5, Properties, h5doc
 
+using Libdl: dllist, dlopen, dlsym
 using Requires: @require
 
 
@@ -98,10 +99,10 @@ function __init__()
     close(fapl)
 
     # Check whether the loaded HDF5 libraries were compiled with parallel support.
-    loaded_libs = filter(s->match(r"hdf5"i, s) !== nothing, Libc.Libdl.dllist())
+    loaded_libs = filter(s->match(r"hdf5"i, s) !== nothing, dllist())
     for libname in loaded_libs
-        has_mpio = Libc.Libdl.dlopen(libname) do lib
-            Libc.Libdl.dlsym(lib, :H5Pset_fapl_mpio; throw_error=false) !== nothing
+        has_mpio = dlopen(libname) do lib
+            dlsym(lib, :H5Pset_fapl_mpio; throw_error=false) !== nothing
         end
         if has_mpio
             HDF5.HAS_PARALLEL[] = true

--- a/src/drivers/drivers.jl
+++ b/src/drivers/drivers.jl
@@ -85,6 +85,11 @@ function set_driver!(p::Properties, ::POSIX)
 end
 
 function __init__()
+    # disable file locking as that can cause problems with mmap'ing
+    if !haskey(ENV, "HDF5_USE_FILE_LOCKING")
+        ENV["HDF5_USE_FILE_LOCKING"] = "FALSE"
+    end
+
     fapl = HDF5.init!(HDF5.FileAccessProperties())
     API.h5p_set_fapl_core(fapl, 4096, false)
     DRIVERS[API.h5p_get_driver(fapl)] = Core

--- a/src/drivers/drivers.jl
+++ b/src/drivers/drivers.jl
@@ -85,7 +85,7 @@ function set_driver!(p::Properties, ::POSIX)
 end
 
 function __init__()
-    fapl = HDF5.FileAccessProperties(fclose_degree=:default)
+    fapl = HDF5.init!(HDF5.FileAccessProperties())
     API.h5p_set_fapl_core(fapl, 4096, false)
     DRIVERS[API.h5p_get_driver(fapl)] = Core
     API.h5p_set_fapl_sec2(fapl)

--- a/src/drivers/drivers.jl
+++ b/src/drivers/drivers.jl
@@ -98,7 +98,7 @@ function __init__()
     close(fapl)
 
     # Check whether the loaded HDF5 libraries were compiled with parallel support.
-    loaded_libs = filter(contains(r"hdf5"i), Libc.Libdl.dllist())
+    loaded_libs = filter(s->match(r"hdf5"i, s) !== nothing, Libc.Libdl.dllist())
     for libname in loaded_libs
         has_mpio = Libc.Libdl.dlopen(libname) do lib
             Libc.Libdl.dlsym(lib, :H5Pset_fapl_mpio; throw_error=false) !== nothing

--- a/src/drivers/mpio.jl
+++ b/src/drivers/mpio.jl
@@ -42,13 +42,6 @@ end
  MPIO(comm::MPI.Comm; kwargs...) =
     MPIO(comm, MPI.Info(;kwargs...))
 
-# Check whether the HDF5 libraries were compiled with parallel support.
-try
-    DRIVERS[API.h5fd_mpio_init()] = MPIO
-    HDF5.HAS_PARALLEL[] = true
-catch e
-end
-
 function set_driver!(fapl::Properties, mpio::MPIO)
     HDF5.has_parallel() || error(
         "HDF5.jl has no parallel support." *

--- a/src/drivers/mpio.jl
+++ b/src/drivers/mpio.jl
@@ -53,6 +53,9 @@ function set_driver!(fapl::Properties, mpio::MPIO)
     GC.@preserve mpio begin
         API.h5p_set_fapl_mpio(fapl, mpi_to_h5(mpio.comm), mpi_to_h5(mpio.info))
     end
+
+    DRIVERS[API.h5p_get_driver(fapl)] = MPIO
+    return nothing
 end
 
 function get_driver(fapl::Properties, ::Type{MPIO})


### PR DESCRIPTION
The h5fd_xxx_init() functions are not part of the HDF5 public API.  A
method of retrieving the hid_t value of drivers that uses
public/supported API calls was suggested in a comment on a related
github issue and is implemented in this commit.  For more details see:

https://github.com/HDFGroup/hdf5/issues/1809#issuecomment-1154397046