### PR TITLE
Add JuliaFormatterTool and format.jl script

### DIFF
--- a/contrib/format/JuliaFormatterTool.jl
+++ b/contrib/format/JuliaFormatterTool.jl
@@ -1,0 +1,45 @@
+"""
+    JuliaFormatterTool
+
+Implements a script that runs a simple loop that runs `JuliaFormatter.format` on
+every iteration after the user presses enter.
+"""
+module JuliaFormatterTool
+
+export run_formatter_loop
+
+using JuliaFormatter
+
+# This tool lives in <repo>/contrib/format/, format <repo> by default
+const default_target_dir = joinpath(dirname(dirname(@__DIR__)))
+
+"""
+    run_formatter_loop(target_dir = $default_target_dir)
+
+This function runs a simple loop that runs `JuliaFormatter.format` on
+every iteration, every time the user presses enter.
+"""
+function run_formatter_loop(target_dir::AbstractString=default_target_dir)
+    printstyled("Welcome to Julia Formatter Tool!\n"; color=:cyan, bold=true)
+    printstyled("--------------------------------\n"; color=:cyan, bold=true)
+    let running::Bool = true
+        while running
+            println()
+            printstyled(
+                "Press enter to format the directory $target_dir or `q[enter]` to quit\n";
+                color=:light_cyan
+            )
+            printstyled("format.jl> "; color=:green, bold=true)
+            input = readline()
+            running = input != "q" && input != "quit" && !startswith(input, "exit")
+            if running
+                println("Applying JuliaFormatter...")
+                @info "Is the current directory formatted?" target_dir format(target_dir)
+            end
+        end
+        println("Thank you for formatting HDF5.jl. Have a nice day!")
+    end
+    return nothing
+end
+
+end # module JuliaFormatterTool

--- a/contrib/format/Project.toml
+++ b/contrib/format/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"

--- a/contrib/format/README.md
+++ b/contrib/format/README.md
@@ -1,0 +1,60 @@
+# JuliaFormatterTool
+
+## Purpose
+
+The purpose is this tool to aid in formatting the repository with JuliaFormatter.
+Rather than starting a fresh Julia session each time you want to format, this will
+run the formatter in a loop. Everytime you press enter, it will format the repository.
+This avoids the initial delay when starting and loading the JuliaFormatter package.
+
+The intended use of this program is to run in a separate terminal or be suspended
+(e.g. via Control-Z) while you edit the repository. Resume the program (e.g. `fg`)
+and press enter to format the repository before committing.
+
+## Invocation
+
+The format.jl script is meant to be executed directly.
+
+On POSIX systems that understand shebang lines the format.jl can be invoked as follows.
+```
+./contrib/format/format.jl
+```
+
+Supplying the file as an argument to `julia` also works.
+
+```
+julia contrib/format/format.jl
+```
+
+The script will automatically install itself by resolving and instantiating its environment.
+To bypass this install step, specify the project environment:
+
+```
+julia --project=contrib/format contrib/format.jl
+```
+
+## Example Usage
+
+```
+$ julia contrib/format/format.jl
+  Activating project at `~/.julia/dev/HDF5/contrib/format`
+  No Changes to `~/.julia/dev/HDF5/contrib/format/Project.toml`
+  No Changes to `~/.julia/dev/HDF5/contrib/format/Manifest.toml`
+
+Welcome to Julia Formatter Tool!
+--------------------------------
+
+Press enter to format the directory ~/.julia/dev/HDF5 or `q[enter]` to quit
+format.jl>
+Applying JuliaFormatter...
+┌ Info: Is the current directory formatted?
+│   target_dir = "~/.julia/dev/HDF5"
+└   format(target_dir) = true
+
+Press enter to format the directory ~/.julia/dev/HDF5 or `q[enter]` to quit
+format.jl>
+Applying JuliaFormatter...
+┌ Info: Is the current directory formatted?
+│   target_dir = "~/.julia/dev/HDF5"
+└   format(target_dir) = true
+```

--- a/contrib/format/format.jl
+++ b/contrib/format/format.jl
@@ -1,0 +1,25 @@
+#!/bin/env julia
+#
+# Runs JuliaFormatter on the repository
+# Invoke this script directly, `./contrib/format/format.jl`
+# or via `julia --project=contrib/format contrib/format/format.jl`
+
+# Install the project if not the current project environment
+if Base.active_project() != joinpath(@__DIR__, "Project.toml")
+    using Pkg
+    Pkg.activate(@__DIR__)
+    Pkg.resolve()
+    Pkg.instantiate()
+end
+
+include("JuliaFormatterTool.jl")
+
+using .JuliaFormatterTool
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    if length(ARGS) == 0
+        run_formatter_loop()
+    else
+        run_formatter_loop(ARGS[1])
+    end
+end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,7 +27,7 @@ makedocs(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://JuliaIO.github.io/HDF5.jl",
         assets=String[],
-        sidebar_sitename=false,
+        sidebar_sitename=false
     ),
     pages=[
         "Home" => "index.md",
@@ -41,10 +41,7 @@ makedocs(;
         ],
         "mpi.md",
         "Low-level library bindings" => "api_bindings.md",
-    ],
+    ]
 )
 
-deploydocs(;
-    repo="github.com/JuliaIO/HDF5.jl.git",
-    push_preview=true,
-)
+deploydocs(; repo="github.com/JuliaIO/HDF5.jl.git", push_preview=true)


### PR DESCRIPTION
This adds a utility script to make using JuliaFormatter easier. It runs `JuliaFormatter.format` in a loop after you press enter. That idea is that you run this on the side or suspended. When you format, just resume the program and press enter.

```
$ julia contrib/format/format.jl
  Activating project at `~/.julia/dev/HDF5/contrib/format`
  No Changes to `~/.julia/dev/HDF5/contrib/format/Project.toml`
  No Changes to `~/.julia/dev/HDF5/contrib/format/Manifest.toml`

Welcome to Julia Formatter Tool!
--------------------------------

Press enter to format the directory ~/.julia/dev/HDF5 or `q[enter]` to quit
format.jl>
Applying JuliaFormatter...
┌ Info: Is the current directory formatted?
│   target_dir = "~/.julia/dev/HDF5"
└   format(target_dir) = true

Press enter to format the directory ~/.julia/dev/HDF5 or `q[enter]` to quit
format.jl>
Applying JuliaFormatter...
┌ Info: Is the current directory formatted?
│   target_dir = "~/.julia/dev/HDF5"
└   format(target_dir) = true
```