### PR TITLE
Fix `track_order` usage in do block

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -41,8 +41,8 @@ Filters, Drivers
 h5doc(name) = "[`$name`](https://portal.hdfgroup.org/display/HDF5/$(name))"
 
 include("api/api.jl")
-
 include("properties.jl")
+include("context.jl")
 include("types.jl")
 include("file.jl")
 include("objects.jl")
@@ -154,15 +154,11 @@ function Base.setindex!(parent::Union{File,Group}, val, path::Union{AbstractStri
     write(parent, path, val; pv...)
 end
 
-
 # end of high-level interface
-
 
 include("api_midlevel.jl")
 
-
 #API.h5s_get_simple_extent_ndims(space_id::API.hid_t) = API.h5s_get_simple_extent_ndims(space_id, C_NULL, C_NULL)
-
 
 # Functions that require special handling
 
@@ -172,8 +168,8 @@ const libversion = API.h5_get_libversion()
 get_access_properties(d::Dataset)   = DatasetAccessProperties(API.h5d_get_access_plist(d))
 get_access_properties(f::File)      = FileAccessProperties(API.h5f_get_access_plist(f))
 get_create_properties(d::Dataset)   = DatasetCreateProperties(API.h5d_get_create_plist(d))
-get_create_properties(g::Group)     = isvalid(g.gcpl) ? g.gcpl : GroupCreateProperties(API.h5g_get_create_plist(g))
-get_create_properties(f::File)      = isvalid(f.fcpl) ? f.fcpl : FileCreateProperties(API.h5f_get_create_plist(f))
+get_create_properties(g::Group)     = GroupCreateProperties(API.h5g_get_create_plist(g))
+get_create_properties(f::File)      = FileCreateProperties(API.h5f_get_create_plist(f))
 get_create_properties(a::Attribute) = AttributeCreateProperties(API.h5a_get_create_plist(a))
 
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -42,9 +42,6 @@ h5doc(name) = "[`$name`](https://portal.hdfgroup.org/display/HDF5/$(name))"
 
 include("api/api.jl")
 
-const IDX_TYPE = Ref(API.H5_INDEX_NAME)
-const ORDER = Ref(API.H5_ITER_INC)
-
 include("properties.jl")
 include("types.jl")
 include("file.jl")
@@ -175,8 +172,8 @@ const libversion = API.h5_get_libversion()
 get_access_properties(d::Dataset)   = DatasetAccessProperties(API.h5d_get_access_plist(d))
 get_access_properties(f::File)      = FileAccessProperties(API.h5f_get_access_plist(f))
 get_create_properties(d::Dataset)   = DatasetCreateProperties(API.h5d_get_create_plist(d))
-get_create_properties(g::Group)     = GroupCreateProperties(API.h5g_get_create_plist(g))
-get_create_properties(f::File)      = FileCreateProperties(API.h5f_get_create_plist(f))
+get_create_properties(g::Group)     = isvalid(g.gcpl) ? g.gcpl : GroupCreateProperties(API.h5g_get_create_plist(g))
+get_create_properties(f::File)      = isvalid(f.fcpl) ? f.fcpl : FileCreateProperties(API.h5f_get_create_plist(f))
 get_create_properties(a::Attribute) = AttributeCreateProperties(API.h5a_get_create_plist(a))
 
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -254,7 +254,7 @@ function Base.keys(attrdict::AttributeDict)
     # faster than iteratively calling h5a_get_name_by_idx
     checkvalid(attrdict.parent)
     keyvec = sizehint!(String[], length(attrdict))
-    API.h5a_iterate(attrdict.parent, IDX_TYPE[], ORDER[]) do _, attr_name, _
+    API.h5a_iterate(attrdict.parent, idx_type(attrdict.parent), order(attrdict.parent)) do _, attr_name, _
         push!(keyvec, unsafe_string(attr_name))
         return false
     end
@@ -304,7 +304,7 @@ Base.length(x::Attributes) = num_attrs(x.parent)
 function Base.keys(x::Attributes)
     checkvalid(x.parent)
     children = sizehint!(String[], length(x))
-    API.h5a_iterate(x.parent, IDX_TYPE[], ORDER[]) do _, attr_name, _
+    API.h5a_iterate(x.parent, idx_type(x.parent), order(x.parent)) do _, attr_name, _
         push!(children, unsafe_string(attr_name))
         return API.herr_t(0)
     end

--- a/src/context.jl
+++ b/src/context.jl
@@ -1,0 +1,52 @@
+struct HDF5Context
+   attribute_access::AttributeAccessProperties
+   attribute_create::AttributeCreateProperties
+   dataset_access  ::DatasetAccessProperties
+   dataset_create  ::DatasetCreateProperties
+   dataset_transfer::DatasetTransferProperties
+   datatype_access ::DatatypeAccessProperties
+   datatype_create ::DatatypeCreateProperties
+   file_access     ::FileAccessProperties
+   file_create     ::FileCreateProperties
+   file_mount      ::FileMountProperties
+   group_access    ::GroupAccessProperties
+   group_create    ::GroupCreateProperties
+   link_access     ::LinkAccessProperties
+   link_create     ::LinkCreateProperties
+   object_copy     ::ObjectCopyProperties
+   object_create   ::ObjectCreateProperties
+   string_create   ::StringCreateProperties
+end
+
+Base.copy(ctx::HDF5Context) =
+    HDF5Context(map(n -> copy(getfield(ctx, n)), fieldnames(HDF5Context))...)
+
+Base.close(ctx::HDF5Context) =
+    foreach(n -> close(getfield(ctx, n)), fieldnames(HDF5Context))
+
+function HDF5Context()
+   HDF5Context(
+       AttributeAccessProperties(),
+       AttributeCreateProperties(),
+       DatasetAccessProperties(),
+       DatasetCreateProperties(),
+       DatasetTransferProperties(),
+       DatatypeAccessProperties(),
+       DatatypeCreateProperties(),
+       FileAccessProperties(),
+       FileCreateProperties(),
+       FileMountProperties(),
+       GroupAccessProperties(),
+       GroupCreateProperties(),
+       LinkAccessProperties(),
+       LinkCreateProperties(),
+       ObjectCopyProperties(),
+       ObjectCreateProperties(),
+       StringCreateProperties(),
+   )
+end
+
+const CONTEXT = HDF5Context()
+
+get_context_property(name::Symbol) =
+    getfield(get(task_local_storage(), :hdf5_context, CONTEXT), name)

--- a/src/context.jl
+++ b/src/context.jl
@@ -1,3 +1,42 @@
+# The context API is under active development. This is an internal API and may change.
+
+"""
+    HDF5Context
+
+*Internal API*
+
+An `HDF5Context` is a collection of HDF5 property lists. It is meant to be used
+as a `Task` local mechanism to store state and change the default property lists
+for new objects.
+
+Use the function `get_context_property(name::Symbol)` to access a property
+list within the local context.
+
+The context in `task_local_storage()[:hdf5_context]` will be checked first.
+A common global HDF5Context is stored in the constant `HDF5.CONTEXT` and
+serves as the default context if the current task does not have a
+`:hdf5_context`.
+
+# Fields
+
+* attribute_access
+* attribute_create
+* dataset_access
+* dataset_create
+* dataset_tranfer
+* datatype_access
+* datatype_create
+* file_access
+* file_create
+* file_mount
+* group_access
+* group_create
+* link_access
+* link_create
+* object_copy
+* object_create
+* string_create
+"""
 struct HDF5Context
    attribute_access::AttributeAccessProperties
    attribute_create::AttributeCreateProperties
@@ -46,7 +85,23 @@ function HDF5Context()
    )
 end
 
+"""
+    HDF5.CONTEXT
+
+*Internal API*
+
+Default `HDF5Context`.
+"""
 const CONTEXT = HDF5Context()
 
+"""
+    get_context_property(name::Symbol)
+
+*Internal API*
+
+Retrieve a property list from the task local context, defaulting to
+`HDF5.CONTEXT` if `task_local_storage()[:hdf5_context]` does not
+exist.
+"""
 get_context_property(name::Symbol) =
     getfield(get(task_local_storage(), :hdf5_context, CONTEXT), name)

--- a/src/file.jl
+++ b/src/file.jl
@@ -42,7 +42,7 @@ function h5open(filename::AbstractString, mode::AbstractString, fapl::FileAccess
         end
         fid = API.h5f_open(filename, flag, fapl)
     end
-    return File(fid, filename)
+    File(fid, filename, fcpl)
 end
 
 
@@ -56,28 +56,27 @@ function h5open(filename::AbstractString, mode::AbstractString = "r";
     try
         pv = setproperties!(fapl, fcpl; pv...)
         isempty(pv) || error("invalid keyword options $pv")
-        file = h5open(filename, mode, fapl, fcpl; swmr=swmr)
-        return file
+        return h5open(filename, mode, fapl, fcpl; swmr=swmr)
     finally
         close(fapl)
-        close(fcpl)
+        # close(fcpl)  # FIXME: need to remain valid in read mode
     end
 end
 
-
 """
-    function h5open(f::Function, args...; swmr=false, pv...)
+    function h5open(f::Function, args...; pv...)
 
 Apply the function f to the result of `h5open(args...; kwargs...)` and close the resulting
-`HDF5.File` upon completion. For example with a `do` block:
+`HDF5.File` upon completion.
+For example with a `do` block:
 
     h5open("foo.h5","w") do h5
         h5["foo"]=[1,2,3]
     end
 
 """
-function h5open(f::Function, args...; swmr=false, pv...)
-    file = h5open(args...; swmr=swmr, pv...)
+function h5open(f::Function, args...; pv...)
+    file = h5open(args...; pv...)
     try
         f(file)
     finally

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -26,11 +26,11 @@ function create_group(parent::Union{File,Group}, path::AbstractString,
     haskey(parent, path) && error("cannot create group: object \"", path, "\" already exists at ", name(parent))
     pv = setproperties!(gcpl; pv...)
     isempty(pv) || error("invalid keyword options $pv")
-    Group(API.h5g_create(parent, path, lcpl, gcpl, API.H5P_DEFAULT), file(parent), gcpl)
+    Group(API.h5g_create(parent, path, lcpl, gcpl, API.H5P_DEFAULT), file(parent))
 end
 
 open_group(parent::Union{File,Group}, name::AbstractString, gapl::GroupAccessProperties=GroupAccessProperties()) =
-    Group(API.h5g_open(checkvalid(parent), name, gapl), file(parent), inherit_gcpl(parent))
+    Group(API.h5g_open(checkvalid(parent), name, gapl), file(parent))
 
 # Get the root group
 root(h5file::File) = open_group(h5file, "/")

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -19,13 +19,30 @@ function Base.close(obj::Union{Group,Dataset})
     nothing
 end
 
+inherit_gcpl(parent) = GroupCreateProperties()
+inherit_gcpl(parent::Group) = isvalid(parent.gcpl) ? parent.gcpl : GroupCreateProperties()
+function inherit_gcpl(parent::File)
+    if isvalid(parent.fcpl)
+        # FIXME: propagate ∩(GroupCreateProperties, FileCreateProperties) properties
+        GroupCreateProperties(track_order = parent.fcpl.track_order)
+    else
+        GroupCreateProperties()
+    end
+end
+
 # Object (group, named datatype, or dataset) open
 function h5object(obj_id::API.hid_t, parent)
     obj_type = API.h5i_get_type(obj_id)
-    obj_type == API.H5I_GROUP ? Group(obj_id, file(parent)) :
-    obj_type == API.H5I_DATATYPE ? Datatype(obj_id, file(parent)) :
-    obj_type == API.H5I_DATASET ? Dataset(obj_id, file(parent)) :
-    error("Invalid object type for path ", path)
+    obj = if obj_type == API.H5I_GROUP
+        Group(obj_id, file(parent), inherit_gcpl(parent))
+    elseif obj_type == API.H5I_DATATYPE
+        Datatype(obj_id, file(parent))
+    elseif obj_type == API.H5I_DATASET
+        Dataset(obj_id, file(parent))
+    else
+        error("Invalid object type for path ", path)
+    end
+    obj
 end
 open_object(parent, path::AbstractString) = h5object(API.h5o_open(checkvalid(parent), path, API.H5P_DEFAULT), parent)
 function gettype(parent, path::AbstractString)

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -19,32 +19,17 @@ function Base.close(obj::Union{Group,Dataset})
     nothing
 end
 
-inherit_gcpl(parent) = GroupCreateProperties()
-inherit_gcpl(parent::Group) = isvalid(parent.gcpl) ? parent.gcpl : GroupCreateProperties()
-function inherit_gcpl(parent::File)
-    if isvalid(parent.fcpl)
-        # FIXME: propagate ∩(GroupCreateProperties, FileCreateProperties) properties
-        GroupCreateProperties(track_order = parent.fcpl.track_order)
-    else
-        GroupCreateProperties()
-    end
-end
-
 # Object (group, named datatype, or dataset) open
 function h5object(obj_id::API.hid_t, parent)
     obj_type = API.h5i_get_type(obj_id)
-    obj = if obj_type == API.H5I_GROUP
-        Group(obj_id, file(parent), inherit_gcpl(parent))
-    elseif obj_type == API.H5I_DATATYPE
-        Datatype(obj_id, file(parent))
-    elseif obj_type == API.H5I_DATASET
-        Dataset(obj_id, file(parent))
-    else
-        error("Invalid object type for path ", path)
-    end
-    obj
+    obj_type == API.H5I_GROUP ? Group(obj_id, file(parent)) :
+    obj_type == API.H5I_DATATYPE ? Datatype(obj_id, file(parent)) :
+    obj_type == API.H5I_DATASET ? Dataset(obj_id, file(parent)) :
+    error("Invalid object type for path ", path)
 end
+
 open_object(parent, path::AbstractString) = h5object(API.h5o_open(checkvalid(parent), path, API.H5P_DEFAULT), parent)
+
 function gettype(parent, path::AbstractString)
     obj_id = API.h5o_open(checkvalid(parent), path, API.H5P_DEFAULT)
     obj_type = API.h5i_get_type(obj_id)

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -272,7 +272,7 @@ end
 get_track_order(p::Properties) = API.h5p_get_link_creation_order(p) != 0 && API.h5p_get_attr_creation_order(p) != 0
 
 function set_track_order!(p::Properties, val::Bool)
-    crt_order_flags = val ? (HDF5.API.H5P_CRT_ORDER_TRACKED | HDF5.API.H5P_CRT_ORDER_INDEXED) : 0
+    crt_order_flags = val ? (API.H5P_CRT_ORDER_TRACKED | API.H5P_CRT_ORDER_INDEXED) : 0
     API.h5p_set_link_creation_order(p, crt_order_flags)
     API.h5p_set_attr_creation_order(p, crt_order_flags)
     nothing

--- a/src/show.jl
+++ b/src/show.jl
@@ -238,7 +238,7 @@ function _show_tree(io::IO, obj::Union{File,Group,Dataset,Datatype,Attributes,At
 
     if attributes && !isa(obj, Attribute)
         obj′ = obj isa Attributes ? obj.parent : obj
-        API.h5a_iterate(obj′, IDX_TYPE[], ORDER[]) do _, cname, _
+        API.h5a_iterate(obj′, idx_type(obj′), order(obj′)) do _, cname, _
             depth_check() && return API.herr_t(1)
 
             name = unsafe_string(cname)
@@ -251,7 +251,7 @@ function _show_tree(io::IO, obj::Union{File,Group,Dataset,Datatype,Attributes,At
 
     typeof(obj) <: Union{File, Group} || return nothing
 
-    API.h5l_iterate(obj, IDX_TYPE[], ORDER[]) do loc_id, cname, _
+    API.h5l_iterate(obj, idx_type(obj), order(obj)) do loc_id, cname, _
         depth_check() && return API.herr_t(1)
 
         name = unsafe_string(cname)

--- a/test/fileio.jl
+++ b/test/fileio.jl
@@ -53,26 +53,27 @@ let fn = tempname() * ".h5"
 
   # issue #939
   h5open(fn, "r"; track_order=true) do io
-    @test HDF5.get_create_properties(io).track_order
+    @test HDF5.get_context_property(:file_create).track_order
     @test all(keys(io) .== ["b", "a", "G"])
-    @test HDF5.get_create_properties(io["G"]).track_order
+    @test HDF5.get_context_property(:group_create).track_order
+    @test HDF5.get_create_properties(io["G"]).track_order  # inferred from file, created with `track_order=true`
     @test all(keys(io["G"]) .== ["z", "f"])
   end
 
   h5open(fn, "r"; track_order=false) do io
-    @test !HDF5.get_create_properties(io).track_order
+    @test !HDF5.get_context_property(:file_create).track_order
     @test all(keys(io) .== ["G", "a", "b"])
-    @test !HDF5.get_create_properties(io["G"]).track_order
-    @test all(keys(io["G"]) .== ["f", "z"])
+    @test !HDF5.get_context_property(:group_create).track_order
+    @test HDF5.get_create_properties(io["G"]).track_order  # inferred from file
+    @test all(keys(io["G"]) .== ["z", "f"])
   end
 
   h5open(fn, "r") do io
     @test !HDF5.get_create_properties(io).track_order
     @test all(keys(io) .== ["G", "a", "b"])
-    @test HDF5.get_create_properties(io["G"]).track_order  # inferred from file, created with `track_order=true`
+    @test HDF5.get_create_properties(io["G"]).track_order  # inferred from file
     @test all(keys(io["G"]) .== ["z", "f"])
   end
-
 end
 
 let fn = tempname() * ".h5"

--- a/test/fileio.jl
+++ b/test/fileio.jl
@@ -50,6 +50,29 @@ let fn = tempname() * ".h5"
   dat = load(fn; dict=OrderedDict())  # `track_order` is inferred from `OrderedDict`
 
   @test all(keys(dat) .== ["b", "a", "G/z", "G/f"])
+
+  # issue #939
+  h5open(fn, "r"; track_order=true) do io
+    @test HDF5.get_create_properties(io).track_order
+    @test all(keys(io) .== ["b", "a", "G"])
+    @test HDF5.get_create_properties(io["G"]).track_order
+    @test all(keys(io["G"]) .== ["z", "f"])
+  end
+
+  h5open(fn, "r"; track_order=false) do io
+    @test !HDF5.get_create_properties(io).track_order
+    @test all(keys(io) .== ["G", "a", "b"])
+    @test !HDF5.get_create_properties(io["G"]).track_order
+    @test all(keys(io["G"]) .== ["f", "z"])
+  end
+
+  h5open(fn, "r") do io
+    @test !HDF5.get_create_properties(io).track_order
+    @test all(keys(io) .== ["G", "a", "b"])
+    @test HDF5.get_create_properties(io["G"]).track_order  # inferred from file, created with `track_order=true`
+    @test all(keys(io["G"]) .== ["z", "f"])
+  end
+
 end
 
 let fn = tempname() * ".h5"


### PR DESCRIPTION
Follow up of https://github.com/JuliaIO/HDF5.jl/pull/912.

- fix https://github.com/JuliaIO/HDF5.jl/issues/939;
- fix https://github.com/JuliaIO/HDF5.jl/issues/985.

Remove `IDX_TYPE` and `ORDER` globals (non thread safe global states).

~~And a little cleanup / simplifications~~.