### PR TITLE
fix invalidations from loading LoopVectorization.jl

### DIFF
--- a/src/properties.jl
+++ b/src/properties.jl
@@ -761,7 +761,7 @@ function class_setproperty!(::Type{FileAccessProperties}, p::Properties, name::S
     name === :libver_bounds ? set_libver_bounds!(p, val) :
     name === :meta_block_size ? API.h5p_set_meta_block_size(p, val) :
     # deprecated
-    name === :fapl_mpio     ? (depwarn("The `fapl_mpio` property is deprecated, use `driver=HDF5.Drivers.MPIO(...)` instead.", :fapl_mpio); p.driver = Drivers.MPIO(val...)) :
+    name === :fapl_mpio     ? (depwarn("The `fapl_mpio` property is deprecated, use `driver=HDF5.Drivers.MPIO(...)` instead.", :fapl_mpio); Drivers.set_driver!(p, Drivers.MPIO(val...))) :
     class_setproperty!(superclass(FileAccessProperties), p, name, val)
 end
 


### PR DESCRIPTION
I fixed some invalidations in HDF5.jl caused by loading LoopVectorization.jl.

With the current version of `master` and Julia v1.8.3:
```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.develop("HDF5"); Pkg.add("LoopVectorization")

julia> using SnoopCompileCore; invalidations = @snoopr(using HDF5, LoopVectorization); using SnoopCompile

julia> length(uinvalidated(invalidations))
597

julia> trees = invalidation_trees(invalidations);

julia> root = trees[end-1]
inserting convert(::Type{T}, i::LoopVectorization.UpperBoundedInteger) where T<:Number in LoopVectorization at /afs/math.uni-hamburg.de/users/am/bbb3094/.julia/packages/LoopVectorization/dniw3/src/reconstruct_loopset.jl:25 invalidated:
   backedges: 1: superseding convert(::Type{T}, x::Number) where T<:Number in Base at number.jl:7 with MethodInstance for convert(::Type{UInt64}, ::Integer) (2 children)
              2: superseding convert(::Type{T}, x::Number) where T<:Number in Base at number.jl:7 with MethodInstance for convert(::Type{Int64}, ::Integer) (4 children)
              3: superseding convert(::Type{T}, x::Number) where T<:Number in Base at number.jl:7 with MethodInstance for convert(::Type{Int32}, ::Integer) (100 children)

julia> ascend(root.backedges[end])
Choose a call for analysis (q to quit):
 >   convert(::Type{Int32}, ::Integer)
       h5p_set_fclose_degree(::HDF5.FileAccessProperties, ::Integer)
         set_fclose_degree!(::HDF5.FileAccessProperties, ::Integer)
           class_setproperty!(::Type{HDF5.FileAccessProperties}, ::HDF5.FileAccessProperties, ::Symbol, ::Any)
             setproperty!(::HDF5.FileAccessProperties, ::Symbol, ::Any)
               class_setproperty!(::Type{HDF5.FileAccessProperties}, ::HDF5.FileAccessProperties, ::Symbol, ::Int64)
                 setproperty!(::HDF5.FileAccessProperties, ::Symbol, ::Int64)
                   init!(::HDF5.FileAccessProperties)
                     init!(::HDF5.FileAccessProperties)
```

This PR:
```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.develop("HDF5"); Pkg.add("LoopVectorization")

julia> using SnoopCompileCore; invalidations = @snoopr(using HDF5, LoopVectorization); using SnoopCompile

julia> length(uinvalidated(invalidations))
538
```
and the invalidations shown above in ascend(root.backedges[end])` are gone.

It looks like Julia was not able to handle the self-recursive nature of the calls efficiently to figure everything out.