### PR TITLE
Ignore src/api/functions.jl for code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,8 @@
 comment: false
 
+ignore:
+  - "src/api/functions.jl"
+
 coverage:
   range: 0..100
   round: down


### PR DESCRIPTION
Ignore `src/api/functions.jl` since those are just bindings for the C API.

See https://docs.codecov.com/docs/ignoring-paths