### PR TITLE
Debug 32-bit windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,33 @@ on:
   pull_request:
 
 jobs:
+  HDF5-system-libs:
+    name: julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} (system libhdf5 + mpich)
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        version:
+          - '1.3'
+        os:
+          - ubuntu-20.04 # required for libhdf5 v1.10.4 support
+        arch:
+          - x64
+    steps:
+      - name: Install libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install mpich libhdf5-mpich-dev
+          echo "JULIA_HDF5_PATH=/usr/lib/x86_64-linux-gnu/hdf5/mpich/" >> $GITHUB_ENV
+          echo "JULIA_MPI_BINARY=system" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+
   HDF5:
     name: julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
@@ -17,11 +44,15 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.3'
           - '1'
           - 'nightly'
         os:
+          - ubuntu-latest
+          - macOS-latest
           - windows-latest
         arch:
+          - x64
           - x86
         exclude:
           - os: macOS-latest
@@ -46,3 +77,63 @@ jobs:
       - uses: julia-actions/julia-runtest@latest
         env:
           JULIA_DEBUG: Main
+      - uses: julia-actions/julia-processcoverage@latest
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info
+
+  integration:
+    name: ${{ matrix.package.repo }} - julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+        package:
+          - {user: JuliaIO, repo: MAT.jl}
+          - {user: JuliaIO, repo: JLD.jl}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone ${{ matrix.package.repo }}
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
+          path: downstream
+      - name: Run ${{ matrix.package.repo }} tests
+        shell: julia --project=downstream {0}
+        run: |
+            using Pkg
+            try
+              # force it to use this PR's version of the package
+              Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+              Pkg.update()
+              Pkg.test()  # resolver may fail with test time deps
+            catch err
+              err isa Pkg.Resolve.ResolverError || rethrow()
+              # If we can't resolve that means this is incompatible by SemVer and this is fine
+              # It means we marked this as a breaking change, so we don't need to worry about
+              # Mistakenly introducing a breaking change, as we have intentionally made one
+              @info "Not compatible with this release. No problem." exception=err
+              exit(0)  #  Exit immediately, as a success
+            end
+
+  docs:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - uses: julia-actions/julia-buildpkg@latest
+        - uses: julia-actions/julia-docdeploy@latest
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,33 +9,6 @@ on:
   pull_request:
 
 jobs:
-  HDF5-system-libs:
-    name: julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} (system libhdf5 + mpich)
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
-    strategy:
-      matrix:
-        version:
-          - '1.3'
-        os:
-          - ubuntu-20.04 # required for libhdf5 v1.10.4 support
-        arch:
-          - x64
-    steps:
-      - name: Install libraries
-        run: |
-          sudo apt-get update
-          sudo apt-get install mpich libhdf5-mpich-dev
-          echo "JULIA_HDF5_PATH=/usr/lib/x86_64-linux-gnu/hdf5/mpich/" >> $GITHUB_ENV
-          echo "JULIA_MPI_BINARY=system" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
-
   HDF5:
     name: julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
@@ -44,15 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
           - '1'
           - 'nightly'
         os:
-          - ubuntu-latest
-          - macOS-latest
           - windows-latest
         arch:
-          - x64
           - x86
         exclude:
           - os: macOS-latest
@@ -77,63 +46,3 @@ jobs:
       - uses: julia-actions/julia-runtest@latest
         env:
           JULIA_DEBUG: Main
