### PR TITLE
Make `begin` as the first index of a `Dataset` work

### DIFF
--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -310,6 +310,7 @@ Base.write(parent::Union{File,Group}, name::Union{AbstractString,Nothing}, data;
 
 Base.eachindex(::IndexLinear, A::Dataset) = Base.OneTo(length(A))
 Base.axes(dset::Dataset) = map(Base.OneTo, size(dset))
+Base.axes(dset::Dataset, d::Integer) = Base.OneTo(size(dset, d))
 
 # Write to a subset of a dataset using array slices: dataset[:,:,10] = array
 

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -131,6 +131,7 @@ Base.flush(ds::Dataset) = API.h5d_flush(checkvalid(ds))
 # Array constructor for datasets
 Base.Array(x::Dataset) = read(x)
 
+# The next two lines are kept for v"1.4" <= VERSION <= v"1.5"
 Base.lastindex(dset::Dataset) = length(dset)
 Base.lastindex(dset::Dataset, d::Int) = size(dset, d)
 

--- a/test/extend_test.jl
+++ b/test/extend_test.jl
@@ -23,7 +23,11 @@ using Test
     @test d[1, end] ≈ 4.1231
     @test d[:, end] ≈ [4.1231]
     @test d[end, :] == [1.1231, 1.313, 5.123, 2.231, 4.1231]
+    @test d[1, begin] ≈ 1.1231
+    @test d[:, begin] ≈ [1.1231]
+    @test d[begin, :] == [1.1231, 1.313, 5.123, 2.231, 4.1231]
     @test d[:, :] == [1.1231 1.313 5.123 2.231 4.1231]
+    @test d[:, begin:end] == [1.1231 1.313 5.123 2.231 4.1231]
 
     # Test all integer types work
     @test d[UInt8(1), UInt16(1)] == 1.1231

--- a/test/extend_test.jl
+++ b/test/extend_test.jl
@@ -23,11 +23,14 @@ using Test
     @test d[1, end] ≈ 4.1231
     @test d[:, end] ≈ [4.1231]
     @test d[end, :] == [1.1231, 1.313, 5.123, 2.231, 4.1231]
-    @test d[1, begin] ≈ 1.1231
-    @test d[:, begin] ≈ [1.1231]
-    @test d[begin, :] == [1.1231, 1.313, 5.123, 2.231, 4.1231]
     @test d[:, :] == [1.1231 1.313 5.123 2.231 4.1231]
-    @test d[:, begin:end] == [1.1231 1.313 5.123 2.231 4.1231]
+
+    @static if VERSION >= v"1.4"
+        @test d[1, begin] ≈ 1.1231
+        @test d[:, begin] ≈ [1.1231]
+        @test d[begin, :] == [1.1231, 1.313, 5.123, 2.231, 4.1231]
+        @test d[:, begin:end] == [1.1231 1.313 5.123 2.231 4.1231]
+    end
 
     # Test all integer types work
     @test d[UInt8(1), UInt16(1)] == 1.1231

--- a/test/extend_test.jl
+++ b/test/extend_test.jl
@@ -25,11 +25,9 @@ using Test
     @test d[end, :] == [1.1231, 1.313, 5.123, 2.231, 4.1231]
     @test d[:, :] == [1.1231 1.313 5.123 2.231 4.1231]
 
-    @static if VERSION >= v"1.4"
-        @test d[1, begin] ≈ 1.1231
-        @test d[:, begin] ≈ [1.1231]
-        @test d[begin, :] == [1.1231, 1.313, 5.123, 2.231, 4.1231]
-        @test d[:, begin:end] == [1.1231 1.313 5.123 2.231 4.1231]
+    if VERSION >= v"1.4"
+        include("extend_test_begin.jl")
+        extend_test_begin(d)
     end
 
     # Test all integer types work

--- a/test/extend_test_begin.jl
+++ b/test/extend_test_begin.jl
@@ -1,0 +1,6 @@
+function extend_test_begin(d)
+    @test d[1, begin] ≈ 1.1231
+    @test d[:, begin] ≈ [1.1231]
+    @test d[begin, :] == [1.1231, 1.313, 5.123, 2.231, 4.1231]
+    @test d[:, begin:end] == [1.1231 1.313 5.123 2.231 4.1231]
+end


### PR DESCRIPTION
Consider that `d` is a `Dataset` with two dimensions. Currently, `d[:, end]` works, however, `d[:, begin]` doesn't. This PR intended to make the latter work.

```julia
using HDF5
fn = tempname()
fid = h5open(fn, "w")
g = create_group(fid, "foo")
d = create_dataset(g, "bar", Int, (1, 3))
d[1, 1:3] = 1:3

@show d[1, end]  # OK
@show d[1, begin] # Error
```

The error message is:
```
MethodError: no method matching axes(::HDF5.Dataset, ::Int64)
Closest candidates are:
  axes(::Base.Broadcast.Broadcasted{<:Any, <:Tuple{Vararg{T, N}} where T}, ::Integer) where N at broadcast.jl:227
  axes(::Number, ::Integer) at number.jl:83
  axes(::AbstractArray{T, N}, ::Any) where {T, N} at abstractarray.jl:72
  ...

Stacktrace:
 [1] firstindex(a::HDF5.Dataset, d::Int64)
   @ Base .\abstractarray.jl:402
 [2] top-level scope
   @ show.jl:1047
 [3] eval
   @ .\boot.jl:368 [inlined]
 [4] include_string(mapexpr::typeof(REPL.softscope), mod::Module, code::String, filename::String)
   @ Base .\loading.jl:1428
```
