### PR TITLE
Remove confusing example of `create_dataset`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -89,13 +89,7 @@ create_group(fid, "mygroup")
 We can write the `"mydataset"` by:
 
 ```@repl main
-fid["mydataset"] = rand()
-```
-
-Or
-
-```@repl main
-create_dataset(fid, "myvector", rand(10))
+fid["mydataset"] = rand(10)
 ```
 
 Writing to a dataset to a group is as simple as:

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -1,3 +1,24 @@
+"""
+    create_group(parent, path[, lcpl, gcpl]; properties...)
+
+# Arguments
+* `parent` - `File` or `Group`
+* `path` - `String` describing the path of the group within the HDF5 file
+* `lcpl` - [`LinkCreateProperties`](@ref)
+* `gcpl` - [`GroupCreateProperties`](@ref)
+* `properties` - keyword name-value pairs set properties of the group
+
+# Keywords
+
+There are many keyword properties that can be set. Below are a few select keywords.
+* `track_order` - `Bool` tracks the group creation order. 
+        Currently this is only used with `FileIO` and `OrderedDict`.
+        Files created with `track_order = true` 
+        should create all subgroups with `track_order = true`.
+
+See also
+* [`H5P`](@ref H5P)
+"""
 function create_group(parent::Union{File,Group}, path::AbstractString,
                   lcpl::LinkCreateProperties=_link_properties(path),
                   gcpl::GroupCreateProperties=GroupCreateProperties();


### PR DESCRIPTION
Based on the example:

https://github.com/JuliaIO/HDF5.jl/blob/d6ecf42d035784f78616a24b03cda7c037eda7c9/docs/src/index.md?plain=1#L89-L99

I thought `create_dataset` would write the data, but `create_dataset` doesn't actually write any data, it just creates the dataset.