-      - uses: julia-actions/julia-processcoverage@latest
-      - uses: codecov/codecov-action@v1
-        with:
-          file: lcov.info
-
-  integration:
-    name: ${{ matrix.package.repo }} - julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - '1'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-        package:
-          - {user: JuliaIO, repo: MAT.jl}
-          - {user: JuliaIO, repo: JLD.jl}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Clone ${{ matrix.package.repo }}
-        uses: actions/checkout@v2
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Run ${{ matrix.package.repo }} tests
-        shell: julia --project=downstream {0}
-        run: |
-            using Pkg
-            try
-              # force it to use this PR's version of the package
-              Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-              Pkg.update()
-              Pkg.test()  # resolver may fail with test time deps
-            catch err
-              err isa Pkg.Resolve.ResolverError || rethrow()
-              # If we can't resolve that means this is incompatible by SemVer and this is fine
-              # It means we marked this as a breaking change, so we don't need to worry about
-              # Mistakenly introducing a breaking change, as we have intentionally made one
-              @info "Not compatible with this release. No problem." exception=err
-              exit(0)  #  Exit immediately, as a success
-            end
-
-  docs:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v2
-        - uses: julia-actions/julia-buildpkg@latest
-        - uses: julia-actions/julia-docdeploy@latest
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -371,7 +371,7 @@
 @bind h5p_set_elink_prefix(plist_id::hid_t, prefix::Ptr{Cchar})::herr_t "Error in h5p_set_elink_prefix (not annotated)"
 @bind h5p_set_est_link_info(plist_id::hid_t, est_num_entries::Cuint, est_name_len::Cuint)::herr_t "Error in h5p_set_est_link_info (not annotated)"
 @bind h5p_set_evict_on_close(fapl_id::hid_t, evict_on_close::hbool_t)::herr_t "Error in h5p_set_evict_on_close (not annotated)"
-@bind h5p_set_external(plist_id::hid_t, name::Ptr{UInt8}, offset::off_t, size::Csize_t)::herr_t "Error setting external property"
+@bind h5p_set_external(plist_id::hid_t, name::Ptr{Cchar}, offset::off_t, size::hsize_t)::herr_t "Error setting external property"
 @bind h5p_set_family_offset(fapl_id::hid_t, offset::hsize_t)::herr_t "Error in h5p_set_family_offset (not annotated)"
 @bind h5p_set_fapl_core(fapl_id::hid_t, increment::Csize_t, backing_store::hbool_t)::herr_t "Error in h5p_set_fapl_core (not annotated)"
 @bind h5p_set_fapl_family(fapl_id::hid_t, memb_size::hsize_t, memb_fapl_id::hid_t)::herr_t "Error in h5p_set_fapl_family (not annotated)"

--- a/src/api/functions.jl
+++ b/src/api/functions.jl
@@ -3247,12 +3247,12 @@ function h5p_set_evict_on_close(fapl_id, evict_on_close)
 end
 
 """
-    h5p_set_external(plist_id::hid_t, name::Ptr{UInt8}, offset::off_t, size::Csize_t)
+    h5p_set_external(plist_id::hid_t, name::Ptr{Cchar}, offset::off_t, size::hsize_t)
 
 See `libhdf5` documentation for [`H5Pset_external`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_EXTERNAL).
 """
 function h5p_set_external(plist_id, name, offset, size)
-    var"#status#" = ccall((:H5Pset_external, libhdf5), herr_t, (hid_t, Ptr{UInt8}, off_t, Csize_t), plist_id, name, offset, size)
+    var"#status#" = ccall((:H5Pset_external, libhdf5), herr_t, (hid_t, Ptr{Cchar}, off_t, hsize_t), plist_id, name, offset, size)
     var"#status#" < 0 && @h5error("Error setting external property")
     return nothing
 end

--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -611,7 +611,9 @@ function h5p_get_external(plist, idx = 0)
         end
     end
     @static if Sys.iswindows() && sizeof(Int) == 4
-        sz[] &= 0xffffffff
+        lower = 0xffffffff & sz[]
+        upper = 0xffffffff & (sz[] >> 32)
+        sz[] = lower == 0 ? upper : lower
     end
     return (name = String(name), offset = offset[], size = sz[])
 end

--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -610,11 +610,6 @@ function h5p_get_external(plist, idx = 0)
             break
         end
     end
-    @static if Sys.iswindows() && sizeof(Int) == 4
-        lower = 0xffffffff & sz[]
-        upper = 0xffffffff & (sz[] >> 32)
-        sz[] = lower == 0 ? upper : lower
-    end
     return (name = String(name), offset = offset[], size = sz[])
 end
 

