### PR TITLE
Bump H5Zblosc version to 0.1.1

### DIFF
--- a/filters/H5Zblosc/Project.toml
+++ b/filters/H5Zblosc/Project.toml
@@ -1,6 +1,6 @@
 name = "H5Zblosc"
 uuid = "c8ec2601-a99c-407f-b158-e79c03c2f5f7"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Blosc = "a74b3585-a348-5f62-a45c-50e91977d574"


### PR DESCRIPTION
H5Zblosc was last update in January 2022, there have been updates since then