### PR TITLE
Remove use of `tempname()` from `setindex!` of an `AttributeDict`

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -250,17 +250,8 @@ end
 function Base.setindex!(attrdict::AttributeDict, val, name::AbstractString)
     if haskey(attrdict, name)
         # in case of an error, we write first to a temporary, then rename
-        max_tries = 100 # number of times to try making a new name
-        _name = nothing
-        for i in 1:max_tries
-            _name = "-><7;*<_NY"*bytes2hex(rand(UInt8, 16))
-            if haskey(attrdict, _name)
-                _name = nothing
-            else
-                break
-            end
-        end
-        isnothing(_name) && error("tempname: max_tries exhausted")
+        _name = "-><7;*<_NY"*bytes2hex(rand(UInt8, 16))
+        haskey(attrdict, _name) && error("`attrdict` has the temp name somehow")
         try
             write_attribute(attrdict.parent, _name, val)
             delete_attribute(attrdict.parent, name)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -250,7 +250,7 @@ end
 function Base.setindex!(attrdict::AttributeDict, val, name::AbstractString)
     if haskey(attrdict, name)
         # in case of an error, we write first to a temporary, then rename
-        _name = "-><7;*<_NY" * bytes2hex(rand(UInt8, 16))
+        _name = "-><7;*<_NY" * bytes2hex(rand(Random.RandomDevice(), UInt8, 16))
         haskey(attrdict, _name) && error("`attrdict` has the temp name somehow")
         try
             write_attribute(attrdict.parent, _name, val)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -253,7 +253,7 @@ function Base.setindex!(attrdict::AttributeDict, val, name::AbstractString)
         max_tries = 100 # number of times to try making a new name
         _name = nothing
         for i in 1:max_tries
-            _name = bytes2hex(rand(UInt8, 16))
+            _name = "-><7;*<_NY"*bytes2hex(rand(UInt8, 16))
             if haskey(attrdict, _name)
                 _name = nothing
             else

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -253,7 +253,7 @@ function Base.setindex!(attrdict::AttributeDict, val, name::AbstractString)
         max_tries = 100 # number of times to try making a new name
         _name = nothing
         for i in 1:max_tries
-            _name = bytes2hex(reinterpret(UInt8,[Libc.rand() for i in 1:3]))
+            _name = bytes2hex(rand(UInt8, 16))
             if haskey(attrdict, _name)
                 _name = nothing
             else

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -250,7 +250,7 @@ end
 function Base.setindex!(attrdict::AttributeDict, val, name::AbstractString)
     if haskey(attrdict, name)
         # in case of an error, we write first to a temporary, then rename
-        _name = "-><7;*<_NY"*bytes2hex(rand(UInt8, 16))
+        _name = "-><7;*<_NY" * bytes2hex(rand(UInt8, 16))
         haskey(attrdict, _name) && error("`attrdict` has the temp name somehow")
         try
             write_attribute(attrdict.parent, _name, val)


### PR DESCRIPTION
Currently `setindex!` uses `tempname()` to get a random unique name for a temporary attribute. However, `tempname()` is quite slow and requires reading the file system to check if the names it generates are unique. In this PR I am replacing `tempname()` with `"-><7;*<_NY" * bytes2hex(rand(Random.RandomDevice(), UInt8, 16))`



```julia
julia> randname1() = "-><7;*<_NY" * bytes2hex(rand(Random.RandomDevice(), UInt8, 16))
randname1 (generic function with 1 method)

julia> randname2() = tempname()
randname2 (generic function with 1 method)

julia> @btime randname1()
  256.557 ns (4 allocations: 264 bytes)
"-><7;*<_NY2390f39a585aec3b0caac0f127a0a83a"

julia> @btime randname2()
  2.085 μs (9 allocations: 1.22 KiB)
"/tmp/jl_yjyjMTO1uh"

```