### PR TITLE
enable tests for virtual datasets

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,6 +62,8 @@ end
     include("filters/FilterTestUtils.jl")
     @debug "objects"
     include("objects.jl")
+    @debug "virtual dataset"
+    include("virtual_dataset.jl")
 
     using MPI
     if HDF5.has_parallel()

--- a/test/virtual_dataset.jl
+++ b/test/virtual_dataset.jl
@@ -25,7 +25,7 @@ d = create_dataset(
     "x",
     datatype(Float64),
     vspace;
-    virtual=[HDF5.VirtualMapping(vspace, "./sub-%0b.hdf5", "x", srcspace)]
+    virtual=[HDF5.VirtualMapping(vspace, "./sub-%b.hdf5", "x", srcspace)]
 )
 
 @test size(d) == (3, 2)


### PR DESCRIPTION
From https://github.com/JuliaIO/HDF5.jl/pull/1012#discussion_r997583755, I had forgot to enable the tests.

It turns out the docs at https://portal.hdfgroup.org/display/HDF5/H5P_SET_VIRTUAL are wrong, the `%b` specifier does not take a dimension argument (at least none of the examples do, and it breaks if you attempt to add one).