--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -610,10 +610,19 @@ function h5p_get_external(plist, idx = 0)
             break
         end
     end
+    # Heuristic for 32-bit Windows bug
+    # Possibly related:
+    # https://github.com/HDFGroup/hdf5/pull/1821
+    # Quote:
+    # The offset parameter is of type off_t and the offset field of H5O_efl_entry_t
+    # is HDoff_t which is a different type on Windows (off_t is a 32-bit long,
+    # HDoff_t is __int64, a 64-bit type).
     @static if Sys.iswindows() && sizeof(Int) == 4
         lower = 0xffffffff & sz[]
         upper = 0xffffffff & (sz[] >> 32)
-        sz[] = lower == 0 ? upper : lower
+        # Scenario 1: The size is in the lower 32 bits, upper 32 bits contains garbage v1.12.2
+        # Scenario 2: The size is in the upper 32 bits, lower 32 bits is 0 as of HDF5 v1.12.1
+        sz[] = lower == 0 && upper != 0xffffffff ? upper : lower
     end
     return (name = String(name), offset = offset[], size = sz[])
 end

--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -600,6 +600,7 @@ function h5p_get_external(plist, idx = 0)
     name = Base.StringVector(name_size)
     while true
         h5p_get_external(plist, idx, name_size, name, offset, sz)
+        @debug "looping..." offset[] sz[]
         null_id = findfirst(==(0x00), name)
         if isnothing(null_id)
             name_size *= 2

--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -600,7 +600,6 @@ function h5p_get_external(plist, idx = 0)
     name = Base.StringVector(name_size)
     while true
         h5p_get_external(plist, idx, name_size, name, offset, sz)
-        @info "looping..." offset[] sz[]
         null_id = findfirst(==(0x00), name)
         if isnothing(null_id)
             name_size *= 2
@@ -618,6 +617,7 @@ function h5p_get_external(plist, idx = 0)
     # is HDoff_t which is a different type on Windows (off_t is a 32-bit long,
     # HDoff_t is __int64, a 64-bit type).
     @static if Sys.iswindows() && sizeof(Int) == 4
+        @debug "h5p_get_external" offset[] sz[]
         lower = 0xffffffff & sz[]
         upper = 0xffffffff & (sz[] >> 32)
         # Scenario 1: The size is in the lower 32 bits, upper 32 bits contains garbage v1.12.2

--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -610,6 +610,11 @@ function h5p_get_external(plist, idx = 0)
             break
         end
     end
+    @static if Sys.iswindows() && sizeof(Int) == 4
+        lower = 0xffffffff & sz[]
+        upper = 0xffffffff & (sz[] >> 32)
+        sz[] = lower == 0 ? upper : lower
+    end
     return (name = String(name), offset = offset[], size = sz[])
 end
 

--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -600,7 +600,7 @@ function h5p_get_external(plist, idx = 0)
     name = Base.StringVector(name_size)
     while true
         h5p_get_external(plist, idx, name_size, name, offset, sz)
-        @debug "looping..." offset[] sz[]
+        @info "looping..." offset[] sz[]
         null_id = findfirst(==(0x00), name)
         if isnothing(null_id)
             name_size *= 2


### PR DESCRIPTION
Our API definition for `h5p_set_external` was wrong. `size` was `Csize_t` but should have been `hsize_t`. On 32-bit Windows, `Csize_t` is 32-bits while `hsize_t` is 64-bits.

Changing that did not fix the issue, however.

With the latest binaries it seems that the size is now shifted by 32 bits. Previously the upper 32 bits had garbage in it.

I suspect the issue is related to https://github.com/HDFGroup/hdf5/pull/1821

```julia
    @static if Sys.iswindows() && sizeof(Int) == 4
        lower = 0xffffffff & sz[]
        upper = 0xffffffff & (sz[] >> 32)
        sz[] = lower == 0 ? upper : lower
    end
```

Fix #996