### PR TITLE
Implement Base.copy(::Properties)

### DIFF
--- a/src/properties.jl
+++ b/src/properties.jl
@@ -17,6 +17,7 @@ function Base.close(obj::Properties)
 end
 
 Base.isvalid(obj::Properties) = obj.id != -1 && API.h5i_is_valid(obj)
+Base.copy(obj::P) where P <: Properties = P(HDF5.API.h5p_copy(obj.id))
 
 # By default, properties objects are only initialized lazily
 function init!(prop::P) where {P<:Properties}


### PR DESCRIPTION
This is a small pull request to extend `Base.copy` to copy property lists. Needed for #982 and context implementation.