### PR TITLE
Check buf size on attr or dset write

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -94,6 +94,10 @@ end
 # generic method
 write_attribute(attr::Attribute, memtype::Datatype, x) = API.h5a_write(attr, memtype, x)
 # specific methods
+function write_attribute(attr::Attribute, memtype::Datatype, x::AbstractArray)
+    length(x) == length(attr) || throw(ArgumentError("Invalid length: $(length(x)) != (length($(name(attr))) = $(length(attr)))"))
+    API.h5a_write(attr, memtype, x)
+end
 function write_attribute(attr::Attribute, memtype::Datatype, str::AbstractString)
     strbuf = Base.cconvert(Cstring, str)
     GC.@preserve strbuf begin

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -95,7 +95,7 @@ end
 write_attribute(attr::Attribute, memtype::Datatype, x) = API.h5a_write(attr, memtype, x)
 # specific methods
 function write_attribute(attr::Attribute, memtype::Datatype, x::AbstractArray)
-    length(x) == length(attr) || throw(ArgumentError("Invalid length: $(length(x)) != (length($(name(attr))) = $(length(attr)))"))
+    length(x) == length(attr) || throw(ArgumentError("Invalid length: $(length(x)) != $(length(attr)), for attribute \"$(name(attr))\""))
     API.h5a_write(attr, memtype, x)
 end
 function write_attribute(attr::Attribute, memtype::Datatype, str::AbstractString)

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -339,7 +339,7 @@ function _check_invalid(dataset::Dataset, buf::AbstractArray)
     num_bytes_dset = Base.checked_mul(sizeof(datatype(dataset)), length(dataset))
     num_bytes_buf = Base.checked_mul(sizeof(eltype(buf)), length(buf))
     num_bytes_buf == num_bytes_dset || throw(ArgumentError(
-        "Invalid number of bytes: $(num_bytes_buf) != (num_bytes($(name(dataset))) = $num_bytes_dset)"
+        "Invalid number of bytes: $(num_bytes_buf) != $num_bytes_dset, for dataset \"$(name(dataset))\""
     ))
     stride(buf, 1) == 1 || throw(ArgumentError("Cannot read/write arrays with a different stride than `Array`"))
 end

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -336,8 +336,8 @@ write_dataset(dset::Dataset, memtype::Datatype, x, xfer::DatasetTransferProperti
 
 # type-specific behaviors
 function _check_invalid(dataset::Dataset, buf::AbstractArray)
-    num_bytes_dset = sizeof(datatype(dataset)) * length(dataset)
-    num_bytes_buf = sizeof(eltype(buf)) * length(buf)
+    num_bytes_dset = Base.checked_mul(sizeof(datatype(dataset)), length(dataset))
+    num_bytes_buf = Base.checked_mul(sizeof(eltype(buf)), length(buf))
     num_bytes_buf == num_bytes_dset || throw(ArgumentError(
         "Invalid number of bytes: $(num_bytes_buf) != (num_bytes($(name(dataset))) = $num_bytes_dset)"
     ))

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -339,7 +339,7 @@ function _check_invalid(dataset::Dataset, buf::AbstractArray)
     num_bytes_dset = Base.checked_mul(sizeof(datatype(dataset)), length(dataset))
     num_bytes_buf = Base.checked_mul(sizeof(eltype(buf)), length(buf))
     num_bytes_buf == num_bytes_dset || throw(ArgumentError(
-        "Invalid number of bytes: $(num_bytes_buf) != $num_bytes_dset, for dataset \"$(name(dataset))\""
+        "Invalid number of bytes: $num_bytes_buf != $num_bytes_dset, for dataset \"$(name(dataset))\""
     ))
     stride(buf, 1) == 1 || throw(ArgumentError("Cannot read/write arrays with a different stride than `Array`"))
 end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -1404,3 +1404,15 @@ rm(fn1)
 rm(fn2)
 
 end
+
+@testset "bounds" begin
+
+# issue #954
+h5open(tempname(), "w") do f
+    a, _ = create_attribute(f, "a", zeros(4))
+    @test_throws ArgumentError write(a, ones(2))
+    d, _ = create_dataset(f, "dd", zeros(4))
+    @test_throws ArgumentError write(d, ones(2))
+end
+
+end


### PR DESCRIPTION
Fix https://github.com/JuliaIO/HDF5.jl/issues/954 (only for `Attribute` and `Dataset` for now as the OP examples, I guess there could be more checks for other Types ?).

~~By the way, what do you say we indent all the `@testset` block in the tests ? They are barely readable when un-indented.~~

~~Or a simple solution would be to add a [formatter](https://github.com/domluna/JuliaFormatter.jl) check action to the github workflows (e.g. https://github.com/JuliaPlots/UnicodePlots.jl/blob/master/.github/workflows/format-check.yml), since the code style is inconsistent in `HDF5.jl`, and it's very irritating.~~