### PR TITLE
link via doxygen tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.jl.cov
 *.jl.mem
 /docs/build/
+/docs/hdf5.tag
 Manifest.toml

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.1"
+julia_version = "1.8.5"
 manifest_format = "2.0"
-project_hash = "e94d95fb1b4f03e9e3c44e30f01c0f513a685f9e"
+project_hash = "b6a401ec252f2bd6b09c1862ed4643c18620cbfa"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
@@ -69,7 +69,7 @@ version = "3.41.0"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "0.5.2+0"
+version = "1.0.1+0"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -99,6 +99,12 @@ version = "0.27.12"
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 version = "1.6.0"
+
+[[deps.EzXML]]
+deps = ["Printf", "XML2_jll"]
+git-tree-sha1 = "0fa3b52a04a4e210aeb1626def9c90df3ae65268"
+uuid = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
+version = "1.1.0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
@@ -186,6 +192,12 @@ version = "1.10.2+0"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "c7cb1f5d892775ba13767a87c7ada0b980ea0a71"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.16.1+2"
 
 [[deps.LinearAlgebra]]
 deps = ["Libdl", "libblastrampoline_jll"]
@@ -320,7 +332,7 @@ version = "1.0.0"
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
-version = "1.10.0"
+version = "1.10.1"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
@@ -338,6 +350,12 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.XML2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "93c41695bc1c08c46c5899f4fe06d6ead504bb73"
+uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
+version = "2.10.3+0"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 H5Zblosc = "c8ec2601-a99c-407f-b158-e79c03c2f5f7"
 H5Zbzip2 = "094576f2-1e46-4c84-8e32-c46c042eaaa2"
 H5Zlz4 = "eb20ec05-5464-47b5-ba41-098e3c1068a3"

--- a/docs/doxygen.jl
+++ b/docs/doxygen.jl
@@ -1,0 +1,105 @@
+using EzXML, Documenter, Markdown, Downloads
+
+
+const ver = "v1_14"
+const baseurl = "https://docs.hdfgroup.org/hdf5/$ver"
+const tagfile = joinpath(@__DIR__,"hdf5.tag")
+Downloads.download("$baseurl/hdf5.tag", tagfile)
+const tagdoc = readxml(tagfile)
+
+#=
+
+findall("/tagfile/compound/member[name='H5FD_mpio_init']", tagdoc)
+findall("/tagfile/compound/member[name='H5Pset_driver']", tagdoc)[2]))
+findall("/tagfile/compound[@kind='group']/member[name='H5Pset_driver']", tagdoc)
+findall("/tagfile/compound[name='FAPL']/member[name='H5Pget_driver']", tagdoc)
+findall("/tagfile/compound[title='The HDF5 Data Model and File Structure']/docanchor[@title='Group']", tagdoc)
+
+=#
+
+function doxygen_url(node)
+    baseurl = "https://docs.hdfgroup.org/hdf5/v1_14"
+    if node.name == "compound"
+        filename = findfirst("filename", node).content
+        anchor = nothing
+    elseif node.name == "member"
+        filename = findfirst("anchorfile", node).content
+        anchor = findfirst("anchor", node).content
+    elseif node.name == "docanchor"
+        filename = findfirst("@file",node).content
+        anchor = node.content
+    else
+        error("invalid node")
+    end
+    if isnothing(anchor)
+        return "$baseurl/$filename"
+    else
+        return "$baseurl/$filename#$anchor"
+    end
+end
+
+function doxygen_title(node)
+    if node.name == "compound"
+        return [
+            Markdown.Italic([findfirst("title", node).content]),
+            " in HDF5 documentation",
+            ]
+    elseif node.name == "member"
+        name = findfirst("name", node).content
+        return [
+            Markdown.Code(name),
+            " in HDF5 documentation",
+            ]
+    elseif node.name == "docanchor"
+        return [
+            Markdown.Italic([findfirst("../title", node).content]),
+            " - ",
+            Markdown.Italic([findfirst("@title", node).content]),
+            " in HDF5 documentation",
+            ]
+    else
+        error("invalid node")
+    end
+end
+
+abstract type DoxygenLinker <: Documenter.Builder.DocumentPipeline end
+
+Documenter.Selectors.order(::Type{DoxygenLinker}) = 3.1  # After cross-references
+
+function Documenter.Selectors.runner(::Type{DoxygenLinker}, doc::Documenter.Documents.Document)
+    @info "DoxygenLinker: expanding links"
+    for (src, page) in doc.blueprint.pages
+        empty!(page.globals.meta)
+        for expanded in values(page.mapping)
+            expand_doxygen(expanded, page, doc)
+        end
+    end
+end
+
+function expand_doxygen(elem, page, doc)
+    Documenter.Documents.walk(page.globals.meta, elem) do link
+        expand_doxygen(link, page.globals.meta, page, doc)
+    end
+end
+
+function expand_doxygen(link::Markdown.Link, meta, page, doc)
+    startswith(link.url, "@doxygen ") || return false
+    xpath = chopprefix(link.url, "@doxygen ")
+
+    nodes = findall(xpath, tagdoc)
+    if length(nodes) == 0
+        @warn "DoxygenLinker: cannot find node at $xpath"
+        return false
+    elseif length(nodes) > 1
+        @warn "DoxygenLinker: multiple nodes matching $xpath"
+    end
+    node = first(nodes)
+
+    link.url = doxygen_url(node)
+    if isempty(link.text)
+        link.text = doxygen_title(node)
+    end
+    return true
+end
+
+expand_doxygen(other, meta, page, doc) = true # Continue to `walk` through element `other`.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,8 @@ using H5Zlz4
 using H5Zzstd
 using MPI  # needed to generate docs for parallel HDF5 API
 
+include("doxygen.jl")
+
 # Used in index.md to filter the autodocs list
 not_low_level_api(m::Method) = !endswith(String(m.file), "src/api.jl")
 not_low_level_api(f::Function) = all(not_low_level_api, methods(f))

--- a/gen/bind_generator.jl
+++ b/gen/bind_generator.jl
@@ -230,9 +230,9 @@ function _bind(__module__, __source__, sig::Expr, err::Union{String,Expr,Nothing
             "See `libhdf5` documentation for [`H5Pget_driver`]" *
             "(https://portal.hdfgroup.org/display/HDF5/H5P_GET_DRIVER).\n"
     else
+        groupname = uppercase(prefix)
         docstr *=
-            "\n\nSee `libhdf5` documentation for [`$cfuncname`]" *
-            "(https://portal.hdfgroup.org/display/HDF5/$(uppercase(string(funcsig.args[1])))).\n"
+            "\n\n# External links\n\n- [](@doxygen /tagfile/compound[name='$groupname']/member[name='$cfuncname']).\n"
     end
     # Then assemble the pieces. Doing it through explicit Expr() objects
     # avoids inserting the line number nodes for the macro --- the call site

--- a/src/api/functions.jl
+++ b/src/api/functions.jl
@@ -14,7 +14,9 @@ _libhdf5_build_ver = let
 """
     h5_close()
 
-See `libhdf5` documentation for [`H5close`](https://portal.hdfgroup.org/display/HDF5/H5_CLOSE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5']/member[name='H5close']).
 """
 function h5_close()
     lock(liblock)
@@ -30,7 +32,9 @@ end
 """
     h5_dont_atexit()
 
-See `libhdf5` documentation for [`H5dont_atexit`](https://portal.hdfgroup.org/display/HDF5/H5_DONT_ATEXIT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5']/member[name='H5dont_atexit']).
 """
 function h5_dont_atexit()
     lock(liblock)
@@ -46,7 +50,9 @@ end
 """
     h5_free_memory(buf::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5free_memory`](https://portal.hdfgroup.org/display/HDF5/H5_FREE_MEMORY).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5']/member[name='H5free_memory']).
 """
 function h5_free_memory(buf)
     lock(liblock)
@@ -62,7 +68,9 @@ end
 """
     h5_garbage_collect()
 
-See `libhdf5` documentation for [`H5garbage_collect`](https://portal.hdfgroup.org/display/HDF5/H5_GARBAGE_COLLECT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5']/member[name='H5garbage_collect']).
 """
 function h5_garbage_collect()
     lock(liblock)
@@ -78,7 +86,9 @@ end
 """
     h5_get_libversion(majnum::Ref{Cuint}, minnum::Ref{Cuint}, relnum::Ref{Cuint})
 
-See `libhdf5` documentation for [`H5get_libversion`](https://portal.hdfgroup.org/display/HDF5/H5_GET_LIBVERSION).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5']/member[name='H5get_libversion']).
 """
 function h5_get_libversion(majnum, minnum, relnum)
     lock(liblock)
@@ -94,7 +104,9 @@ end
 """
     h5_is_library_threadsafe(is_ts::Ref{Cuint})
 
-See `libhdf5` documentation for [`H5is_library_threadsafe`](https://portal.hdfgroup.org/display/HDF5/H5_IS_LIBRARY_THREADSAFE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5']/member[name='H5is_library_threadsafe']).
 """
 function h5_is_library_threadsafe(is_ts)
     lock(liblock)
@@ -110,7 +122,9 @@ end
 """
     h5_open()
 
-See `libhdf5` documentation for [`H5open`](https://portal.hdfgroup.org/display/HDF5/H5_OPEN).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5']/member[name='H5open']).
 """
 function h5_open()
     lock(liblock)
@@ -126,7 +140,9 @@ end
 """
     h5_set_free_list_limits(reg_global_lim::Cint, reg_list_lim::Cint, arr_global_lim::Cint, arr_list_lim::Cint, blk_global_lim::Cint, blk_list_lim::Cint)
 
-See `libhdf5` documentation for [`H5set_free_list_limits`](https://portal.hdfgroup.org/display/HDF5/H5_SET_FREE_LIST_LIMITS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5']/member[name='H5set_free_list_limits']).
 """
 function h5_set_free_list_limits(reg_global_lim, reg_list_lim, arr_global_lim, arr_list_lim, blk_global_lim, blk_list_lim)
     lock(liblock)
@@ -142,7 +158,9 @@ end
 """
     h5a_close(id::hid_t)
 
-See `libhdf5` documentation for [`H5Aclose`](https://portal.hdfgroup.org/display/HDF5/H5A_CLOSE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Aclose']).
 """
 function h5a_close(id)
     lock(liblock)
@@ -158,7 +176,9 @@ end
 """
     h5a_create(loc_id::hid_t, attr_name::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Acreate2`](https://portal.hdfgroup.org/display/HDF5/H5A_CREATE2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Acreate2']).
 """
 function h5a_create(loc_id, attr_name, type_id, space_id, acpl_id, aapl_id)
     lock(liblock)
@@ -174,7 +194,9 @@ end
 """
     h5a_create_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t, lapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Acreate_by_name`](https://portal.hdfgroup.org/display/HDF5/H5A_CREATE_BY_NAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Acreate_by_name']).
 """
 function h5a_create_by_name(loc_id, obj_name, attr_name, type_id, space_id, acpl_id, aapl_id, lapl_id)
     lock(liblock)
@@ -190,7 +212,9 @@ end
 """
     h5a_delete(loc_id::hid_t, attr_name::Ptr{UInt8})
 
-See `libhdf5` documentation for [`H5Adelete`](https://portal.hdfgroup.org/display/HDF5/H5A_DELETE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Adelete']).
 """
 function h5a_delete(loc_id, attr_name)
     lock(liblock)
@@ -206,7 +230,9 @@ end
 """
     h5a_delete_by_idx(loc_id::hid_t, obj_name::Ptr{UInt8}, idx_type::Cint, order::Cint, n::hsize_t, lapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Adelete_by_idx`](https://portal.hdfgroup.org/display/HDF5/H5A_DELETE_BY_IDX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Adelete_by_idx']).
 """
 function h5a_delete_by_idx(loc_id, obj_name, idx_type, order, n, lapl_id)
     lock(liblock)
@@ -222,7 +248,9 @@ end
 """
     h5a_delete_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, lapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Adelete_by_name`](https://portal.hdfgroup.org/display/HDF5/H5A_DELETE_BY_NAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Adelete_by_name']).
 """
 function h5a_delete_by_name(loc_id, obj_name, attr_name, lapl_id)
     lock(liblock)
@@ -238,7 +266,9 @@ end
 """
     h5a_exists(obj_id::hid_t, attr_name::Ptr{UInt8}) -> Bool
 
-See `libhdf5` documentation for [`H5Aexists`](https://portal.hdfgroup.org/display/HDF5/H5A_EXISTS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Aexists']).
 """
 function h5a_exists(obj_id, attr_name)
     lock(liblock)
@@ -254,7 +284,9 @@ end
 """
     h5a_exists_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, lapl_id::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Aexists_by_name`](https://portal.hdfgroup.org/display/HDF5/H5A_EXISTS_BY_NAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Aexists_by_name']).
 """
 function h5a_exists_by_name(loc_id, obj_name, attr_name, lapl_id)
     lock(liblock)
@@ -270,7 +302,9 @@ end
 """
     h5a_get_create_plist(attr_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Aget_create_plist`](https://portal.hdfgroup.org/display/HDF5/H5A_GET_CREATE_PLIST).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Aget_create_plist']).
 """
 function h5a_get_create_plist(attr_id)
     lock(liblock)
@@ -286,7 +320,9 @@ end
 """
     h5a_get_name(attr_id::hid_t, buf_size::Csize_t, buf::Ptr{UInt8}) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Aget_name`](https://portal.hdfgroup.org/display/HDF5/H5A_GET_NAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Aget_name']).
 """
 function h5a_get_name(attr_id, buf_size, buf)
     lock(liblock)
@@ -302,7 +338,9 @@ end
 """
     h5a_get_name_by_idx(loc_id::hid_t, obj_name::Cstring, index_type::Cint, order::Cint, idx::hsize_t, name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Aget_name_by_idx`](https://portal.hdfgroup.org/display/HDF5/H5A_GET_NAME_BY_IDX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Aget_name_by_idx']).
 """
 function h5a_get_name_by_idx(loc_id, obj_name, index_type, order, idx, name, size, lapl_id)
     lock(liblock)
@@ -318,7 +356,9 @@ end
 """
     h5a_get_space(attr_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Aget_space`](https://portal.hdfgroup.org/display/HDF5/H5A_GET_SPACE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Aget_space']).
 """
 function h5a_get_space(attr_id)
     lock(liblock)
@@ -334,7 +374,9 @@ end
 """
     h5a_get_type(attr_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Aget_type`](https://portal.hdfgroup.org/display/HDF5/H5A_GET_TYPE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Aget_type']).
 """
 function h5a_get_type(attr_id)
     lock(liblock)
@@ -350,7 +392,9 @@ end
 """
     h5a_iterate(obj_id::hid_t, idx_type::Cint, order::Cint, n::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Any)
 
-See `libhdf5` documentation for [`H5Aiterate2`](https://portal.hdfgroup.org/display/HDF5/H5A_ITERATE2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Aiterate2']).
 """
 function h5a_iterate(obj_id, idx_type, order, n, op, op_data)
     lock(liblock)
@@ -366,7 +410,9 @@ end
 """
     h5a_open(obj_id::hid_t, attr_name::Ptr{UInt8}, aapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Aopen`](https://portal.hdfgroup.org/display/HDF5/H5A_OPEN).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Aopen']).
 """
 function h5a_open(obj_id, attr_name, aapl_id)
     lock(liblock)
@@ -382,7 +428,9 @@ end
 """
     h5a_open_by_idx(obj_id::hid_t, pathname::Ptr{UInt8}, idx_type::Cint, order::Cint, n::hsize_t, aapl_id::hid_t, lapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Aopen_by_idx`](https://portal.hdfgroup.org/display/HDF5/H5A_OPEN_BY_IDX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Aopen_by_idx']).
 """
 function h5a_open_by_idx(obj_id, pathname, idx_type, order, n, aapl_id, lapl_id)
     lock(liblock)
@@ -398,7 +446,9 @@ end
 """
     h5a_read(attr_id::hid_t, mem_type_id::hid_t, buf::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Aread`](https://portal.hdfgroup.org/display/HDF5/H5A_READ).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Aread']).
 """
 function h5a_read(attr_id, mem_type_id, buf)
     lock(liblock)
@@ -414,7 +464,9 @@ end
 """
     h5a_rename(loc_id::hid_t, old_attr_name::Cstring, new_attr_name::Cstring)
 
-See `libhdf5` documentation for [`H5Arename`](https://portal.hdfgroup.org/display/HDF5/H5A_RENAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Arename']).
 """
 function h5a_rename(loc_id, old_attr_name, new_attr_name)
     lock(liblock)
@@ -430,7 +482,9 @@ end
 """
     h5a_write(attr_hid::hid_t, mem_type_id::hid_t, buf::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Awrite`](https://portal.hdfgroup.org/display/HDF5/H5A_WRITE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5A']/member[name='H5Awrite']).
 """
 function h5a_write(attr_hid, mem_type_id, buf)
     lock(liblock)
@@ -446,7 +500,9 @@ end
 """
     h5d_close(dataset_id::hid_t)
 
-See `libhdf5` documentation for [`H5Dclose`](https://portal.hdfgroup.org/display/HDF5/H5D_CLOSE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dclose']).
 """
 function h5d_close(dataset_id)
     lock(liblock)
@@ -462,7 +518,9 @@ end
 """
     h5d_create(loc_id::hid_t, pathname::Ptr{UInt8}, dtype_id::hid_t, space_id::hid_t, lcpl_id::hid_t, dcpl_id::hid_t, dapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Dcreate2`](https://portal.hdfgroup.org/display/HDF5/H5D_CREATE2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dcreate2']).
 """
 function h5d_create(loc_id, pathname, dtype_id, space_id, lcpl_id, dcpl_id, dapl_id)
     lock(liblock)
@@ -478,7 +536,9 @@ end
 """
     h5d_create_anon(loc_id::hid_t, type_id::hid_t, space_id::hid_t, dcpl_id::hid_t, dapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Dcreate_anon`](https://portal.hdfgroup.org/display/HDF5/H5D_CREATE_ANON).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dcreate_anon']).
 """
 function h5d_create_anon(loc_id, type_id, space_id, dcpl_id, dapl_id)
     lock(liblock)
@@ -494,7 +554,9 @@ end
 """
     h5d_extend(dataset_id::hid_t, size::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Dextend`](https://portal.hdfgroup.org/display/HDF5/H5D_EXTEND).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dextend']).
 """
 function h5d_extend(dataset_id, size)
     lock(liblock)
@@ -510,7 +572,9 @@ end
 """
     h5d_fill(fill::Ptr{Cvoid}, fill_type_id::hid_t, buf::Ptr{Cvoid}, buf_type_id::hid_t, space_id::hid_t)
 
-See `libhdf5` documentation for [`H5Dfill`](https://portal.hdfgroup.org/display/HDF5/H5D_FILL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dfill']).
 """
 function h5d_fill(fill, fill_type_id, buf, buf_type_id, space_id)
     lock(liblock)
@@ -526,7 +590,9 @@ end
 """
     h5d_flush(dataset_id::hid_t)
 
-See `libhdf5` documentation for [`H5Dflush`](https://portal.hdfgroup.org/display/HDF5/H5D_FLUSH).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dflush']).
 """
 function h5d_flush(dataset_id)
     lock(liblock)
@@ -542,7 +608,9 @@ end
 """
     h5d_gather(src_space_id::hid_t, src_buf::Ptr{Cvoid}, type_id::hid_t, dst_buf_size::Csize_t, dst_buf::Ptr{Cvoid}, op::Ptr{Cvoid}, op_data::Any)
 
-See `libhdf5` documentation for [`H5Dgather`](https://portal.hdfgroup.org/display/HDF5/H5D_GATHER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dgather']).
 """
 function h5d_gather(src_space_id, src_buf, type_id, dst_buf_size, dst_buf, op, op_data)
     lock(liblock)
@@ -558,7 +626,9 @@ end
 """
     h5d_get_access_plist(dataset_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Dget_access_plist`](https://portal.hdfgroup.org/display/HDF5/H5D_GET_ACCESS_PLIST).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dget_access_plist']).
 """
 function h5d_get_access_plist(dataset_id)
     lock(liblock)
@@ -574,7 +644,9 @@ end
 """
     h5d_get_chunk_info(dataset_id::hid_t, fspace_id::hid_t, index::hsize_t, offset::Ptr{hsize_t}, filter_mask::Ptr{Cuint}, addr::Ptr{haddr_t}, size::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Dget_chunk_info`](https://portal.hdfgroup.org/display/HDF5/H5D_GET_CHUNK_INFO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dget_chunk_info']).
 """
 function h5d_get_chunk_info(dataset_id, fspace_id, index, offset, filter_mask, addr, size)
     lock(liblock)
@@ -591,7 +663,9 @@ end
     @doc """
         h5d_get_chunk_info_by_coord(dataset_id::hid_t, offset::Ptr{hsize_t}, filter_mask::Ptr{Cuint}, addr::Ptr{haddr_t}, size::Ptr{hsize_t})
 
-    See `libhdf5` documentation for [`H5Dget_chunk_info_by_coord`](https://portal.hdfgroup.org/display/HDF5/H5D_GET_CHUNK_INFO_BY_COORD).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dget_chunk_info_by_coord']).
     """
     function h5d_get_chunk_info_by_coord(dataset_id, offset, filter_mask, addr, size)
         lock(liblock)
@@ -608,7 +682,9 @@ end
 """
     h5d_get_chunk_storage_size(dataset_id::hid_t, offset::Ptr{hsize_t}, chunk_nbytes::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Dget_chunk_storage_size`](https://portal.hdfgroup.org/display/HDF5/H5D_GET_CHUNK_STORAGE_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dget_chunk_storage_size']).
 """
 function h5d_get_chunk_storage_size(dataset_id, offset, chunk_nbytes)
     lock(liblock)
@@ -624,7 +700,9 @@ end
 """
     h5d_get_create_plist(dataset_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Dget_create_plist`](https://portal.hdfgroup.org/display/HDF5/H5D_GET_CREATE_PLIST).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dget_create_plist']).
 """
 function h5d_get_create_plist(dataset_id)
     lock(liblock)
@@ -641,7 +719,9 @@ end
     @doc """
         h5d_get_num_chunks(dataset_id::hid_t, fspace_id::hid_t, nchunks::Ptr{hsize_t})
 
-    See `libhdf5` documentation for [`H5Dget_num_chunks`](https://portal.hdfgroup.org/display/HDF5/H5D_GET_NUM_CHUNKS).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dget_num_chunks']).
     """
     function h5d_get_num_chunks(dataset_id, fspace_id, nchunks)
         lock(liblock)
@@ -658,7 +738,9 @@ end
 """
     h5d_get_offset(dataset_id::hid_t) -> haddr_t
 
-See `libhdf5` documentation for [`H5Dget_offset`](https://portal.hdfgroup.org/display/HDF5/H5D_GET_OFFSET).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dget_offset']).
 """
 function h5d_get_offset(dataset_id)
     lock(liblock)
@@ -674,7 +756,9 @@ end
 """
     h5d_get_space(dataset_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Dget_space`](https://portal.hdfgroup.org/display/HDF5/H5D_GET_SPACE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dget_space']).
 """
 function h5d_get_space(dataset_id)
     lock(liblock)
@@ -690,7 +774,9 @@ end
 """
     h5d_get_space_status(dataset_id::hid_t, status::Ref{Cint})
 
-See `libhdf5` documentation for [`H5Dget_space_status`](https://portal.hdfgroup.org/display/HDF5/H5D_GET_SPACE_STATUS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dget_space_status']).
 """
 function h5d_get_space_status(dataset_id, status)
     lock(liblock)
@@ -706,7 +792,9 @@ end
 """
     h5d_get_storage_size(dataset_id::hid_t) -> hsize_t
 
-See `libhdf5` documentation for [`H5Dget_storage_size`](https://portal.hdfgroup.org/display/HDF5/H5D_GET_STORAGE_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dget_storage_size']).
 """
 function h5d_get_storage_size(dataset_id)
     lock(liblock)
@@ -722,7 +810,9 @@ end
 """
     h5d_get_type(dataset_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Dget_type`](https://portal.hdfgroup.org/display/HDF5/H5D_GET_TYPE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dget_type']).
 """
 function h5d_get_type(dataset_id)
     lock(liblock)
@@ -738,7 +828,9 @@ end
 """
     h5d_iterate(buf::Ptr{Cvoid}, type_id::hid_t, space_id::hid_t, operator::Ptr{Cvoid}, operator_data::Any)
 
-See `libhdf5` documentation for [`H5Diterate`](https://portal.hdfgroup.org/display/HDF5/H5D_ITERATE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Diterate']).
 """
 function h5d_iterate(buf, type_id, space_id, operator, operator_data)
     lock(liblock)
@@ -754,7 +846,9 @@ end
 """
     h5d_open(loc_id::hid_t, pathname::Ptr{UInt8}, dapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Dopen2`](https://portal.hdfgroup.org/display/HDF5/H5D_OPEN2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dopen2']).
 """
 function h5d_open(loc_id, pathname, dapl_id)
     lock(liblock)
@@ -770,7 +864,9 @@ end
 """
     h5d_read(dataset_id::hid_t, mem_type_id::hid_t, mem_space_id::hid_t, file_space_id::hid_t, xfer_plist_id::hid_t, buf::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Dread`](https://portal.hdfgroup.org/display/HDF5/H5D_READ).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dread']).
 """
 function h5d_read(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf)
     lock(liblock)
@@ -786,7 +882,9 @@ end
 """
     h5d_read_chunk(dset::hid_t, dxpl_id::hid_t, offset::Ptr{hsize_t}, filters::Ptr{UInt32}, buf::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Dread_chunk`](https://portal.hdfgroup.org/display/HDF5/H5D_READ_CHUNK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dread_chunk']).
 """
 function h5d_read_chunk(dset, dxpl_id, offset, filters, buf)
     lock(liblock)
@@ -802,7 +900,9 @@ end
 """
     h5d_refresh(dataset_id::hid_t)
 
-See `libhdf5` documentation for [`H5Drefresh`](https://portal.hdfgroup.org/display/HDF5/H5D_REFRESH).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Drefresh']).
 """
 function h5d_refresh(dataset_id)
     lock(liblock)
@@ -818,7 +918,9 @@ end
 """
     h5d_scatter(op::Ptr{Cvoid}, op_data::Any, type_id::hid_t, dst_space_id::hid_t, dst_buf::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Dscatter`](https://portal.hdfgroup.org/display/HDF5/H5D_SCATTER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dscatter']).
 """
 function h5d_scatter(op, op_data, type_id, dst_space_id, dst_buf)
     lock(liblock)
@@ -834,7 +936,9 @@ end
 """
     h5d_set_extent(dataset_id::hid_t, new_dims::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Dset_extent`](https://portal.hdfgroup.org/display/HDF5/H5D_SET_EXTENT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dset_extent']).
 """
 function h5d_set_extent(dataset_id, new_dims)
     lock(liblock)
@@ -850,7 +954,9 @@ end
 """
     h5d_vlen_get_buf_size(dset_id::hid_t, type_id::hid_t, space_id::hid_t, buf::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Dvlen_get_buf_size`](https://portal.hdfgroup.org/display/HDF5/H5D_VLEN_GET_BUF_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dvlen_get_buf_size']).
 """
 function h5d_vlen_get_buf_size(dset_id, type_id, space_id, buf)
     lock(liblock)
@@ -866,7 +972,9 @@ end
 """
     h5d_vlen_reclaim(type_id::hid_t, space_id::hid_t, plist_id::hid_t, buf::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Dvlen_reclaim`](https://portal.hdfgroup.org/display/HDF5/H5D_VLEN_RECLAIM).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dvlen_reclaim']).
 """
 function h5d_vlen_reclaim(type_id, space_id, plist_id, buf)
     lock(liblock)
@@ -882,7 +990,9 @@ end
 """
     h5d_write(dataset_id::hid_t, mem_type_id::hid_t, mem_space_id::hid_t, file_space_id::hid_t, xfer_plist_id::hid_t, buf::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Dwrite`](https://portal.hdfgroup.org/display/HDF5/H5D_WRITE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dwrite']).
 """
 function h5d_write(dataset_id, mem_type_id, mem_space_id, file_space_id, xfer_plist_id, buf)
     lock(liblock)
@@ -898,7 +1008,9 @@ end
 """
     h5d_write_chunk(dset_id::hid_t, dxpl_id::hid_t, filter_mask::UInt32, offset::Ptr{hsize_t}, bufsize::Csize_t, buf::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Dwrite_chunk`](https://portal.hdfgroup.org/display/HDF5/H5D_WRITE_CHUNK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5D']/member[name='H5Dwrite_chunk']).
 """
 function h5d_write_chunk(dset_id, dxpl_id, filter_mask, offset, bufsize, buf)
     lock(liblock)
@@ -914,7 +1026,9 @@ end
 """
     h5e_get_auto(estack_id::hid_t, func::Ref{Ptr{Cvoid}}, client_data::Ref{Ptr{Cvoid}})
 
-See `libhdf5` documentation for [`H5Eget_auto2`](https://portal.hdfgroup.org/display/HDF5/H5E_GET_AUTO2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5E']/member[name='H5Eget_auto2']).
 """
 function h5e_get_auto(estack_id, func, client_data)
     lock(liblock)
@@ -930,7 +1044,9 @@ end
 """
     h5e_set_auto(estack_id::hid_t, func::Ptr{Cvoid}, client_data::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Eset_auto2`](https://portal.hdfgroup.org/display/HDF5/H5E_SET_AUTO2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5E']/member[name='H5Eset_auto2']).
 """
 function h5e_set_auto(estack_id, func, client_data)
     lock(liblock)
@@ -946,7 +1062,9 @@ end
 """
     h5e_get_current_stack() -> hid_t
 
-See `libhdf5` documentation for [`H5Eget_current_stack`](https://portal.hdfgroup.org/display/HDF5/H5E_GET_CURRENT_STACK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5E']/member[name='H5Eget_current_stack']).
 """
 function h5e_get_current_stack()
     lock(liblock)
@@ -962,7 +1080,9 @@ end
 """
     h5e_get_msg(mesg_id::hid_t, mesg_type::Ref{Cint}, mesg::Ref{UInt8}, len::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Eget_msg`](https://portal.hdfgroup.org/display/HDF5/H5E_GET_MSG).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5E']/member[name='H5Eget_msg']).
 """
 function h5e_get_msg(mesg_id, mesg_type, mesg, len)
     lock(liblock)
@@ -978,7 +1098,9 @@ end
 """
     h5e_get_num(estack_id::hid_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Eget_num`](https://portal.hdfgroup.org/display/HDF5/H5E_GET_NUM).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5E']/member[name='H5Eget_num']).
 """
 function h5e_get_num(estack_id)
     lock(liblock)
@@ -994,7 +1116,9 @@ end
 """
     h5e_close_stack(stack_id::hid_t)
 
-See `libhdf5` documentation for [`H5Eclose_stack`](https://portal.hdfgroup.org/display/HDF5/H5E_CLOSE_STACK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5E']/member[name='H5Eclose_stack']).
 """
 function h5e_close_stack(stack_id)
     lock(liblock)
@@ -1010,7 +1134,9 @@ end
 """
     h5e_walk(stack_id::hid_t, direction::Cint, op::Ptr{Cvoid}, op_data::Any)
 
-See `libhdf5` documentation for [`H5Ewalk2`](https://portal.hdfgroup.org/display/HDF5/H5E_WALK2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5E']/member[name='H5Ewalk2']).
 """
 function h5e_walk(stack_id, direction, op, op_data)
     lock(liblock)
@@ -1026,7 +1152,9 @@ end
 """
     h5f_clear_elink_file_cache(file_id::hid_t)
 
-See `libhdf5` documentation for [`H5Fclear_elink_file_cache`](https://portal.hdfgroup.org/display/HDF5/H5F_CLEAR_ELINK_FILE_CACHE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fclear_elink_file_cache']).
 """
 function h5f_clear_elink_file_cache(file_id)
     lock(liblock)
@@ -1042,7 +1170,9 @@ end
 """
     h5f_close(file_id::hid_t)
 
-See `libhdf5` documentation for [`H5Fclose`](https://portal.hdfgroup.org/display/HDF5/H5F_CLOSE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fclose']).
 """
 function h5f_close(file_id)
     lock(liblock)
@@ -1058,7 +1188,9 @@ end
 """
     h5f_create(pathname::Ptr{UInt8}, flags::Cuint, fcpl_id::hid_t, fapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Fcreate`](https://portal.hdfgroup.org/display/HDF5/H5F_CREATE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fcreate']).
 """
 function h5f_create(pathname, flags, fcpl_id, fapl_id)
     lock(liblock)
@@ -1074,7 +1206,9 @@ end
 """
     h5f_delete(filename::Ptr{Cchar}, fapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Fdelete`](https://portal.hdfgroup.org/display/HDF5/H5F_DELETE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fdelete']).
 """
 function h5f_delete(filename, fapl_id)
     lock(liblock)
@@ -1090,7 +1224,9 @@ end
 """
     h5f_flush(object_id::hid_t, scope::Cint)
 
-See `libhdf5` documentation for [`H5Fflush`](https://portal.hdfgroup.org/display/HDF5/H5F_FLUSH).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fflush']).
 """
 function h5f_flush(object_id, scope)
     lock(liblock)
@@ -1106,7 +1242,9 @@ end
 """
     h5f_format_convert(fid::hid_t)
 
-See `libhdf5` documentation for [`H5Fformat_convert`](https://portal.hdfgroup.org/display/HDF5/H5F_FORMAT_CONVERT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fformat_convert']).
 """
 function h5f_format_convert(fid)
     lock(liblock)
@@ -1122,7 +1260,9 @@ end
 """
     h5f_get_access_plist(file_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Fget_access_plist`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_ACCESS_PLIST).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_access_plist']).
 """
 function h5f_get_access_plist(file_id)
     lock(liblock)
@@ -1138,7 +1278,9 @@ end
 """
     h5f_get_create_plist(file_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Fget_create_plist`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_CREATE_PLIST).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_create_plist']).
 """
 function h5f_get_create_plist(file_id)
     lock(liblock)
@@ -1154,7 +1296,9 @@ end
 """
     h5f_get_dset_no_attrs_hint(file_id::hid_t, minimize::Ptr{hbool_t})
 
-See `libhdf5` documentation for [`H5Fget_dset_no_attrs_hint`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_DSET_NO_ATTRS_HINT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_dset_no_attrs_hint']).
 """
 function h5f_get_dset_no_attrs_hint(file_id, minimize)
     lock(liblock)
@@ -1170,7 +1314,9 @@ end
 """
     h5f_get_eoa(file_id::hid_t, eoa::Ptr{haddr_t})
 
-See `libhdf5` documentation for [`H5Fget_eoa`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_EOA).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_eoa']).
 """
 function h5f_get_eoa(file_id, eoa)
     lock(liblock)
@@ -1186,7 +1332,9 @@ end
 """
     h5f_get_file_image(file_id::hid_t, buf_ptr::Ptr{Cvoid}, buf_len::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Fget_file_image`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_FILE_IMAGE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_file_image']).
 """
 function h5f_get_file_image(file_id, buf_ptr, buf_len)
     lock(liblock)
@@ -1202,7 +1350,9 @@ end
 """
     h5f_get_fileno(file_id::hid_t, fileno::Ptr{Culong})
 
-See `libhdf5` documentation for [`H5Fget_fileno`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_FILENO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_fileno']).
 """
 function h5f_get_fileno(file_id, fileno)
     lock(liblock)
@@ -1218,7 +1368,9 @@ end
 """
     h5f_get_filesize(file_id::hid_t, size::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Fget_filesize`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_FILESIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_filesize']).
 """
 function h5f_get_filesize(file_id, size)
     lock(liblock)
@@ -1234,7 +1386,9 @@ end
 """
     h5f_get_free_sections(file_id::hid_t, type::H5F_mem_t, nsects::Csize_t, sect_info::Ptr{H5F_sect_info_t}) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Fget_free_sections`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_FREE_SECTIONS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_free_sections']).
 """
 function h5f_get_free_sections(file_id, type, nsects, sect_info)
     lock(liblock)
@@ -1250,7 +1404,9 @@ end
 """
     h5f_get_freespace(file_id::hid_t) -> hssize_t
 
-See `libhdf5` documentation for [`H5Fget_freespace`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_FREESPACE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_freespace']).
 """
 function h5f_get_freespace(file_id)
     lock(liblock)
@@ -1266,7 +1422,9 @@ end
 """
     h5f_get_intent(file_id::hid_t, intent::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Fget_intent`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_INTENT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_intent']).
 """
 function h5f_get_intent(file_id, intent)
     lock(liblock)
@@ -1282,7 +1440,9 @@ end
 """
     h5f_get_info(obj_id::hid_t, file_info::Ptr{H5F_info2_t})
 
-See `libhdf5` documentation for [`H5Fget_info2`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_INFO2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_info2']).
 """
 function h5f_get_info(obj_id, file_info)
     lock(liblock)
@@ -1298,7 +1458,9 @@ end
 """
     h5f_get_mdc_config(file_id::hid_t, config_ptr::Ptr{H5AC_cache_config_t})
 
-See `libhdf5` documentation for [`H5Fget_mdc_config`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_MDC_CONFIG).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_mdc_config']).
 """
 function h5f_get_mdc_config(file_id, config_ptr)
     lock(liblock)
@@ -1314,7 +1476,9 @@ end
 """
     h5f_get_mdc_hit_rate(file_id::hid_t, hit_rate_ptr::Ptr{Cdouble})
 
-See `libhdf5` documentation for [`H5Fget_mdc_hit_rate`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_MDC_HIT_RATE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_mdc_hit_rate']).
 """
 function h5f_get_mdc_hit_rate(file_id, hit_rate_ptr)
     lock(liblock)
@@ -1330,7 +1494,9 @@ end
 """
     h5f_get_mdc_image_info(file_id::hid_t, image_addr::Ptr{haddr_t}, image_size::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Fget_mdc_image_info`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_MDC_IMAGE_INFO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_mdc_image_info']).
 """
 function h5f_get_mdc_image_info(file_id, image_addr, image_size)
     lock(liblock)
@@ -1346,7 +1512,9 @@ end
 """
     h5f_get_mdc_logging_status(file_id::hid_t, is_enabled::Ptr{hbool_t}, is_currently_logging::Ptr{hbool_t})
 
-See `libhdf5` documentation for [`H5Fget_mdc_logging_status`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_MDC_LOGGING_STATUS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_mdc_logging_status']).
 """
 function h5f_get_mdc_logging_status(file_id, is_enabled, is_currently_logging)
     lock(liblock)
@@ -1362,7 +1530,9 @@ end
 """
     h5f_get_mdc_size(file_id::hid_t, max_size_ptr::Ptr{Csize_t}, min_clean_size_ptr::Ptr{Csize_t}, cur_size_ptr::Ptr{Csize_t}, cur_num_entries_ptr::Ptr{Cint})
 
-See `libhdf5` documentation for [`H5Fget_mdc_size`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_MDC_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_mdc_size']).
 """
 function h5f_get_mdc_size(file_id, max_size_ptr, min_clean_size_ptr, cur_size_ptr, cur_num_entries_ptr)
     lock(liblock)
@@ -1378,7 +1548,9 @@ end
 """
     h5f_get_metadata_read_retry_info(file_id::hid_t, info::Ptr{H5F_retry_info_t})
 
-See `libhdf5` documentation for [`H5Fget_metadata_read_retry_info`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_METADATA_READ_RETRY_INFO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_metadata_read_retry_info']).
 """
 function h5f_get_metadata_read_retry_info(file_id, info)
     lock(liblock)
@@ -1394,7 +1566,9 @@ end
 """
     h5f_get_mpi_atomicity(file_id::hid_t, flag::Ptr{hbool_t})
 
-See `libhdf5` documentation for [`H5Fget_mpi_atomicity`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_MPI_ATOMICITY).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_mpi_atomicity']).
 """
 function h5f_get_mpi_atomicity(file_id, flag)
     lock(liblock)
@@ -1410,7 +1584,9 @@ end
 """
     h5f_get_name(obj_id::hid_t, buf::Ptr{UInt8}, buf_size::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Fget_name`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_NAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_name']).
 """
 function h5f_get_name(obj_id, buf, buf_size)
     lock(liblock)
@@ -1426,7 +1602,9 @@ end
 """
     h5f_get_obj_count(file_id::hid_t, types::Cuint) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Fget_obj_count`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_OBJ_COUNT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_obj_count']).
 """
 function h5f_get_obj_count(file_id, types)
     lock(liblock)
@@ -1442,7 +1620,9 @@ end
 """
     h5f_get_obj_ids(file_id::hid_t, types::Cuint, max_objs::Csize_t, obj_id_list::Ptr{hid_t}) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Fget_obj_ids`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_OBJ_IDS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_obj_ids']).
 """
 function h5f_get_obj_ids(file_id, types, max_objs, obj_id_list)
     lock(liblock)
@@ -1458,7 +1638,9 @@ end
 """
     h5f_get_page_buffering_stats(file_id::hid_t, accesses::Ptr{Cuint}, hits::Ptr{Cuint}, misses::Ptr{Cuint}, evictions::Ptr{Cuint}, bypasses::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Fget_page_buffering_stats`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_PAGE_BUFFERING_STATS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_page_buffering_stats']).
 """
 function h5f_get_page_buffering_stats(file_id, accesses, hits, misses, evictions, bypasses)
     lock(liblock)
@@ -1474,7 +1656,9 @@ end
 """
     h5f_get_vfd_handle(file_id::hid_t, fapl_id::hid_t, file_handle::Ref{Ptr{Cvoid}})
 
-See `libhdf5` documentation for [`H5Fget_vfd_handle`](https://portal.hdfgroup.org/display/HDF5/H5F_GET_VFD_HANDLE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fget_vfd_handle']).
 """
 function h5f_get_vfd_handle(file_id, fapl_id, file_handle)
     lock(liblock)
@@ -1490,7 +1674,9 @@ end
 """
     h5f_increment_filesize(file_id::hid_t, increment::hsize_t)
 
-See `libhdf5` documentation for [`H5Fincrement_filesize`](https://portal.hdfgroup.org/display/HDF5/H5F_INCREMENT_FILESIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fincrement_filesize']).
 """
 function h5f_increment_filesize(file_id, increment)
     lock(liblock)
@@ -1506,7 +1692,9 @@ end
 """
     h5f_is_accessible(container_name::Ptr{Cchar}, fapl_id::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Fis_accessible`](https://portal.hdfgroup.org/display/HDF5/H5F_IS_ACCESSIBLE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fis_accessible']).
 """
 function h5f_is_accessible(container_name, fapl_id)
     lock(liblock)
@@ -1522,7 +1710,9 @@ end
 """
     h5f_is_hdf5(pathname::Cstring) -> Bool
 
-See `libhdf5` documentation for [`H5Fis_hdf5`](https://portal.hdfgroup.org/display/HDF5/H5F_IS_HDF5).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fis_hdf5']).
 """
 function h5f_is_hdf5(pathname)
     lock(liblock)
@@ -1538,7 +1728,9 @@ end
 """
     h5f_mount(loc::hid_t, name::Ptr{Cchar}, child::hid_t, plist::hid_t)
 
-See `libhdf5` documentation for [`H5Fmount`](https://portal.hdfgroup.org/display/HDF5/H5F_MOUNT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fmount']).
 """
 function h5f_mount(loc, name, child, plist)
     lock(liblock)
@@ -1554,7 +1746,9 @@ end
 """
     h5f_open(pathname::Cstring, flags::Cuint, fapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Fopen`](https://portal.hdfgroup.org/display/HDF5/H5F_OPEN).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fopen']).
 """
 function h5f_open(pathname, flags, fapl_id)
     lock(liblock)
@@ -1570,7 +1764,9 @@ end
 """
     h5f_reopen(file_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Freopen`](https://portal.hdfgroup.org/display/HDF5/H5F_REOPEN).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Freopen']).
 """
 function h5f_reopen(file_id)
     lock(liblock)
@@ -1586,7 +1782,9 @@ end
 """
     h5f_reset_mdc_hit_rate_stats(file_id::hid_t)
 
-See `libhdf5` documentation for [`H5Freset_mdc_hit_rate_stats`](https://portal.hdfgroup.org/display/HDF5/H5F_RESET_MDC_HIT_RATE_STATS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Freset_mdc_hit_rate_stats']).
 """
 function h5f_reset_mdc_hit_rate_stats(file_id)
     lock(liblock)
@@ -1602,7 +1800,9 @@ end
 """
     h5f_reset_page_buffering_stats(file_id::hid_t)
 
-See `libhdf5` documentation for [`H5Freset_page_buffering_stats`](https://portal.hdfgroup.org/display/HDF5/H5F_RESET_PAGE_BUFFERING_STATS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Freset_page_buffering_stats']).
 """
 function h5f_reset_page_buffering_stats(file_id)
     lock(liblock)
@@ -1618,7 +1818,9 @@ end
 """
     h5f_set_dset_no_attrs_hint(file_id::hid_t, minimize::hbool_t)
 
-See `libhdf5` documentation for [`H5Fset_dset_no_attrs_hint`](https://portal.hdfgroup.org/display/HDF5/H5F_SET_DSET_NO_ATTRS_HINT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fset_dset_no_attrs_hint']).
 """
 function h5f_set_dset_no_attrs_hint(file_id, minimize)
     lock(liblock)
@@ -1634,7 +1836,9 @@ end
 """
     h5f_set_libver_bounds(file_id::hid_t, low::H5F_libver_t, high::H5F_libver_t)
 
-See `libhdf5` documentation for [`H5Fset_libver_bounds`](https://portal.hdfgroup.org/display/HDF5/H5F_SET_LIBVER_BOUNDS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fset_libver_bounds']).
 """
 function h5f_set_libver_bounds(file_id, low, high)
     lock(liblock)
@@ -1650,7 +1854,9 @@ end
 """
     h5f_set_mdc_config(file_id::hid_t, config_ptr::Ptr{H5AC_cache_config_t})
 
-See `libhdf5` documentation for [`H5Fset_mdc_config`](https://portal.hdfgroup.org/display/HDF5/H5F_SET_MDC_CONFIG).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fset_mdc_config']).
 """
 function h5f_set_mdc_config(file_id, config_ptr)
     lock(liblock)
@@ -1666,7 +1872,9 @@ end
 """
     h5f_set_mpi_atomicity(file_id::hid_t, flag::hbool_t)
 
-See `libhdf5` documentation for [`H5Fset_mpi_atomicity`](https://portal.hdfgroup.org/display/HDF5/H5F_SET_MPI_ATOMICITY).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fset_mpi_atomicity']).
 """
 function h5f_set_mpi_atomicity(file_id, flag)
     lock(liblock)
@@ -1682,7 +1890,9 @@ end
 """
     h5f_start_mdc_logging(file_id::hid_t)
 
-See `libhdf5` documentation for [`H5Fstart_mdc_logging`](https://portal.hdfgroup.org/display/HDF5/H5F_START_MDC_LOGGING).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fstart_mdc_logging']).
 """
 function h5f_start_mdc_logging(file_id)
     lock(liblock)
@@ -1698,7 +1908,9 @@ end
 """
     h5f_start_swmr_write(id::hid_t)
 
-See `libhdf5` documentation for [`H5Fstart_swmr_write`](https://portal.hdfgroup.org/display/HDF5/H5F_START_SWMR_WRITE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fstart_swmr_write']).
 """
 function h5f_start_swmr_write(id)
     lock(liblock)
@@ -1714,7 +1926,9 @@ end
 """
     h5f_stop_mdc_logging(file_id::hid_t)
 
-See `libhdf5` documentation for [`H5Fstop_mdc_logging`](https://portal.hdfgroup.org/display/HDF5/H5F_STOP_MDC_LOGGING).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Fstop_mdc_logging']).
 """
 function h5f_stop_mdc_logging(file_id)
     lock(liblock)
@@ -1730,7 +1944,9 @@ end
 """
     h5f_unmount(loc::hid_t, name::Ptr{Cchar})
 
-See `libhdf5` documentation for [`H5Funmount`](https://portal.hdfgroup.org/display/HDF5/H5F_UNMOUNT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5F']/member[name='H5Funmount']).
 """
 function h5f_unmount(loc, name)
     lock(liblock)
@@ -1746,7 +1962,9 @@ end
 """
     h5g_close(group_id::hid_t)
 
-See `libhdf5` documentation for [`H5Gclose`](https://portal.hdfgroup.org/display/HDF5/H5G_CLOSE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5G']/member[name='H5Gclose']).
 """
 function h5g_close(group_id)
     lock(liblock)
@@ -1762,7 +1980,9 @@ end
 """
     h5g_create(loc_id::hid_t, pathname::Ptr{UInt8}, lcpl_id::hid_t, gcpl_id::hid_t, gapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Gcreate2`](https://portal.hdfgroup.org/display/HDF5/H5G_CREATE2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5G']/member[name='H5Gcreate2']).
 """
 function h5g_create(loc_id, pathname, lcpl_id, gcpl_id, gapl_id)
     lock(liblock)
@@ -1778,7 +1998,9 @@ end
 """
     h5g_get_create_plist(group_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Gget_create_plist`](https://portal.hdfgroup.org/display/HDF5/H5G_GET_CREATE_PLIST).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5G']/member[name='H5Gget_create_plist']).
 """
 function h5g_get_create_plist(group_id)
     lock(liblock)
@@ -1794,7 +2016,9 @@ end
 """
     h5g_get_info(group_id::hid_t, buf::Ptr{H5G_info_t})
 
-See `libhdf5` documentation for [`H5Gget_info`](https://portal.hdfgroup.org/display/HDF5/H5G_GET_INFO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5G']/member[name='H5Gget_info']).
 """
 function h5g_get_info(group_id, buf)
     lock(liblock)
@@ -1810,7 +2034,9 @@ end
 """
     h5g_get_num_objs(loc_id::hid_t, num_obj::Ptr{hsize_t}) -> hid_t
 
-See `libhdf5` documentation for [`H5Gget_num_objs`](https://portal.hdfgroup.org/display/HDF5/H5G_GET_NUM_OBJS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5G']/member[name='H5Gget_num_objs']).
 """
 function h5g_get_num_objs(loc_id, num_obj)
     lock(liblock)
@@ -1826,7 +2052,9 @@ end
 """
     h5g_get_objname_by_idx(loc_id::hid_t, idx::hsize_t, pathname::Ptr{UInt8}, size::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Gget_objname_by_idx`](https://portal.hdfgroup.org/display/HDF5/H5G_GET_OBJNAME_BY_IDX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5G']/member[name='H5Gget_objname_by_idx']).
 """
 function h5g_get_objname_by_idx(loc_id, idx, pathname, size)
     lock(liblock)
@@ -1842,7 +2070,9 @@ end
 """
     h5g_open(loc_id::hid_t, pathname::Ptr{UInt8}, gapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Gopen2`](https://portal.hdfgroup.org/display/HDF5/H5G_OPEN2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5G']/member[name='H5Gopen2']).
 """
 function h5g_open(loc_id, pathname, gapl_id)
     lock(liblock)
@@ -1858,7 +2088,9 @@ end
 """
     h5i_dec_ref(obj_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Idec_ref`](https://portal.hdfgroup.org/display/HDF5/H5I_DEC_REF).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5I']/member[name='H5Idec_ref']).
 """
 function h5i_dec_ref(obj_id)
     lock(liblock)
@@ -1874,7 +2106,9 @@ end
 """
     h5i_get_file_id(obj_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Iget_file_id`](https://portal.hdfgroup.org/display/HDF5/H5I_GET_FILE_ID).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5I']/member[name='H5Iget_file_id']).
 """
 function h5i_get_file_id(obj_id)
     lock(liblock)
@@ -1890,7 +2124,9 @@ end
 """
     h5i_get_name(obj_id::hid_t, buf::Ptr{UInt8}, buf_size::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Iget_name`](https://portal.hdfgroup.org/display/HDF5/H5I_GET_NAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5I']/member[name='H5Iget_name']).
 """
 function h5i_get_name(obj_id, buf, buf_size)
     lock(liblock)
@@ -1906,7 +2142,9 @@ end
 """
     h5i_get_ref(obj_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Iget_ref`](https://portal.hdfgroup.org/display/HDF5/H5I_GET_REF).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5I']/member[name='H5Iget_ref']).
 """
 function h5i_get_ref(obj_id)
     lock(liblock)
@@ -1922,7 +2160,9 @@ end
 """
     h5i_get_type(obj_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Iget_type`](https://portal.hdfgroup.org/display/HDF5/H5I_GET_TYPE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5I']/member[name='H5Iget_type']).
 """
 function h5i_get_type(obj_id)
     lock(liblock)
@@ -1938,7 +2178,9 @@ end
 """
     h5i_inc_ref(obj_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Iinc_ref`](https://portal.hdfgroup.org/display/HDF5/H5I_INC_REF).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5I']/member[name='H5Iinc_ref']).
 """
 function h5i_inc_ref(obj_id)
     lock(liblock)
@@ -1954,7 +2196,9 @@ end
 """
     h5i_is_valid(obj_id::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Iis_valid`](https://portal.hdfgroup.org/display/HDF5/H5I_IS_VALID).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5I']/member[name='H5Iis_valid']).
 """
 function h5i_is_valid(obj_id)
     lock(liblock)
@@ -1970,7 +2214,9 @@ end
 """
     h5l_create_external(target_file_name::Ptr{UInt8}, target_obj_name::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Lcreate_external`](https://portal.hdfgroup.org/display/HDF5/H5L_CREATE_EXTERNAL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5L']/member[name='H5Lcreate_external']).
 """
 function h5l_create_external(target_file_name, target_obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
     lock(liblock)
@@ -1986,7 +2232,9 @@ end
 """
     h5l_create_hard(obj_loc_id::hid_t, obj_name::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Lcreate_hard`](https://portal.hdfgroup.org/display/HDF5/H5L_CREATE_HARD).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5L']/member[name='H5Lcreate_hard']).
 """
 function h5l_create_hard(obj_loc_id, obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
     lock(liblock)
@@ -2002,7 +2250,9 @@ end
 """
     h5l_create_soft(target_path::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Lcreate_soft`](https://portal.hdfgroup.org/display/HDF5/H5L_CREATE_SOFT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5L']/member[name='H5Lcreate_soft']).
 """
 function h5l_create_soft(target_path, link_loc_id, link_name, lcpl_id, lapl_id)
     lock(liblock)
@@ -2018,7 +2268,9 @@ end
 """
     h5l_delete(obj_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Ldelete`](https://portal.hdfgroup.org/display/HDF5/H5L_DELETE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5L']/member[name='H5Ldelete']).
 """
 function h5l_delete(obj_id, pathname, lapl_id)
     lock(liblock)
@@ -2034,7 +2286,9 @@ end
 """
     h5l_move(src_obj_id::hid_t, src_name::Ptr{UInt8}, dest_obj_id::hid_t, dest_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Lmove`](https://portal.hdfgroup.org/display/HDF5/H5L_MOVE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5L']/member[name='H5Lmove']).
 """
 function h5l_move(src_obj_id, src_name, dest_obj_id, dest_name, lcpl_id, lapl_id)
     lock(liblock)
@@ -2050,7 +2304,9 @@ end
 """
     h5l_exists(loc_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Lexists`](https://portal.hdfgroup.org/display/HDF5/H5L_EXISTS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5L']/member[name='H5Lexists']).
 """
 function h5l_exists(loc_id, pathname, lapl_id)
     lock(liblock)
@@ -2066,7 +2322,9 @@ end
 """
     h5l_get_info(link_loc_id::hid_t, link_name::Ptr{UInt8}, link_buf::Ptr{H5L_info_t}, lapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Lget_info`](https://portal.hdfgroup.org/display/HDF5/H5L_GET_INFO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5L']/member[name='H5Lget_info']).
 """
 function h5l_get_info(link_loc_id, link_name, link_buf, lapl_id)
     lock(liblock)
@@ -2082,7 +2340,9 @@ end
 """
     h5l_get_name_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_field::Cint, order::Cint, n::hsize_t, name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Lget_name_by_idx`](https://portal.hdfgroup.org/display/HDF5/H5L_GET_NAME_BY_IDX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5L']/member[name='H5Lget_name_by_idx']).
 """
 function h5l_get_name_by_idx(loc_id, group_name, index_field, order, n, name, size, lapl_id)
     lock(liblock)
@@ -2099,7 +2359,9 @@ end
     @doc """
         h5l_iterate(group_id::hid_t, idx_type::Cint, order::Cint, idx::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Any)
 
-    See `libhdf5` documentation for [`H5Literate`](https://portal.hdfgroup.org/display/HDF5/H5L_ITERATE).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5L']/member[name='H5Literate']).
     """
     function h5l_iterate(group_id, idx_type, order, idx, op, op_data)
         lock(liblock)
@@ -2117,7 +2379,9 @@ end
     @doc """
         h5l_iterate(group_id::hid_t, idx_type::Cint, order::Cint, idx::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Any)
 
-    See `libhdf5` documentation for [`H5Literate1`](https://portal.hdfgroup.org/display/HDF5/H5L_ITERATE1).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5L']/member[name='H5Literate1']).
     """
     function h5l_iterate(group_id, idx_type, order, idx, op, op_data)
         lock(liblock)
@@ -2134,7 +2398,9 @@ end
 """
     h5o_are_mdc_flushes_disabled(object_id::hid_t, are_disabled::Ptr{hbool_t})
 
-See `libhdf5` documentation for [`H5Oare_mdc_flushes_disabled`](https://portal.hdfgroup.org/display/HDF5/H5O_ARE_MDC_FLUSHES_DISABLED).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oare_mdc_flushes_disabled']).
 """
 function h5o_are_mdc_flushes_disabled(object_id, are_disabled)
     lock(liblock)
@@ -2150,7 +2416,9 @@ end
 """
     h5o_close(object_id::hid_t)
 
-See `libhdf5` documentation for [`H5Oclose`](https://portal.hdfgroup.org/display/HDF5/H5O_CLOSE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oclose']).
 """
 function h5o_close(object_id)
     lock(liblock)
@@ -2166,7 +2434,9 @@ end
 """
     h5o_copy(src_loc_id::hid_t, src_name::Ptr{UInt8}, dst_loc_id::hid_t, dst_name::Ptr{UInt8}, ocpypl_id::hid_t, lcpl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Ocopy`](https://portal.hdfgroup.org/display/HDF5/H5O_COPY).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Ocopy']).
 """
 function h5o_copy(src_loc_id, src_name, dst_loc_id, dst_name, ocpypl_id, lcpl_id)
     lock(liblock)
@@ -2182,7 +2452,9 @@ end
 """
     h5o_decr_refcount(object_id::hid_t)
 
-See `libhdf5` documentation for [`H5Odecr_refcount`](https://portal.hdfgroup.org/display/HDF5/H5O_DECR_REFCOUNT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Odecr_refcount']).
 """
 function h5o_decr_refcount(object_id)
     lock(liblock)
@@ -2198,7 +2470,9 @@ end
 """
     h5o_disable_mdc_flushes(object_id::hid_t)
 
-See `libhdf5` documentation for [`H5Odisable_mdc_flushes`](https://portal.hdfgroup.org/display/HDF5/H5O_DISABLE_MDC_FLUSHES).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Odisable_mdc_flushes']).
 """
 function h5o_disable_mdc_flushes(object_id)
     lock(liblock)
@@ -2214,7 +2488,9 @@ end
 """
     h5o_enable_mdc_flushes(object_id::hid_t)
 
-See `libhdf5` documentation for [`H5Oenable_mdc_flushes`](https://portal.hdfgroup.org/display/HDF5/H5O_ENABLE_MDC_FLUSHES).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oenable_mdc_flushes']).
 """
 function h5o_enable_mdc_flushes(object_id)
     lock(liblock)
@@ -2230,7 +2506,9 @@ end
 """
     h5o_exists_by_name(loc_id::hid_t, name::Ptr{Cchar}, lapl_id::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Oexists_by_name`](https://portal.hdfgroup.org/display/HDF5/H5O_EXISTS_BY_NAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oexists_by_name']).
 """
 function h5o_exists_by_name(loc_id, name, lapl_id)
     lock(liblock)
@@ -2246,7 +2524,9 @@ end
 """
     h5o_flush(obj_id::hid_t)
 
-See `libhdf5` documentation for [`H5Oflush`](https://portal.hdfgroup.org/display/HDF5/H5O_FLUSH).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oflush']).
 """
 function h5o_flush(obj_id)
     lock(liblock)
@@ -2262,7 +2542,9 @@ end
 """
     h5o_get_comment(obj_id::hid_t, comment::Ptr{Cchar}, bufsize::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Oget_comment`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_COMMENT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_comment']).
 """
 function h5o_get_comment(obj_id, comment, bufsize)
     lock(liblock)
@@ -2278,7 +2560,9 @@ end
 """
     h5o_get_comment_by_name(loc_id::hid_t, name::Ptr{Cchar}, comment::Ptr{Cchar}, bufsize::Csize_t, lapl_id::hid_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Oget_comment_by_name`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_COMMENT_BY_NAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_comment_by_name']).
 """
 function h5o_get_comment_by_name(loc_id, name, comment, bufsize, lapl_id)
     lock(liblock)
@@ -2295,7 +2579,9 @@ end
     @doc """
         h5o_get_info(object_id::hid_t, buf::Ptr{H5O_info1_t})
 
-    See `libhdf5` documentation for [`H5Oget_info1`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO1).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_info1']).
     """
     function h5o_get_info(object_id, buf)
         lock(liblock)
@@ -2313,7 +2599,9 @@ end
     @doc """
         h5o_get_info(loc_id::hid_t, oinfo::Ptr{H5O_info1_t}, fields::Cuint)
 
-    See `libhdf5` documentation for [`H5Oget_info2`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO2).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_info2']).
     """
     function h5o_get_info(loc_id, oinfo, fields)
         lock(liblock)
@@ -2331,7 +2619,9 @@ end
     @doc """
         h5o_get_info(loc_id::hid_t, oinfo::Ptr{H5O_info2_t}, fields::Cuint)
 
-    See `libhdf5` documentation for [`H5Oget_info3`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO3).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_info3']).
     """
     function h5o_get_info(loc_id, oinfo, fields)
         lock(liblock)
@@ -2349,7 +2639,9 @@ end
     @doc """
         h5o_get_info_by_idx(loc_id::hid_t, group_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info1_t}, lapl_id::hid_t)
 
-    See `libhdf5` documentation for [`H5Oget_info_by_idx1`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO_BY_IDX1).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_info_by_idx1']).
     """
     function h5o_get_info_by_idx(loc_id, group_name, idx_type, order, n, oinfo, lapl_id)
         lock(liblock)
@@ -2367,7 +2659,9 @@ end
     @doc """
         h5o_get_info_by_idx(loc_id::hid_t, group_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info1_t}, fields::Cuint, lapl_id::hid_t)
 
-    See `libhdf5` documentation for [`H5Oget_info_by_idx2`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO_BY_IDX2).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_info_by_idx2']).
     """
     function h5o_get_info_by_idx(loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id)
         lock(liblock)
@@ -2385,7 +2679,9 @@ end
     @doc """
         h5o_get_info_by_idx(loc_id::hid_t, group_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info2_t}, fields::Cuint, lapl_id::hid_t)
 
-    See `libhdf5` documentation for [`H5Oget_info_by_idx3`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO_BY_IDX3).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_info_by_idx3']).
     """
     function h5o_get_info_by_idx(loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id)
         lock(liblock)
@@ -2403,7 +2699,9 @@ end
     @doc """
         h5o_get_info_by_name(loc_id::hid_t, name::Ptr{Cchar}, oinfo::Ptr{H5O_info1_t}, lapl_id::hid_t)
 
-    See `libhdf5` documentation for [`H5Oget_info_by_name1`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO_BY_NAME1).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_info_by_name1']).
     """
     function h5o_get_info_by_name(loc_id, name, oinfo, lapl_id)
         lock(liblock)
@@ -2421,7 +2719,9 @@ end
     @doc """
         h5o_get_info_by_name(loc_id::hid_t, name::Ptr{Cchar}, oinfo::Ptr{H5O_info1_t}, fields::Cuint, lapl_id::hid_t)
 
-    See `libhdf5` documentation for [`H5Oget_info_by_name2`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO_BY_NAME2).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_info_by_name2']).
     """
     function h5o_get_info_by_name(loc_id, name, oinfo, fields, lapl_id)
         lock(liblock)
@@ -2439,7 +2739,9 @@ end
     @doc """
         h5o_get_info_by_name(loc_id::hid_t, name::Ptr{Cchar}, oinfo::Ptr{H5O_info2_t}, fields::Cuint, lapl_id::hid_t)
 
-    See `libhdf5` documentation for [`H5Oget_info_by_name3`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO_BY_NAME3).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_info_by_name3']).
     """
     function h5o_get_info_by_name(loc_id, name, oinfo, fields, lapl_id)
         lock(liblock)
@@ -2456,7 +2758,9 @@ end
 """
     h5o_get_native_info(loc_id::hid_t, oinfo::Ptr{H5O_native_info_t}, fields::Cuint)
 
-See `libhdf5` documentation for [`H5Oget_native_info`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_NATIVE_INFO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_native_info']).
 """
 function h5o_get_native_info(loc_id, oinfo, fields)
     lock(liblock)
@@ -2472,7 +2776,9 @@ end
 """
     h5o_get_native_info_by_idx(loc_id::hid_t, group_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_native_info_t}, fields::Cuint, lapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Oget_native_info_by_idx`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_NATIVE_INFO_BY_IDX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_native_info_by_idx']).
 """
 function h5o_get_native_info_by_idx(loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id)
     lock(liblock)
@@ -2488,7 +2794,9 @@ end
 """
     h5o_get_native_info_by_name(loc_id::hid_t, name::Ptr{Cchar}, oinfo::Ptr{H5O_native_info_t}, fields::Cuint, lapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Oget_native_info_by_name`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_NATIVE_INFO_BY_NAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oget_native_info_by_name']).
 """
 function h5o_get_native_info_by_name(loc_id, name, oinfo, fields, lapl_id)
     lock(liblock)
@@ -2504,7 +2812,9 @@ end
 """
     h5o_incr_refcount(object_id::hid_t)
 
-See `libhdf5` documentation for [`H5Oincr_refcount`](https://portal.hdfgroup.org/display/HDF5/H5O_INCR_REFCOUNT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oincr_refcount']).
 """
 function h5o_incr_refcount(object_id)
     lock(liblock)
@@ -2520,7 +2830,9 @@ end
 """
     h5o_link(obj_id::hid_t, new_loc_id::hid_t, new_name::Ptr{Cchar}, lcpl_id::hid_t, lapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Olink`](https://portal.hdfgroup.org/display/HDF5/H5O_LINK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Olink']).
 """
 function h5o_link(obj_id, new_loc_id, new_name, lcpl_id, lapl_id)
     lock(liblock)
@@ -2536,7 +2848,9 @@ end
 """
     h5o_open(loc_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Oopen`](https://portal.hdfgroup.org/display/HDF5/H5O_OPEN).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oopen']).
 """
 function h5o_open(loc_id, pathname, lapl_id)
     lock(liblock)
@@ -2552,7 +2866,9 @@ end
 """
     h5o_open_by_addr(loc_id::hid_t, addr::haddr_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Oopen_by_addr`](https://portal.hdfgroup.org/display/HDF5/H5O_OPEN_BY_ADDR).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oopen_by_addr']).
 """
 function h5o_open_by_addr(loc_id, addr)
     lock(liblock)
@@ -2568,7 +2884,9 @@ end
 """
     h5o_open_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_type::Cint, order::Cint, n::hsize_t, lapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Oopen_by_idx`](https://portal.hdfgroup.org/display/HDF5/H5O_OPEN_BY_IDX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oopen_by_idx']).
 """
 function h5o_open_by_idx(loc_id, group_name, index_type, order, n, lapl_id)
     lock(liblock)
@@ -2584,7 +2902,9 @@ end
 """
     h5o_refresh(oid::hid_t)
 
-See `libhdf5` documentation for [`H5Orefresh`](https://portal.hdfgroup.org/display/HDF5/H5O_REFRESH).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Orefresh']).
 """
 function h5o_refresh(oid)
     lock(liblock)
@@ -2600,7 +2920,9 @@ end
 """
     h5o_set_comment(obj_id::hid_t, comment::Ptr{Cchar})
 
-See `libhdf5` documentation for [`H5Oset_comment`](https://portal.hdfgroup.org/display/HDF5/H5O_SET_COMMENT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oset_comment']).
 """
 function h5o_set_comment(obj_id, comment)
     lock(liblock)
@@ -2616,7 +2938,9 @@ end
 """
     h5o_set_comment_by_name(loc_id::hid_t, name::Ptr{Cchar}, comment::Ptr{Cchar}, lapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Oset_comment_by_name`](https://portal.hdfgroup.org/display/HDF5/H5O_SET_COMMENT_BY_NAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Oset_comment_by_name']).
 """
 function h5o_set_comment_by_name(loc_id, name, comment, lapl_id)
     lock(liblock)
@@ -2632,7 +2956,9 @@ end
 """
     h5o_token_cmp(loc_id::hid_t, token1::Ptr{H5O_token_t}, token2::Ptr{H5O_token_t}, cmp_value::Ptr{Cint})
 
-See `libhdf5` documentation for [`H5Otoken_cmp`](https://portal.hdfgroup.org/display/HDF5/H5O_TOKEN_CMP).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Otoken_cmp']).
 """
 function h5o_token_cmp(loc_id, token1, token2, cmp_value)
     lock(liblock)
@@ -2648,7 +2974,9 @@ end
 """
     h5o_token_from_str(loc_id::hid_t, token_str::Ptr{Cchar}, token::Ptr{H5O_token_t})
 
-See `libhdf5` documentation for [`H5Otoken_from_str`](https://portal.hdfgroup.org/display/HDF5/H5O_TOKEN_FROM_STR).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Otoken_from_str']).
 """
 function h5o_token_from_str(loc_id, token_str, token)
     lock(liblock)
@@ -2664,7 +2992,9 @@ end
 """
     h5o_token_to_str(loc_id::hid_t, token::Ptr{H5O_token_t}, token_str::Ptr{Ptr{Cchar}})
 
-See `libhdf5` documentation for [`H5Otoken_to_str`](https://portal.hdfgroup.org/display/HDF5/H5O_TOKEN_TO_STR).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Otoken_to_str']).
 """
 function h5o_token_to_str(loc_id, token, token_str)
     lock(liblock)
@@ -2681,7 +3011,9 @@ end
     @doc """
         h5o_visit(obj_id::hid_t, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate1_t, op_data::Ptr{Cvoid})
 
-    See `libhdf5` documentation for [`H5Ovisit1`](https://portal.hdfgroup.org/display/HDF5/H5O_VISIT1).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Ovisit1']).
     """
     function h5o_visit(obj_id, idx_type, order, op, op_data)
         lock(liblock)
@@ -2699,7 +3031,9 @@ end
     @doc """
         h5o_visit(obj_id::hid_t, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate2_t, op_data::Ptr{Cvoid}, fields::Cuint)
 
-    See `libhdf5` documentation for [`H5Ovisit3`](https://portal.hdfgroup.org/display/HDF5/H5O_VISIT3).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Ovisit3']).
     """
     function h5o_visit(obj_id, idx_type, order, op, op_data, fields)
         lock(liblock)
@@ -2717,7 +3051,9 @@ end
     @doc """
         h5o_visit_by_name(loc_id::hid_t, obj_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate1_t, op_data::Ptr{Cvoid}, lapl_id::hid_t)
 
-    See `libhdf5` documentation for [`H5Ovisit_by_name1`](https://portal.hdfgroup.org/display/HDF5/H5O_VISIT_BY_NAME1).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Ovisit_by_name1']).
     """
     function h5o_visit_by_name(loc_id, obj_name, idx_type, order, op, op_data, lapl_id)
         lock(liblock)
@@ -2735,7 +3071,9 @@ end
     @doc """
         h5o_visit_by_name(loc_id::hid_t, obj_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate2_t, op_data::Ptr{Cvoid}, fields::Cuint, lapl_id::hid_t)
 
-    See `libhdf5` documentation for [`H5Ovisit_by_name3`](https://portal.hdfgroup.org/display/HDF5/H5O_VISIT_BY_NAME3).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5O']/member[name='H5Ovisit_by_name3']).
     """
     function h5o_visit_by_name(loc_id, obj_name, idx_type, order, op, op_data, fields, lapl_id)
         lock(liblock)
@@ -2752,7 +3090,9 @@ end
 """
     h5p_get(plist_id::hid_t, name::Ptr{Cchar}, value::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pget`](https://portal.hdfgroup.org/display/HDF5/H5P_GET).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget']).
 """
 function h5p_get(plist_id, name, value)
     lock(liblock)
@@ -2768,7 +3108,9 @@ end
 """
     h5p_get_alignment(fapl_id::hid_t, threshold::Ref{hsize_t}, alignment::Ref{hsize_t})
 
-See `libhdf5` documentation for [`H5Pget_alignment`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_ALIGNMENT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_alignment']).
 """
 function h5p_get_alignment(fapl_id, threshold, alignment)
     lock(liblock)
@@ -2784,7 +3126,9 @@ end
 """
     h5p_get_alloc_time(plist_id::hid_t, alloc_time::Ptr{Cint})
 
-See `libhdf5` documentation for [`H5Pget_alloc_time`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_ALLOC_TIME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_alloc_time']).
 """
 function h5p_get_alloc_time(plist_id, alloc_time)
     lock(liblock)
@@ -2800,7 +3144,9 @@ end
 """
     h5p_get_append_flush(dapl_id::hid_t, dims::Cuint, boundary::Ptr{hsize_t}, func::Ptr{H5D_append_cb_t}, udata::Ptr{Ptr{Cvoid}})
 
-See `libhdf5` documentation for [`H5Pget_append_flush`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_APPEND_FLUSH).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_append_flush']).
 """
 function h5p_get_append_flush(dapl_id, dims, boundary, func, udata)
     lock(liblock)
@@ -2816,7 +3162,9 @@ end
 """
     h5p_get_attr_creation_order(plist_id::hid_t, crt_order_flags::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_attr_creation_order`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_ATTR_CREATION_ORDER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_attr_creation_order']).
 """
 function h5p_get_attr_creation_order(plist_id, crt_order_flags)
     lock(liblock)
@@ -2832,7 +3180,9 @@ end
 """
     h5p_get_attr_phase_change(plist_id::hid_t, max_compact::Ptr{Cuint}, min_dense::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_attr_phase_change`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_ATTR_PHASE_CHANGE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_attr_phase_change']).
 """
 function h5p_get_attr_phase_change(plist_id, max_compact, min_dense)
     lock(liblock)
@@ -2848,7 +3198,9 @@ end
 """
     h5p_get_btree_ratios(plist_id::hid_t, left::Ptr{Cdouble}, middle::Ptr{Cdouble}, right::Ptr{Cdouble})
 
-See `libhdf5` documentation for [`H5Pget_btree_ratios`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_BTREE_RATIOS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_btree_ratios']).
 """
 function h5p_get_btree_ratios(plist_id, left, middle, right)
     lock(liblock)
@@ -2864,7 +3216,9 @@ end
 """
     h5p_get_buffer(plist_id::hid_t, tconv::Ptr{Ptr{Cvoid}}, bkg::Ptr{Ptr{Cvoid}}) -> Csize_t
 
-See `libhdf5` documentation for [`H5Pget_buffer`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_BUFFER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_buffer']).
 """
 function h5p_get_buffer(plist_id, tconv, bkg)
     lock(liblock)
@@ -2880,7 +3234,9 @@ end
 """
     h5p_get_cache(plist_id::hid_t, mdc_nelmts::Ptr{Cint}, rdcc_nslots::Ptr{Csize_t}, rdcc_nbytes::Ptr{Csize_t}, rdcc_w0::Ptr{Cdouble})
 
-See `libhdf5` documentation for [`H5Pget_cache`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_CACHE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_cache']).
 """
 function h5p_get_cache(plist_id, mdc_nelmts, rdcc_nslots, rdcc_nbytes, rdcc_w0)
     lock(liblock)
@@ -2896,7 +3252,9 @@ end
 """
     h5p_get_char_encoding(plist_id::hid_t, encoding::Ref{Cint})
 
-See `libhdf5` documentation for [`H5Pget_char_encoding`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_CHAR_ENCODING).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_char_encoding']).
 """
 function h5p_get_char_encoding(plist_id, encoding)
     lock(liblock)
@@ -2912,7 +3270,9 @@ end
 """
     h5p_get_chunk(plist_id::hid_t, n_dims::Cint, dims::Ptr{hsize_t}) -> Int
 
-See `libhdf5` documentation for [`H5Pget_chunk`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_CHUNK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_chunk']).
 """
 function h5p_get_chunk(plist_id, n_dims, dims)
     lock(liblock)
@@ -2928,7 +3288,9 @@ end
 """
     h5p_get_chunk_cache(dapl_id::hid_t, rdcc_nslots::Ptr{Csize_t}, rdcc_nbytes::Ptr{Csize_t}, rdcc_w0::Ptr{Cdouble})
 
-See `libhdf5` documentation for [`H5Pget_chunk_cache`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_CHUNK_CACHE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_chunk_cache']).
 """
 function h5p_get_chunk_cache(dapl_id, rdcc_nslots, rdcc_nbytes, rdcc_w0)
     lock(liblock)
@@ -2944,7 +3306,9 @@ end
 """
     h5p_get_chunk_opts(plist_id::hid_t, opts::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_chunk_opts`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_CHUNK_OPTS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_chunk_opts']).
 """
 function h5p_get_chunk_opts(plist_id, opts)
     lock(liblock)
@@ -2960,7 +3324,9 @@ end
 """
     h5p_get_class(plist_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Pget_class`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_CLASS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_class']).
 """
 function h5p_get_class(plist_id)
     lock(liblock)
@@ -2976,7 +3342,9 @@ end
 """
     h5p_get_class_parent(pclass_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Pget_class_parent`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_CLASS_PARENT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_class_parent']).
 """
 function h5p_get_class_parent(pclass_id)
     lock(liblock)
@@ -2992,7 +3360,9 @@ end
 """
     h5p_get_copy_object(plist_id::hid_t, copy_options::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_copy_object`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_COPY_OBJECT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_copy_object']).
 """
 function h5p_get_copy_object(plist_id, copy_options)
     lock(liblock)
@@ -3008,7 +3378,9 @@ end
 """
     h5p_get_core_write_tracking(fapl_id::hid_t, is_enabled::Ptr{hbool_t}, page_size::Ptr{Csize_t})
 
-See `libhdf5` documentation for [`H5Pget_core_write_tracking`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_CORE_WRITE_TRACKING).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_core_write_tracking']).
 """
 function h5p_get_core_write_tracking(fapl_id, is_enabled, page_size)
     lock(liblock)
@@ -3024,7 +3396,9 @@ end
 """
     h5p_get_create_intermediate_group(lcpl_id::hid_t, crt_intermed_group::Ref{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_create_intermediate_group`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_CREATE_INTERMEDIATE_GROUP).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_create_intermediate_group']).
 """
 function h5p_get_create_intermediate_group(lcpl_id, crt_intermed_group)
     lock(liblock)
@@ -3040,7 +3414,9 @@ end
 """
     h5p_get_data_transform(plist_id::hid_t, expression::Ptr{Cchar}, size::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Pget_data_transform`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_DATA_TRANSFORM).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_data_transform']).
 """
 function h5p_get_data_transform(plist_id, expression, size)
     lock(liblock)
@@ -3056,7 +3432,9 @@ end
 """
     h5p_get_driver(plist_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Pget_driver`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_DRIVER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_driver']).
 """
 function h5p_get_driver(plist_id)
     lock(liblock)
@@ -3072,7 +3450,9 @@ end
 """
     h5p_get_driver_info(plist_id::hid_t) -> Ptr{Cvoid}
 
-See `libhdf5` documentation for [`H5Pget_driver_info`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_DRIVER_INFO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_driver_info']).
 """
 function h5p_get_driver_info(plist_id)
     lock(liblock)
@@ -3088,7 +3468,9 @@ end
 """
     h5p_get_dset_no_attrs_hint(dcpl_id::hid_t, minimize::Ptr{hbool_t})
 
-See `libhdf5` documentation for [`H5Pget_dset_no_attrs_hint`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_DSET_NO_ATTRS_HINT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_dset_no_attrs_hint']).
 """
 function h5p_get_dset_no_attrs_hint(dcpl_id, minimize)
     lock(liblock)
@@ -3104,7 +3486,9 @@ end
 """
     h5p_get_dxpl_mpio(dxpl_id::hid_t, xfer_mode::Ptr{Cint})
 
-See `libhdf5` documentation for [`H5Pget_dxpl_mpio`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_DXPL_MPIO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_dxpl_mpio']).
 """
 function h5p_get_dxpl_mpio(dxpl_id, xfer_mode)
     lock(liblock)
@@ -3120,7 +3504,9 @@ end
 """
     h5p_get_edc_check(plist_id::hid_t) -> H5Z_EDC_t
 
-See `libhdf5` documentation for [`H5Pget_edc_check`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_EDC_CHECK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_edc_check']).
 """
 function h5p_get_edc_check(plist_id)
     lock(liblock)
@@ -3136,7 +3522,9 @@ end
 """
     h5p_get_efile_prefix(dapl_id::hid_t, prefix::Ptr{UInt8}, size::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Pget_efile_prefix`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_EFILE_PREFIX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_efile_prefix']).
 """
 function h5p_get_efile_prefix(dapl_id, prefix, size)
     lock(liblock)
@@ -3152,7 +3540,9 @@ end
 """
     h5p_get_elink_acc_flags(lapl_id::hid_t, flags::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_elink_acc_flags`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_ELINK_ACC_FLAGS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_elink_acc_flags']).
 """
 function h5p_get_elink_acc_flags(lapl_id, flags)
     lock(liblock)
@@ -3168,7 +3558,9 @@ end
 """
     h5p_get_elink_cb(lapl_id::hid_t, func::Ptr{H5L_elink_traverse_t}, op_data::Ptr{Ptr{Cvoid}})
 
-See `libhdf5` documentation for [`H5Pget_elink_cb`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_ELINK_CB).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_elink_cb']).
 """
 function h5p_get_elink_cb(lapl_id, func, op_data)
     lock(liblock)
@@ -3184,7 +3576,9 @@ end
 """
     h5p_get_elink_fapl(lapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Pget_elink_fapl`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_ELINK_FAPL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_elink_fapl']).
 """
 function h5p_get_elink_fapl(lapl_id)
     lock(liblock)
@@ -3200,7 +3594,9 @@ end
 """
     h5p_get_elink_file_cache_size(plist_id::hid_t, efc_size::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_elink_file_cache_size`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_ELINK_FILE_CACHE_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_elink_file_cache_size']).
 """
 function h5p_get_elink_file_cache_size(plist_id, efc_size)
     lock(liblock)
@@ -3216,7 +3612,9 @@ end
 """
     h5p_get_elink_prefix(plist_id::hid_t, prefix::Ptr{Cchar}, size::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Pget_elink_prefix`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_ELINK_PREFIX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_elink_prefix']).
 """
 function h5p_get_elink_prefix(plist_id, prefix, size)
     lock(liblock)
@@ -3232,7 +3630,9 @@ end
 """
     h5p_get_est_link_info(plist_id::hid_t, est_num_entries::Ptr{Cuint}, est_name_len::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_est_link_info`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_EST_LINK_INFO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_est_link_info']).
 """
 function h5p_get_est_link_info(plist_id, est_num_entries, est_name_len)
     lock(liblock)
@@ -3248,7 +3648,9 @@ end
 """
     h5p_get_evict_on_close(fapl_id::hid_t, evict_on_close::Ptr{hbool_t})
 
-See `libhdf5` documentation for [`H5Pget_evict_on_close`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_EVICT_ON_CLOSE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_evict_on_close']).
 """
 function h5p_get_evict_on_close(fapl_id, evict_on_close)
     lock(liblock)
@@ -3264,7 +3666,9 @@ end
 """
     h5p_get_external(plist::hid_t, idx::Cuint, name_size::Csize_t, name::Ptr{Cuchar}, offset::Ptr{off_t}, size::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Pget_external`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_EXTERNAL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_external']).
 """
 function h5p_get_external(plist, idx, name_size, name, offset, size)
     lock(liblock)
@@ -3280,7 +3684,9 @@ end
 """
     h5p_get_external_count(plist::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Pget_external_count`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_EXTERNAL_COUNT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_external_count']).
 """
 function h5p_get_external_count(plist)
     lock(liblock)
@@ -3296,7 +3702,9 @@ end
 """
     h5p_get_family_offset(fapl_id::hid_t, offset::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Pget_family_offset`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FAMILY_OFFSET).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_family_offset']).
 """
 function h5p_get_family_offset(fapl_id, offset)
     lock(liblock)
@@ -3312,7 +3720,9 @@ end
 """
     h5p_get_fapl_core(fapl_id::hid_t, increment::Ptr{Csize_t}, backing_store::Ptr{hbool_t})
 
-See `libhdf5` documentation for [`H5Pget_fapl_core`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FAPL_CORE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_fapl_core']).
 """
 function h5p_get_fapl_core(fapl_id, increment, backing_store)
     lock(liblock)
@@ -3328,7 +3738,9 @@ end
 """
     h5p_get_fapl_family(fapl_id::hid_t, memb_size::Ptr{hsize_t}, memb_fapl_id::Ptr{hid_t})
 
-See `libhdf5` documentation for [`H5Pget_fapl_family`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FAPL_FAMILY).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_fapl_family']).
 """
 function h5p_get_fapl_family(fapl_id, memb_size, memb_fapl_id)
     lock(liblock)
@@ -3344,7 +3756,9 @@ end
 """
     h5p_get_fapl_hdfs(fapl_id::hid_t, fa_out::Ptr{H5FD_hdfs_fapl_t})
 
-See `libhdf5` documentation for [`H5Pget_fapl_hdfs`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FAPL_HDFS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_fapl_hdfs']).
 """
 function h5p_get_fapl_hdfs(fapl_id, fa_out)
     lock(liblock)
@@ -3360,7 +3774,9 @@ end
 """
     h5p_get_fapl_multi(fapl_id::hid_t, memb_map::Ptr{H5FD_mem_t}, memb_fapl::Ptr{hid_t}, memb_name::Ptr{Ptr{Cchar}}, memb_addr::Ptr{haddr_t}, relax::Ptr{hbool_t})
 
-See `libhdf5` documentation for [`H5Pget_fapl_multi`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FAPL_MULTI).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_fapl_multi']).
 """
 function h5p_get_fapl_multi(fapl_id, memb_map, memb_fapl, memb_name, memb_addr, relax)
     lock(liblock)
@@ -3376,7 +3792,9 @@ end
 """
     h5p_get_fapl_splitter(fapl_id::hid_t, config_ptr::Ptr{H5FD_splitter_vfd_config_t})
 
-See `libhdf5` documentation for [`H5Pget_fapl_splitter`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FAPL_SPLITTER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_fapl_splitter']).
 """
 function h5p_get_fapl_splitter(fapl_id, config_ptr)
     lock(liblock)
@@ -3392,7 +3810,9 @@ end
 """
     h5p_get_fapl_ros3(fapl_id::hid_t, fa_out::Ptr{H5FD_ros3_fapl_t})
 
-See `libhdf5` documentation for [`H5Pget_fapl_ros3`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FAPL_ROS3).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_fapl_ros3']).
 """
 function h5p_get_fapl_ros3(fapl_id, fa_out)
     lock(liblock)
@@ -3408,7 +3828,9 @@ end
 """
     h5p_get_fclose_degree(fapl_id::hid_t, fc_degree::Ref{Cint})
 
-See `libhdf5` documentation for [`H5Pget_fclose_degree`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FCLOSE_DEGREE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_fclose_degree']).
 """
 function h5p_get_fclose_degree(fapl_id, fc_degree)
     lock(liblock)
@@ -3424,7 +3846,9 @@ end
 """
     h5p_get_file_image(fapl_id::hid_t, buf_ptr_ptr::Ptr{Ptr{Cvoid}}, buf_len_ptr::Ptr{Csize_t})
 
-See `libhdf5` documentation for [`H5Pget_file_image`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FILE_IMAGE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_file_image']).
 """
 function h5p_get_file_image(fapl_id, buf_ptr_ptr, buf_len_ptr)
     lock(liblock)
@@ -3440,7 +3864,9 @@ end
 """
     h5p_get_file_image_callbacks(fapl_id::hid_t, callbacks_ptr::Ptr{H5FD_file_image_callbacks_t})
 
-See `libhdf5` documentation for [`H5Pget_file_image_callbacks`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FILE_IMAGE_CALLBACKS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_file_image_callbacks']).
 """
 function h5p_get_file_image_callbacks(fapl_id, callbacks_ptr)
     lock(liblock)
@@ -3456,7 +3882,9 @@ end
 """
     h5p_get_file_locking(fapl_id::hid_t, use_file_locking::Ptr{hbool_t}, ignore_when_disabled::Ptr{hbool_t})
 
-See `libhdf5` documentation for [`H5Pget_file_locking`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FILE_LOCKING).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_file_locking']).
 """
 function h5p_get_file_locking(fapl_id, use_file_locking, ignore_when_disabled)
     lock(liblock)
@@ -3472,7 +3900,9 @@ end
 """
     h5p_get_file_space(plist_id::hid_t, strategy::Ptr{H5F_file_space_type_t}, threshold::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Pget_file_space`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FILE_SPACE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_file_space']).
 """
 function h5p_get_file_space(plist_id, strategy, threshold)
     lock(liblock)
@@ -3488,7 +3918,9 @@ end
 """
     h5p_get_file_space_page_size(plist_id::hid_t, fsp_size::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Pget_file_space_page_size`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FILE_SPACE_PAGE_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_file_space_page_size']).
 """
 function h5p_get_file_space_page_size(plist_id, fsp_size)
     lock(liblock)
@@ -3504,7 +3936,9 @@ end
 """
     h5p_get_file_space_strategy(plist_id::hid_t, strategy::Ptr{H5F_fspace_strategy_t}, persist::Ptr{hbool_t}, threshold::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Pget_file_space_strategy`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FILE_SPACE_STRATEGY).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_file_space_strategy']).
 """
 function h5p_get_file_space_strategy(plist_id, strategy, persist, threshold)
     lock(liblock)
@@ -3520,7 +3954,9 @@ end
 """
     h5p_get_fill_time(plist_id::hid_t, fill_time::Ptr{H5D_fill_time_t})
 
-See `libhdf5` documentation for [`H5Pget_fill_time`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FILL_TIME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_fill_time']).
 """
 function h5p_get_fill_time(plist_id, fill_time)
     lock(liblock)
@@ -3536,7 +3972,9 @@ end
 """
     h5p_get_fill_value(plist_id::hid_t, type_id::hid_t, value::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pget_fill_value`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FILL_VALUE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_fill_value']).
 """
 function h5p_get_fill_value(plist_id, type_id, value)
     lock(liblock)
@@ -3552,7 +3990,9 @@ end
 """
     h5p_get_filter(plist_id::hid_t, idx::Cuint, flags::Ptr{Cuint}, cd_nemlts::Ref{Csize_t}, cd_values::Ptr{Cuint}, namelen::Csize_t, name::Ptr{Cchar}, filter_config::Ptr{Cuint}) -> H5Z_filter_t
 
-See `libhdf5` documentation for [`H5Pget_filter2`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FILTER2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_filter2']).
 """
 function h5p_get_filter(plist_id, idx, flags, cd_nemlts, cd_values, namelen, name, filter_config)
     lock(liblock)
@@ -3568,7 +4008,9 @@ end
 """
     h5p_get_filter_by_id(plist_id::hid_t, filter_id::H5Z_filter_t, flags::Ref{Cuint}, cd_nelmts::Ref{Csize_t}, cd_values::Ptr{Cuint}, namelen::Csize_t, name::Ptr{UInt8}, filter_config::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_filter_by_id2`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_FILTER_BY_ID2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_filter_by_id2']).
 """
 function h5p_get_filter_by_id(plist_id, filter_id, flags, cd_nelmts, cd_values, namelen, name, filter_config)
     lock(liblock)
@@ -3584,7 +4026,9 @@ end
 """
     h5p_get_gc_references(fapl_id::hid_t, gc_ref::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_gc_references`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_GC_REFERENCES).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_gc_references']).
 """
 function h5p_get_gc_references(fapl_id, gc_ref)
     lock(liblock)
@@ -3600,7 +4044,9 @@ end
 """
     h5p_get_hyper_vector_size(fapl_id::hid_t, size::Ptr{Csize_t})
 
-See `libhdf5` documentation for [`H5Pget_hyper_vector_size`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_HYPER_VECTOR_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_hyper_vector_size']).
 """
 function h5p_get_hyper_vector_size(fapl_id, size)
     lock(liblock)
@@ -3616,7 +4062,9 @@ end
 """
     h5p_get_istore_k(plist_id::hid_t, ik::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_istore_k`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_ISTORE_K).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_istore_k']).
 """
 function h5p_get_istore_k(plist_id, ik)
     lock(liblock)
@@ -3632,7 +4080,9 @@ end
 """
     h5p_get_layout(plist_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Pget_layout`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_LAYOUT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_layout']).
 """
 function h5p_get_layout(plist_id)
     lock(liblock)
@@ -3648,7 +4098,9 @@ end
 """
     h5p_get_libver_bounds(fapl_id::hid_t, low::Ref{Cint}, high::Ref{Cint})
 
-See `libhdf5` documentation for [`H5Pget_libver_bounds`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_LIBVER_BOUNDS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_libver_bounds']).
 """
 function h5p_get_libver_bounds(fapl_id, low, high)
     lock(liblock)
@@ -3664,7 +4116,9 @@ end
 """
     h5p_get_link_creation_order(plist_id::hid_t, crt_order_flags::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_link_creation_order`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_LINK_CREATION_ORDER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_link_creation_order']).
 """
 function h5p_get_link_creation_order(plist_id, crt_order_flags)
     lock(liblock)
@@ -3680,7 +4134,9 @@ end
 """
     h5p_get_link_phase_change(plist_id::hid_t, max_compact::Ptr{Cuint}, min_dense::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_link_phase_change`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_LINK_PHASE_CHANGE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_link_phase_change']).
 """
 function h5p_get_link_phase_change(plist_id, max_compact, min_dense)
     lock(liblock)
@@ -3696,7 +4152,9 @@ end
 """
     h5p_get_local_heap_size_hint(plist_id::hid_t, size_hint::Ref{Csize_t})
 
-See `libhdf5` documentation for [`H5Pget_local_heap_size_hint`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_LOCAL_HEAP_SIZE_HINT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_local_heap_size_hint']).
 """
 function h5p_get_local_heap_size_hint(plist_id, size_hint)
     lock(liblock)
@@ -3712,7 +4170,9 @@ end
 """
     h5p_get_mcdt_search_cb(plist_id::hid_t, func::Ptr{H5O_mcdt_search_cb_t}, op_data::Ptr{Ptr{Cvoid}})
 
-See `libhdf5` documentation for [`H5Pget_mcdt_search_cb`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_MCDT_SEARCH_CB).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_mcdt_search_cb']).
 """
 function h5p_get_mcdt_search_cb(plist_id, func, op_data)
     lock(liblock)
@@ -3728,7 +4188,9 @@ end
 """
     h5p_get_mdc_config(plist_id::hid_t, config_ptr::Ptr{H5AC_cache_config_t})
 
-See `libhdf5` documentation for [`H5Pget_mdc_config`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_MDC_CONFIG).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_mdc_config']).
 """
 function h5p_get_mdc_config(plist_id, config_ptr)
     lock(liblock)
@@ -3744,7 +4206,9 @@ end
 """
     h5p_get_mdc_image_config(plist_id::hid_t, config_ptr::Ptr{H5AC_cache_image_config_t})
 
-See `libhdf5` documentation for [`H5Pget_mdc_image_config`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_MDC_IMAGE_CONFIG).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_mdc_image_config']).
 """
 function h5p_get_mdc_image_config(plist_id, config_ptr)
     lock(liblock)
@@ -3760,7 +4224,9 @@ end
 """
     h5p_get_mdc_log_options(plist_id::hid_t, is_enabled::Ptr{hbool_t}, location::Ptr{Cchar}, location_size::Ptr{Csize_t}, start_on_access::Ptr{hbool_t})
 
-See `libhdf5` documentation for [`H5Pget_mdc_log_options`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_MDC_LOG_OPTIONS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_mdc_log_options']).
 """
 function h5p_get_mdc_log_options(plist_id, is_enabled, location, location_size, start_on_access)
     lock(liblock)
@@ -3776,7 +4242,9 @@ end
 """
     h5p_get_meta_block_size(fapl_id::hid_t, size::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Pget_meta_block_size`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_META_BLOCK_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_meta_block_size']).
 """
 function h5p_get_meta_block_size(fapl_id, size)
     lock(liblock)
@@ -3792,7 +4260,9 @@ end
 """
     h5p_get_metadata_read_attempts(plist_id::hid_t, attempts::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_metadata_read_attempts`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_METADATA_READ_ATTEMPTS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_metadata_read_attempts']).
 """
 function h5p_get_metadata_read_attempts(plist_id, attempts)
     lock(liblock)
@@ -3808,7 +4278,9 @@ end
 """
     h5p_get_multi_type(fapl_id::hid_t, type::Ptr{H5FD_mem_t})
 
-See `libhdf5` documentation for [`H5Pget_multi_type`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_MULTI_TYPE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_multi_type']).
 """
 function h5p_get_multi_type(fapl_id, type)
     lock(liblock)
@@ -3824,7 +4296,9 @@ end
 """
     h5p_get_nfilters(plist_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Pget_nfilters`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_NFILTERS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_nfilters']).
 """
 function h5p_get_nfilters(plist_id)
     lock(liblock)
@@ -3840,7 +4314,9 @@ end
 """
     h5p_get_nlinks(plist_id::hid_t, nlinks::Ptr{Csize_t})
 
-See `libhdf5` documentation for [`H5Pget_nlinks`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_NLINKS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_nlinks']).
 """
 function h5p_get_nlinks(plist_id, nlinks)
     lock(liblock)
@@ -3856,7 +4332,9 @@ end
 """
     h5p_get_nprops(id::hid_t, nprops::Ptr{Csize_t})
 
-See `libhdf5` documentation for [`H5Pget_nprops`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_NPROPS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_nprops']).
 """
 function h5p_get_nprops(id, nprops)
     lock(liblock)
@@ -3872,7 +4350,9 @@ end
 """
     h5p_get_obj_track_times(plist_id::hid_t, track_times::Ref{UInt8})
 
-See `libhdf5` documentation for [`H5Pget_obj_track_times`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_OBJ_TRACK_TIMES).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_obj_track_times']).
 """
 function h5p_get_obj_track_times(plist_id, track_times)
     lock(liblock)
@@ -3888,7 +4368,9 @@ end
 """
     h5p_get_object_flush_cb(plist_id::hid_t, func::Ptr{H5F_flush_cb_t}, udata::Ptr{Ptr{Cvoid}})
 
-See `libhdf5` documentation for [`H5Pget_object_flush_cb`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_OBJECT_FLUSH_CB).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_object_flush_cb']).
 """
 function h5p_get_object_flush_cb(plist_id, func, udata)
     lock(liblock)
@@ -3904,7 +4386,9 @@ end
 """
     h5p_get_page_buffer_size(plist_id::hid_t, buf_size::Ptr{Csize_t}, min_meta_perc::Ptr{Cuint}, min_raw_perc::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_page_buffer_size`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_PAGE_BUFFER_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_page_buffer_size']).
 """
 function h5p_get_page_buffer_size(plist_id, buf_size, min_meta_perc, min_raw_perc)
     lock(liblock)
@@ -3920,7 +4404,9 @@ end
 """
     h5p_get_preserve(plist_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Pget_preserve`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_PRESERVE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_preserve']).
 """
 function h5p_get_preserve(plist_id)
     lock(liblock)
@@ -3936,7 +4422,9 @@ end
 """
     h5p_get_shared_mesg_index(plist_id::hid_t, index_num::Cuint, mesg_type_flags::Ptr{Cuint}, min_mesg_size::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_shared_mesg_index`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_SHARED_MESG_INDEX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_shared_mesg_index']).
 """
 function h5p_get_shared_mesg_index(plist_id, index_num, mesg_type_flags, min_mesg_size)
     lock(liblock)
@@ -3952,7 +4440,9 @@ end
 """
     h5p_get_shared_mesg_nindexes(plist_id::hid_t, nindexes::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_shared_mesg_nindexes`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_SHARED_MESG_NINDEXES).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_shared_mesg_nindexes']).
 """
 function h5p_get_shared_mesg_nindexes(plist_id, nindexes)
     lock(liblock)
@@ -3968,7 +4458,9 @@ end
 """
     h5p_get_shared_mesg_phase_change(plist_id::hid_t, max_list::Ptr{Cuint}, min_btree::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_shared_mesg_phase_change`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_SHARED_MESG_PHASE_CHANGE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_shared_mesg_phase_change']).
 """
 function h5p_get_shared_mesg_phase_change(plist_id, max_list, min_btree)
     lock(liblock)
@@ -3984,7 +4476,9 @@ end
 """
     h5p_get_sieve_buf_size(fapl_id::hid_t, size::Ptr{Csize_t})
 
-See `libhdf5` documentation for [`H5Pget_sieve_buf_size`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_SIEVE_BUF_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_sieve_buf_size']).
 """
 function h5p_get_sieve_buf_size(fapl_id, size)
     lock(liblock)
@@ -4000,7 +4494,9 @@ end
 """
     h5p_get_size(id::hid_t, name::Ptr{Cchar}, size::Ptr{Csize_t})
 
-See `libhdf5` documentation for [`H5Pget_size`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_size']).
 """
 function h5p_get_size(id, name, size)
     lock(liblock)
@@ -4016,7 +4512,9 @@ end
 """
     h5p_get_sizes(plist_id::hid_t, sizeof_addr::Ptr{Csize_t}, sizeof_size::Ptr{Csize_t})
 
-See `libhdf5` documentation for [`H5Pget_sizes`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_SIZES).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_sizes']).
 """
 function h5p_get_sizes(plist_id, sizeof_addr, sizeof_size)
     lock(liblock)
@@ -4032,7 +4530,9 @@ end
 """
     h5p_get_small_data_block_size(fapl_id::hid_t, size::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Pget_small_data_block_size`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_SMALL_DATA_BLOCK_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_small_data_block_size']).
 """
 function h5p_get_small_data_block_size(fapl_id, size)
     lock(liblock)
@@ -4048,7 +4548,9 @@ end
 """
     h5p_get_sym_k(plist_id::hid_t, ik::Ptr{Cuint}, lk::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_sym_k`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_SYM_K).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_sym_k']).
 """
 function h5p_get_sym_k(plist_id, ik, lk)
     lock(liblock)
@@ -4064,7 +4566,9 @@ end
 """
     h5p_get_type_conv_cb(dxpl_id::hid_t, op::Ptr{H5T_conv_except_func_t}, operate_data::Ptr{Ptr{Cvoid}})
 
-See `libhdf5` documentation for [`H5Pget_type_conv_cb`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_TYPE_CONV_CB).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_type_conv_cb']).
 """
 function h5p_get_type_conv_cb(dxpl_id, op, operate_data)
     lock(liblock)
@@ -4080,7 +4584,9 @@ end
 """
     h5p_get_userblock(plist_id::hid_t, len::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Pget_userblock`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_USERBLOCK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_userblock']).
 """
 function h5p_get_userblock(plist_id, len)
     lock(liblock)
@@ -4096,7 +4602,9 @@ end
 """
     h5p_get_version(plist_id::hid_t, boot::Ptr{Cuint}, freelist::Ptr{Cuint}, stab::Ptr{Cuint}, shhdr::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pget_version`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_VERSION).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_version']).
 """
 function h5p_get_version(plist_id, boot, freelist, stab, shhdr)
     lock(liblock)
@@ -4112,7 +4620,9 @@ end
 """
     h5p_get_virtual_count(dcpl_id::hid_t, count::Ptr{Csize_t})
 
-See `libhdf5` documentation for [`H5Pget_virtual_count`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_VIRTUAL_COUNT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_virtual_count']).
 """
 function h5p_get_virtual_count(dcpl_id, count)
     lock(liblock)
@@ -4128,7 +4638,9 @@ end
 """
     h5p_get_virtual_dsetname(dcpl_id::hid_t, index::Csize_t, name::Ptr{Cchar}, size::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Pget_virtual_dsetname`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_VIRTUAL_DSETNAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_virtual_dsetname']).
 """
 function h5p_get_virtual_dsetname(dcpl_id, index, name, size)
     lock(liblock)
@@ -4144,7 +4656,9 @@ end
 """
     h5p_get_virtual_filename(dcpl_id::hid_t, index::Csize_t, name::Ptr{Cchar}, size::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Pget_virtual_filename`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_VIRTUAL_FILENAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_virtual_filename']).
 """
 function h5p_get_virtual_filename(dcpl_id, index, name, size)
     lock(liblock)
@@ -4160,7 +4674,9 @@ end
 """
     h5p_get_virtual_prefix(dapl_id::hid_t, prefix::Ptr{Cchar}, size::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5Pget_virtual_prefix`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_VIRTUAL_PREFIX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_virtual_prefix']).
 """
 function h5p_get_virtual_prefix(dapl_id, prefix, size)
     lock(liblock)
@@ -4176,7 +4692,9 @@ end
 """
     h5p_get_virtual_printf_gap(dapl_id::hid_t, gap_size::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Pget_virtual_printf_gap`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_VIRTUAL_PRINTF_GAP).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_virtual_printf_gap']).
 """
 function h5p_get_virtual_printf_gap(dapl_id, gap_size)
     lock(liblock)
@@ -4192,7 +4710,9 @@ end
 """
     h5p_get_virtual_srcspace(dcpl_id::hid_t, index::Csize_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Pget_virtual_srcspace`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_VIRTUAL_SRCSPACE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_virtual_srcspace']).
 """
 function h5p_get_virtual_srcspace(dcpl_id, index)
     lock(liblock)
@@ -4208,7 +4728,9 @@ end
 """
     h5p_get_virtual_view(dapl_id::hid_t, view::Ptr{H5D_vds_view_t})
 
-See `libhdf5` documentation for [`H5Pget_virtual_view`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_VIRTUAL_VIEW).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_virtual_view']).
 """
 function h5p_get_virtual_view(dapl_id, view)
     lock(liblock)
@@ -4224,7 +4746,9 @@ end
 """
     h5p_get_virtual_vspace(dcpl_id::hid_t, index::Csize_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Pget_virtual_vspace`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_VIRTUAL_VSPACE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_virtual_vspace']).
 """
 function h5p_get_virtual_vspace(dcpl_id, index)
     lock(liblock)
@@ -4240,7 +4764,9 @@ end
 """
     h5p_get_vlen_mem_manager(plist_id::hid_t, alloc_func::Ptr{H5MM_allocate_t}, alloc_info::Ptr{Ptr{Cvoid}}, free_func::Ptr{H5MM_free_t}, free_info::Ptr{Ptr{Cvoid}})
 
-See `libhdf5` documentation for [`H5Pget_vlen_mem_manager`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_VLEN_MEM_MANAGER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_vlen_mem_manager']).
 """
 function h5p_get_vlen_mem_manager(plist_id, alloc_func, alloc_info, free_func, free_info)
     lock(liblock)
@@ -4256,7 +4782,9 @@ end
 """
     h5p_get_vol_id(plist_id::hid_t, vol_id::Ptr{hid_t})
 
-See `libhdf5` documentation for [`H5Pget_vol_id`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_VOL_ID).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_vol_id']).
 """
 function h5p_get_vol_id(plist_id, vol_id)
     lock(liblock)
@@ -4272,7 +4800,9 @@ end
 """
     h5p_get_vol_info(plist_id::hid_t, vol_info::Ptr{Ptr{Cvoid}})
 
-See `libhdf5` documentation for [`H5Pget_vol_info`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_VOL_INFO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pget_vol_info']).
 """
 function h5p_get_vol_info(plist_id, vol_info)
     lock(liblock)
@@ -4288,7 +4818,9 @@ end
 """
     h5p_set(plist_id::hid_t, name::Ptr{Cchar}, value::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pset`](https://portal.hdfgroup.org/display/HDF5/H5P_SET).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset']).
 """
 function h5p_set(plist_id, name, value)
     lock(liblock)
@@ -4304,7 +4836,9 @@ end
 """
     h5p_set_alignment(plist_id::hid_t, threshold::hsize_t, alignment::hsize_t)
 
-See `libhdf5` documentation for [`H5Pset_alignment`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_ALIGNMENT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_alignment']).
 """
 function h5p_set_alignment(plist_id, threshold, alignment)
     lock(liblock)
@@ -4320,7 +4854,9 @@ end
 """
     h5p_set_alloc_time(plist_id::hid_t, alloc_time::Cint)
 
-See `libhdf5` documentation for [`H5Pset_alloc_time`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_ALLOC_TIME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_alloc_time']).
 """
 function h5p_set_alloc_time(plist_id, alloc_time)
     lock(liblock)
@@ -4336,7 +4872,9 @@ end
 """
     h5p_set_append_flush(dapl_id::hid_t, ndims::Cuint, boundary::Ptr{hsize_t}, func::H5D_append_cb_t, udata::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pset_append_flush`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_APPEND_FLUSH).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_append_flush']).
 """
 function h5p_set_append_flush(dapl_id, ndims, boundary, func, udata)
     lock(liblock)
@@ -4352,7 +4890,9 @@ end
 """
     h5p_set_attr_creation_order(plist_id::hid_t, crt_order_flags::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_attr_creation_order`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_ATTR_CREATION_ORDER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_attr_creation_order']).
 """
 function h5p_set_attr_creation_order(plist_id, crt_order_flags)
     lock(liblock)
@@ -4368,7 +4908,9 @@ end
 """
     h5p_set_attr_phase_change(plist_id::hid_t, max_compact::Cuint, min_dense::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_attr_phase_change`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_ATTR_PHASE_CHANGE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_attr_phase_change']).
 """
 function h5p_set_attr_phase_change(plist_id, max_compact, min_dense)
     lock(liblock)
@@ -4384,7 +4926,9 @@ end
 """
     h5p_set_btree_ratios(plist_id::hid_t, left::Cdouble, middle::Cdouble, right::Cdouble)
 
-See `libhdf5` documentation for [`H5Pset_btree_ratios`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_BTREE_RATIOS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_btree_ratios']).
 """
 function h5p_set_btree_ratios(plist_id, left, middle, right)
     lock(liblock)
@@ -4400,7 +4944,9 @@ end
 """
     h5p_set_buffer(plist_id::hid_t, size::Csize_t, tconv::Ptr{Cvoid}, bkg::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pset_buffer`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_BUFFER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_buffer']).
 """
 function h5p_set_buffer(plist_id, size, tconv, bkg)
     lock(liblock)
@@ -4416,7 +4962,9 @@ end
 """
     h5p_set_cache(plist_id::hid_t, mdc_nelmts::Cint, rdcc_nslots::Csize_t, rdcc_nbytes::Csize_t, rdcc_w0::Cdouble)
 
-See `libhdf5` documentation for [`H5Pset_cache`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_CACHE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_cache']).
 """
 function h5p_set_cache(plist_id, mdc_nelmts, rdcc_nslots, rdcc_nbytes, rdcc_w0)
     lock(liblock)
@@ -4432,7 +4980,9 @@ end
 """
     h5p_set_char_encoding(plist_id::hid_t, encoding::Cint)
 
-See `libhdf5` documentation for [`H5Pset_char_encoding`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_CHAR_ENCODING).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_char_encoding']).
 """
 function h5p_set_char_encoding(plist_id, encoding)
     lock(liblock)
@@ -4448,7 +4998,9 @@ end
 """
     h5p_set_chunk(plist_id::hid_t, ndims::Cint, dims::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Pset_chunk`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_CHUNK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_chunk']).
 """
 function h5p_set_chunk(plist_id, ndims, dims)
     lock(liblock)
@@ -4464,7 +5016,9 @@ end
 """
     h5p_set_chunk_cache(dapl_id::hid_t, rdcc_nslots::Csize_t, rdcc_nbytes::Csize_t, rdcc_w0::Cdouble)
 
-See `libhdf5` documentation for [`H5Pset_chunk_cache`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_CHUNK_CACHE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_chunk_cache']).
 """
 function h5p_set_chunk_cache(dapl_id, rdcc_nslots, rdcc_nbytes, rdcc_w0)
     lock(liblock)
@@ -4480,7 +5034,9 @@ end
 """
     h5p_set_chunk_opts(plist_id::hid_t, opts::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_chunk_opts`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_CHUNK_OPTS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_chunk_opts']).
 """
 function h5p_set_chunk_opts(plist_id, opts)
     lock(liblock)
@@ -4496,7 +5052,9 @@ end
 """
     h5p_set_copy_object(plist_id::hid_t, copy_options::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_copy_object`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_COPY_OBJECT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_copy_object']).
 """
 function h5p_set_copy_object(plist_id, copy_options)
     lock(liblock)
@@ -4512,7 +5070,9 @@ end
 """
     h5p_set_core_write_tracking(fapl_id::hid_t, is_enabled::hbool_t, page_size::Csize_t)
 
-See `libhdf5` documentation for [`H5Pset_core_write_tracking`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_CORE_WRITE_TRACKING).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_core_write_tracking']).
 """
 function h5p_set_core_write_tracking(fapl_id, is_enabled, page_size)
     lock(liblock)
@@ -4528,7 +5088,9 @@ end
 """
     h5p_set_create_intermediate_group(plist_id::hid_t, setting::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_create_intermediate_group`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_CREATE_INTERMEDIATE_GROUP).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_create_intermediate_group']).
 """
 function h5p_set_create_intermediate_group(plist_id, setting)
     lock(liblock)
@@ -4544,7 +5106,9 @@ end
 """
     h5p_set_data_transform(plist_id::hid_t, expression::Ptr{Cchar})
 
-See `libhdf5` documentation for [`H5Pset_data_transform`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_DATA_TRANSFORM).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_data_transform']).
 """
 function h5p_set_data_transform(plist_id, expression)
     lock(liblock)
@@ -4560,7 +5124,9 @@ end
 """
     h5p_set_deflate(plist_id::hid_t, setting::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_deflate`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_DEFLATE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_deflate']).
 """
 function h5p_set_deflate(plist_id, setting)
     lock(liblock)
@@ -4576,7 +5142,9 @@ end
 """
     h5p_set_driver(plist_id::hid_t, driver_id::hid_t, driver_info::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pset_driver`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_DRIVER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_driver']).
 """
 function h5p_set_driver(plist_id, driver_id, driver_info)
     lock(liblock)
@@ -4592,7 +5160,9 @@ end
 """
     h5p_set_dset_no_attrs_hint(dcpl_id::hid_t, minimize::hbool_t)
 
-See `libhdf5` documentation for [`H5Pset_dset_no_attrs_hint`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_DSET_NO_ATTRS_HINT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_dset_no_attrs_hint']).
 """
 function h5p_set_dset_no_attrs_hint(dcpl_id, minimize)
     lock(liblock)
@@ -4608,7 +5178,9 @@ end
 """
     h5p_set_dxpl_mpio(dxpl_id::hid_t, xfer_mode::Cint)
 
-See `libhdf5` documentation for [`H5Pset_dxpl_mpio`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_DXPL_MPIO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_dxpl_mpio']).
 """
 function h5p_set_dxpl_mpio(dxpl_id, xfer_mode)
     lock(liblock)
@@ -4624,7 +5196,9 @@ end
 """
     h5p_set_edc_check(plist_id::hid_t, check::H5Z_EDC_t)
 
-See `libhdf5` documentation for [`H5Pset_edc_check`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_EDC_CHECK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_edc_check']).
 """
 function h5p_set_edc_check(plist_id, check)
     lock(liblock)
@@ -4640,7 +5214,9 @@ end
 """
     h5p_set_efile_prefix(plist_id::hid_t, prefix::Ptr{UInt8})
 
-See `libhdf5` documentation for [`H5Pset_efile_prefix`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_EFILE_PREFIX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_efile_prefix']).
 """
 function h5p_set_efile_prefix(plist_id, prefix)
     lock(liblock)
@@ -4656,7 +5232,9 @@ end
 """
     h5p_set_elink_acc_flags(lapl_id::hid_t, flags::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_elink_acc_flags`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_ELINK_ACC_FLAGS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_elink_acc_flags']).
 """
 function h5p_set_elink_acc_flags(lapl_id, flags)
     lock(liblock)
@@ -4672,7 +5250,9 @@ end
 """
     h5p_set_elink_cb(lapl_id::hid_t, func::H5L_elink_traverse_t, op_data::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pset_elink_cb`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_ELINK_CB).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_elink_cb']).
 """
 function h5p_set_elink_cb(lapl_id, func, op_data)
     lock(liblock)
@@ -4688,7 +5268,9 @@ end
 """
     h5p_set_elink_fapl(lapl_id::hid_t, fapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Pset_elink_fapl`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_ELINK_FAPL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_elink_fapl']).
 """
 function h5p_set_elink_fapl(lapl_id, fapl_id)
     lock(liblock)
@@ -4704,7 +5286,9 @@ end
 """
     h5p_set_elink_file_cache_size(plist_id::hid_t, efc_size::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_elink_file_cache_size`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_ELINK_FILE_CACHE_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_elink_file_cache_size']).
 """
 function h5p_set_elink_file_cache_size(plist_id, efc_size)
     lock(liblock)
@@ -4720,7 +5304,9 @@ end
 """
     h5p_set_elink_prefix(plist_id::hid_t, prefix::Ptr{Cchar})
 
-See `libhdf5` documentation for [`H5Pset_elink_prefix`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_ELINK_PREFIX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_elink_prefix']).
 """
 function h5p_set_elink_prefix(plist_id, prefix)
     lock(liblock)
@@ -4736,7 +5322,9 @@ end
 """
     h5p_set_est_link_info(plist_id::hid_t, est_num_entries::Cuint, est_name_len::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_est_link_info`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_EST_LINK_INFO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_est_link_info']).
 """
 function h5p_set_est_link_info(plist_id, est_num_entries, est_name_len)
     lock(liblock)
@@ -4752,7 +5340,9 @@ end
 """
     h5p_set_evict_on_close(fapl_id::hid_t, evict_on_close::hbool_t)
 
-See `libhdf5` documentation for [`H5Pset_evict_on_close`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_EVICT_ON_CLOSE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_evict_on_close']).
 """
 function h5p_set_evict_on_close(fapl_id, evict_on_close)
     lock(liblock)
@@ -4768,7 +5358,9 @@ end
 """
     h5p_set_external(plist_id::hid_t, name::Ptr{Cchar}, offset::off_t, size::hsize_t)
 
-See `libhdf5` documentation for [`H5Pset_external`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_EXTERNAL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_external']).
 """
 function h5p_set_external(plist_id, name, offset, size)
     lock(liblock)
@@ -4784,7 +5376,9 @@ end
 """
     h5p_set_family_offset(fapl_id::hid_t, offset::hsize_t)
 
-See `libhdf5` documentation for [`H5Pset_family_offset`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAMILY_OFFSET).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_family_offset']).
 """
 function h5p_set_family_offset(fapl_id, offset)
     lock(liblock)
@@ -4800,7 +5394,9 @@ end
 """
     h5p_set_fapl_core(fapl_id::hid_t, increment::Csize_t, backing_store::hbool_t)
 
-See `libhdf5` documentation for [`H5Pset_fapl_core`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_CORE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fapl_core']).
 """
 function h5p_set_fapl_core(fapl_id, increment, backing_store)
     lock(liblock)
@@ -4816,7 +5412,9 @@ end
 """
     h5p_set_fapl_family(fapl_id::hid_t, memb_size::hsize_t, memb_fapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Pset_fapl_family`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_FAMILY).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fapl_family']).
 """
 function h5p_set_fapl_family(fapl_id, memb_size, memb_fapl_id)
     lock(liblock)
@@ -4832,7 +5430,9 @@ end
 """
     h5p_set_fapl_hdfs(fapl_id::hid_t, fa::Ptr{H5FD_hdfs_fapl_t})
 
-See `libhdf5` documentation for [`H5Pset_fapl_hdfs`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_HDFS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fapl_hdfs']).
 """
 function h5p_set_fapl_hdfs(fapl_id, fa)
     lock(liblock)
@@ -4848,7 +5448,9 @@ end
 """
     h5p_set_fapl_log(fapl_id::hid_t, logfile::Ptr{Cchar}, flags::Culonglong, buf_size::Csize_t)
 
-See `libhdf5` documentation for [`H5Pset_fapl_log`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_LOG).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fapl_log']).
 """
 function h5p_set_fapl_log(fapl_id, logfile, flags, buf_size)
     lock(liblock)
@@ -4864,7 +5466,9 @@ end
 """
     h5p_set_fapl_multi(fapl_id::hid_t, memb_map::Ptr{H5FD_mem_t}, memb_fapl::Ptr{hid_t}, memb_name::Ptr{Ptr{Cchar}}, memb_addr::Ptr{haddr_t}, relax::hbool_t)
 
-See `libhdf5` documentation for [`H5Pset_fapl_multi`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_MULTI).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fapl_multi']).
 """
 function h5p_set_fapl_multi(fapl_id, memb_map, memb_fapl, memb_name, memb_addr, relax)
     lock(liblock)
@@ -4880,7 +5484,9 @@ end
 """
     h5p_set_fapl_sec2(fapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Pset_fapl_sec2`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_SEC2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fapl_sec2']).
 """
 function h5p_set_fapl_sec2(fapl_id)
     lock(liblock)
@@ -4896,7 +5502,9 @@ end
 """
     h5p_set_fapl_ros3(fapl_id::hid_t, fa::Ptr{H5FD_ros3_fapl_t})
 
-See `libhdf5` documentation for [`H5Pset_fapl_ros3`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_ROS3).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fapl_ros3']).
 """
 function h5p_set_fapl_ros3(fapl_id, fa)
     lock(liblock)
@@ -4912,7 +5520,9 @@ end
 """
     h5p_set_fapl_split(fapl::hid_t, meta_ext::Ptr{Cchar}, meta_plist_id::hid_t, raw_ext::Ptr{Cchar}, raw_plist_id::hid_t)
 
-See `libhdf5` documentation for [`H5Pset_fapl_split`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_SPLIT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fapl_split']).
 """
 function h5p_set_fapl_split(fapl, meta_ext, meta_plist_id, raw_ext, raw_plist_id)
     lock(liblock)
@@ -4928,7 +5538,9 @@ end
 """
     h5p_set_fapl_splitter(fapl_id::hid_t, config_ptr::Ptr{H5FD_splitter_vfd_config_t})
 
-See `libhdf5` documentation for [`H5Pset_fapl_splitter`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_SPLITTER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fapl_splitter']).
 """
 function h5p_set_fapl_splitter(fapl_id, config_ptr)
     lock(liblock)
@@ -4944,7 +5556,9 @@ end
 """
     h5p_set_fapl_stdio(fapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Pset_fapl_stdio`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_STDIO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fapl_stdio']).
 """
 function h5p_set_fapl_stdio(fapl_id)
     lock(liblock)
@@ -4960,7 +5574,9 @@ end
 """
     h5p_set_fapl_windows(fapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Pset_fapl_windows`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_WINDOWS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fapl_windows']).
 """
 function h5p_set_fapl_windows(fapl_id)
     lock(liblock)
@@ -4976,7 +5592,9 @@ end
 """
     h5p_set_fclose_degree(plist_id::hid_t, fc_degree::Cint)
 
-See `libhdf5` documentation for [`H5Pset_fclose_degree`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FCLOSE_DEGREE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fclose_degree']).
 """
 function h5p_set_fclose_degree(plist_id, fc_degree)
     lock(liblock)
@@ -4992,7 +5610,9 @@ end
 """
     h5p_set_file_image(fapl_id::hid_t, buf_ptr::Ptr{Cvoid}, buf_len::Csize_t)
 
-See `libhdf5` documentation for [`H5Pset_file_image`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FILE_IMAGE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_file_image']).
 """
 function h5p_set_file_image(fapl_id, buf_ptr, buf_len)
     lock(liblock)
@@ -5008,7 +5628,9 @@ end
 """
     h5p_set_file_image_callbacks(fapl_id::hid_t, callbacks_ptr::Ptr{H5FD_file_image_callbacks_t})
 
-See `libhdf5` documentation for [`H5Pset_file_image_callbacks`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FILE_IMAGE_CALLBACKS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_file_image_callbacks']).
 """
 function h5p_set_file_image_callbacks(fapl_id, callbacks_ptr)
     lock(liblock)
@@ -5024,7 +5646,9 @@ end
 """
     h5p_set_file_locking(fapl_id::hid_t, use_file_locking::hbool_t, ignore_when_disabled::hbool_t)
 
-See `libhdf5` documentation for [`H5Pset_file_locking`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FILE_LOCKING).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_file_locking']).
 """
 function h5p_set_file_locking(fapl_id, use_file_locking, ignore_when_disabled)
     lock(liblock)
@@ -5040,7 +5664,9 @@ end
 """
     h5p_set_file_space(plist_id::hid_t, strategy::H5F_file_space_type_t, threshold::hsize_t)
 
-See `libhdf5` documentation for [`H5Pset_file_space`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FILE_SPACE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_file_space']).
 """
 function h5p_set_file_space(plist_id, strategy, threshold)
     lock(liblock)
@@ -5056,7 +5682,9 @@ end
 """
     h5p_set_file_space_page_size(plist_id::hid_t, fsp_size::hsize_t)
 
-See `libhdf5` documentation for [`H5Pset_file_space_page_size`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FILE_SPACE_PAGE_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_file_space_page_size']).
 """
 function h5p_set_file_space_page_size(plist_id, fsp_size)
     lock(liblock)
@@ -5072,7 +5700,9 @@ end
 """
     h5p_set_file_space_strategy(plist_id::hid_t, strategy::H5F_fspace_strategy_t, persist::hbool_t, threshold::hsize_t)
 
-See `libhdf5` documentation for [`H5Pset_file_space_strategy`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FILE_SPACE_STRATEGY).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_file_space_strategy']).
 """
 function h5p_set_file_space_strategy(plist_id, strategy, persist, threshold)
     lock(liblock)
@@ -5088,7 +5718,9 @@ end
 """
     h5p_set_fill_time(plist_id::hid_t, fill_time::H5D_fill_time_t)
 
-See `libhdf5` documentation for [`H5Pset_fill_time`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FILL_TIME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fill_time']).
 """
 function h5p_set_fill_time(plist_id, fill_time)
     lock(liblock)
@@ -5104,7 +5736,9 @@ end
 """
     h5p_set_fill_value(plist_id::hid_t, type_id::hid_t, value::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pset_fill_value`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FILL_VALUE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fill_value']).
 """
 function h5p_set_fill_value(plist_id, type_id, value)
     lock(liblock)
@@ -5120,7 +5754,9 @@ end
 """
     h5p_set_filter(plist_id::hid_t, filter_id::H5Z_filter_t, flags::Cuint, cd_nelmts::Csize_t, cd_values::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pset_filter`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FILTER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_filter']).
 """
 function h5p_set_filter(plist_id, filter_id, flags, cd_nelmts, cd_values)
     lock(liblock)
@@ -5136,7 +5772,9 @@ end
 """
     h5p_set_filter_callback(plist_id::hid_t, func::H5Z_filter_func_t, op_data::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pset_filter_callback`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FILTER_CALLBACK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_filter_callback']).
 """
 function h5p_set_filter_callback(plist_id, func, op_data)
     lock(liblock)
@@ -5152,7 +5790,9 @@ end
 """
     h5p_set_fletcher32(plist_id::hid_t)
 
-See `libhdf5` documentation for [`H5Pset_fletcher32`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FLETCHER32).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_fletcher32']).
 """
 function h5p_set_fletcher32(plist_id)
     lock(liblock)
@@ -5168,7 +5808,9 @@ end
 """
     h5p_set_gc_references(fapl_id::hid_t, gc_ref::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_gc_references`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_GC_REFERENCES).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_gc_references']).
 """
 function h5p_set_gc_references(fapl_id, gc_ref)
     lock(liblock)
@@ -5184,7 +5826,9 @@ end
 """
     h5p_set_hyper_vector_size(plist_id::hid_t, size::Csize_t)
 
-See `libhdf5` documentation for [`H5Pset_hyper_vector_size`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_HYPER_VECTOR_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_hyper_vector_size']).
 """
 function h5p_set_hyper_vector_size(plist_id, size)
     lock(liblock)
@@ -5200,7 +5844,9 @@ end
 """
     h5p_set_istore_k(plist_id::hid_t, ik::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_istore_k`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_ISTORE_K).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_istore_k']).
 """
 function h5p_set_istore_k(plist_id, ik)
     lock(liblock)
@@ -5216,7 +5862,9 @@ end
 """
     h5p_set_layout(plist_id::hid_t, setting::Cint)
 
-See `libhdf5` documentation for [`H5Pset_layout`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_LAYOUT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_layout']).
 """
 function h5p_set_layout(plist_id, setting)
     lock(liblock)
@@ -5232,7 +5880,9 @@ end
 """
     h5p_set_libver_bounds(fapl_id::hid_t, low::Cint, high::Cint)
 
-See `libhdf5` documentation for [`H5Pset_libver_bounds`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_LIBVER_BOUNDS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_libver_bounds']).
 """
 function h5p_set_libver_bounds(fapl_id, low, high)
     lock(liblock)
@@ -5248,7 +5898,9 @@ end
 """
     h5p_set_link_creation_order(plist_id::hid_t, crt_order_flags::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_link_creation_order`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_LINK_CREATION_ORDER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_link_creation_order']).
 """
 function h5p_set_link_creation_order(plist_id, crt_order_flags)
     lock(liblock)
@@ -5264,7 +5916,9 @@ end
 """
     h5p_set_link_phase_change(plist_id::hid_t, max_compact::Cuint, min_dense::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_link_phase_change`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_LINK_PHASE_CHANGE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_link_phase_change']).
 """
 function h5p_set_link_phase_change(plist_id, max_compact, min_dense)
     lock(liblock)
@@ -5280,7 +5934,9 @@ end
 """
     h5p_set_local_heap_size_hint(plist_id::hid_t, size_hint::Csize_t)
 
-See `libhdf5` documentation for [`H5Pset_local_heap_size_hint`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_LOCAL_HEAP_SIZE_HINT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_local_heap_size_hint']).
 """
 function h5p_set_local_heap_size_hint(plist_id, size_hint)
     lock(liblock)
@@ -5296,7 +5952,9 @@ end
 """
     h5p_set_mcdt_search_cb(plist_id::hid_t, func::H5O_mcdt_search_cb_t, op_data::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pset_mcdt_search_cb`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_MCDT_SEARCH_CB).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_mcdt_search_cb']).
 """
 function h5p_set_mcdt_search_cb(plist_id, func, op_data)
     lock(liblock)
@@ -5312,7 +5970,9 @@ end
 """
     h5p_set_mdc_config(plist_id::hid_t, config_ptr::Ptr{H5AC_cache_config_t})
 
-See `libhdf5` documentation for [`H5Pset_mdc_config`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_MDC_CONFIG).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_mdc_config']).
 """
 function h5p_set_mdc_config(plist_id, config_ptr)
     lock(liblock)
@@ -5328,7 +5988,9 @@ end
 """
     h5p_set_mdc_image_config(plist_id::hid_t, config_ptr::Ptr{H5AC_cache_image_config_t})
 
-See `libhdf5` documentation for [`H5Pset_mdc_image_config`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_MDC_IMAGE_CONFIG).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_mdc_image_config']).
 """
 function h5p_set_mdc_image_config(plist_id, config_ptr)
     lock(liblock)
@@ -5344,7 +6006,9 @@ end
 """
     h5p_set_mdc_log_options(plist_id::hid_t, is_enabled::hbool_t, location::Ptr{Cchar}, start_on_access::hbool_t)
 
-See `libhdf5` documentation for [`H5Pset_mdc_log_options`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_MDC_LOG_OPTIONS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_mdc_log_options']).
 """
 function h5p_set_mdc_log_options(plist_id, is_enabled, location, start_on_access)
     lock(liblock)
@@ -5360,7 +6024,9 @@ end
 """
     h5p_set_meta_block_size(fapl_id::hid_t, size::hsize_t)
 
-See `libhdf5` documentation for [`H5Pset_meta_block_size`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_META_BLOCK_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_meta_block_size']).
 """
 function h5p_set_meta_block_size(fapl_id, size)
     lock(liblock)
@@ -5376,7 +6042,9 @@ end
 """
     h5p_set_metadata_read_attempts(plist_id::hid_t, attempts::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_metadata_read_attempts`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_METADATA_READ_ATTEMPTS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_metadata_read_attempts']).
 """
 function h5p_set_metadata_read_attempts(plist_id, attempts)
     lock(liblock)
@@ -5392,7 +6060,9 @@ end
 """
     h5p_set_multi_type(fapl_id::hid_t, type::H5FD_mem_t)
 
-See `libhdf5` documentation for [`H5Pset_multi_type`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_MULTI_TYPE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_multi_type']).
 """
 function h5p_set_multi_type(fapl_id, type)
     lock(liblock)
@@ -5408,7 +6078,9 @@ end
 """
     h5p_set_nbit(plist_id::hid_t)
 
-See `libhdf5` documentation for [`H5Pset_nbit`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_NBIT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_nbit']).
 """
 function h5p_set_nbit(plist_id)
     lock(liblock)
@@ -5424,7 +6096,9 @@ end
 """
     h5p_set_nlinks(plist_id::hid_t, nlinks::Csize_t)
 
-See `libhdf5` documentation for [`H5Pset_nlinks`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_NLINKS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_nlinks']).
 """
 function h5p_set_nlinks(plist_id, nlinks)
     lock(liblock)
@@ -5440,7 +6114,9 @@ end
 """
     h5p_set_obj_track_times(plist_id::hid_t, track_times::UInt8)
 
-See `libhdf5` documentation for [`H5Pset_obj_track_times`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_OBJ_TRACK_TIMES).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_obj_track_times']).
 """
 function h5p_set_obj_track_times(plist_id, track_times)
     lock(liblock)
@@ -5456,7 +6132,9 @@ end
 """
     h5p_set_object_flush_cb(plist_id::hid_t, func::H5F_flush_cb_t, udata::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pset_object_flush_cb`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_OBJECT_FLUSH_CB).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_object_flush_cb']).
 """
 function h5p_set_object_flush_cb(plist_id, func, udata)
     lock(liblock)
@@ -5472,7 +6150,9 @@ end
 """
     h5p_set_page_buffer_size(plist_id::hid_t, buf_size::Csize_t, min_meta_per::Cuint, min_raw_per::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_page_buffer_size`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_PAGE_BUFFER_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_page_buffer_size']).
 """
 function h5p_set_page_buffer_size(plist_id, buf_size, min_meta_per, min_raw_per)
     lock(liblock)
@@ -5488,7 +6168,9 @@ end
 """
     h5p_set_preserve(plist_id::hid_t, status::hbool_t)
 
-See `libhdf5` documentation for [`H5Pset_preserve`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_PRESERVE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_preserve']).
 """
 function h5p_set_preserve(plist_id, status)
     lock(liblock)
@@ -5504,7 +6186,9 @@ end
 """
     h5p_set_scaleoffset(plist_id::hid_t, scale_type::Cint, scale_factor::Cint)
 
-See `libhdf5` documentation for [`H5Pset_scaleoffset`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_SCALEOFFSET).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_scaleoffset']).
 """
 function h5p_set_scaleoffset(plist_id, scale_type, scale_factor)
     lock(liblock)
@@ -5520,7 +6204,9 @@ end
 """
     h5p_set_shared_mesg_index(plist_id::hid_t, index_num::Cuint, mesg_type_flags::Cuint, min_mesg_size::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_shared_mesg_index`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_SHARED_MESG_INDEX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_shared_mesg_index']).
 """
 function h5p_set_shared_mesg_index(plist_id, index_num, mesg_type_flags, min_mesg_size)
     lock(liblock)
@@ -5536,7 +6222,9 @@ end
 """
     h5p_set_shared_mesg_nindexes(plist_id::hid_t, nindexes::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_shared_mesg_nindexes`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_SHARED_MESG_NINDEXES).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_shared_mesg_nindexes']).
 """
 function h5p_set_shared_mesg_nindexes(plist_id, nindexes)
     lock(liblock)
@@ -5552,7 +6240,9 @@ end
 """
     h5p_set_shared_mesg_phase_change(plist_id::hid_t, max_list::Cuint, min_btree::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_shared_mesg_phase_change`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_SHARED_MESG_PHASE_CHANGE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_shared_mesg_phase_change']).
 """
 function h5p_set_shared_mesg_phase_change(plist_id, max_list, min_btree)
     lock(liblock)
@@ -5568,7 +6258,9 @@ end
 """
     h5p_set_shuffle(plist_id::hid_t)
 
-See `libhdf5` documentation for [`H5Pset_shuffle`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_SHUFFLE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_shuffle']).
 """
 function h5p_set_shuffle(plist_id)
     lock(liblock)
@@ -5584,7 +6276,9 @@ end
 """
     h5p_set_sieve_buf_size(fapl_id::hid_t, size::Csize_t)
 
-See `libhdf5` documentation for [`H5Pset_sieve_buf_size`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_SIEVE_BUF_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_sieve_buf_size']).
 """
 function h5p_set_sieve_buf_size(fapl_id, size)
     lock(liblock)
@@ -5600,7 +6294,9 @@ end
 """
     h5p_set_sizes(plist_id::hid_t, sizeof_addr::Csize_t, sizeof_size::Csize_t)
 
-See `libhdf5` documentation for [`H5Pset_sizes`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_SIZES).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_sizes']).
 """
 function h5p_set_sizes(plist_id, sizeof_addr, sizeof_size)
     lock(liblock)
@@ -5616,7 +6312,9 @@ end
 """
     h5p_set_small_data_block_size(fapl_id::hid_t, size::hsize_t)
 
-See `libhdf5` documentation for [`H5Pset_small_data_block_size`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_SMALL_DATA_BLOCK_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_small_data_block_size']).
 """
 function h5p_set_small_data_block_size(fapl_id, size)
     lock(liblock)
@@ -5632,7 +6330,9 @@ end
 """
     h5p_set_sym_k(plist_id::hid_t, ik::Cuint, lk::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_sym_k`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_SYM_K).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_sym_k']).
 """
 function h5p_set_sym_k(plist_id, ik, lk)
     lock(liblock)
@@ -5648,7 +6348,9 @@ end
 """
     h5p_set_szip(plist_id::hid_t, options_mask::Cuint, pixels_per_block::Cuint)
 
-See `libhdf5` documentation for [`H5Pset_szip`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_SZIP).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_szip']).
 """
 function h5p_set_szip(plist_id, options_mask, pixels_per_block)
     lock(liblock)
@@ -5664,7 +6366,9 @@ end
 """
     h5p_set_type_conv_cb(dxpl_id::hid_t, op::H5T_conv_except_func_t, operate_data::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pset_type_conv_cb`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_TYPE_CONV_CB).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_type_conv_cb']).
 """
 function h5p_set_type_conv_cb(dxpl_id, op, operate_data)
     lock(liblock)
@@ -5680,7 +6384,9 @@ end
 """
     h5p_set_userblock(plist_id::hid_t, len::hsize_t)
 
-See `libhdf5` documentation for [`H5Pset_userblock`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_USERBLOCK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_userblock']).
 """
 function h5p_set_userblock(plist_id, len)
     lock(liblock)
@@ -5696,7 +6402,9 @@ end
 """
     h5p_set_virtual(dcpl_id::hid_t, vspace_id::hid_t, src_file_name::Ptr{UInt8}, src_dset_name::Ptr{UInt8}, src_space_id::hid_t)
 
-See `libhdf5` documentation for [`H5Pset_virtual`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_VIRTUAL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_virtual']).
 """
 function h5p_set_virtual(dcpl_id, vspace_id, src_file_name, src_dset_name, src_space_id)
     lock(liblock)
@@ -5712,7 +6420,9 @@ end
 """
     h5p_set_virtual_prefix(dapl_id::hid_t, prefix::Ptr{Cchar})
 
-See `libhdf5` documentation for [`H5Pset_virtual_prefix`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_VIRTUAL_PREFIX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_virtual_prefix']).
 """
 function h5p_set_virtual_prefix(dapl_id, prefix)
     lock(liblock)
@@ -5728,7 +6438,9 @@ end
 """
     h5p_set_virtual_printf_gap(dapl_id::hid_t, gap_size::hsize_t)
 
-See `libhdf5` documentation for [`H5Pset_virtual_printf_gap`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_VIRTUAL_PRINTF_GAP).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_virtual_printf_gap']).
 """
 function h5p_set_virtual_printf_gap(dapl_id, gap_size)
     lock(liblock)
@@ -5744,7 +6456,9 @@ end
 """
     h5p_set_virtual_view(dapl_id::hid_t, view::H5D_vds_view_t)
 
-See `libhdf5` documentation for [`H5Pset_virtual_view`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_VIRTUAL_VIEW).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_virtual_view']).
 """
 function h5p_set_virtual_view(dapl_id, view)
     lock(liblock)
@@ -5760,7 +6474,9 @@ end
 """
     h5p_set_vlen_mem_manager(plist_id::hid_t, alloc_func::H5MM_allocate_t, alloc_info::Ptr{Cvoid}, free_func::H5MM_free_t, free_info::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pset_vlen_mem_manager`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_VLEN_MEM_MANAGER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_vlen_mem_manager']).
 """
 function h5p_set_vlen_mem_manager(plist_id, alloc_func, alloc_info, free_func, free_info)
     lock(liblock)
@@ -5776,7 +6492,9 @@ end
 """
     h5p_set_vol(plist_id::hid_t, new_vol_id::hid_t, new_vol_info::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Pset_vol`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_VOL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pset_vol']).
 """
 function h5p_set_vol(plist_id, new_vol_id, new_vol_info)
     lock(liblock)
@@ -5792,7 +6510,9 @@ end
 """
     h5p_add_merge_committed_dtype_path(plist_id::hid_t, path::Ptr{Cchar})
 
-See `libhdf5` documentation for [`H5Padd_merge_committed_dtype_path`](https://portal.hdfgroup.org/display/HDF5/H5P_ADD_MERGE_COMMITTED_DTYPE_PATH).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Padd_merge_committed_dtype_path']).
 """
 function h5p_add_merge_committed_dtype_path(plist_id, path)
     lock(liblock)
@@ -5808,7 +6528,9 @@ end
 """
     h5p_all_filters_avail(plist_id::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Pall_filters_avail`](https://portal.hdfgroup.org/display/HDF5/H5P_ALL_FILTERS_AVAIL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pall_filters_avail']).
 """
 function h5p_all_filters_avail(plist_id)
     lock(liblock)
@@ -5824,7 +6546,9 @@ end
 """
     h5p_close(id::hid_t)
 
-See `libhdf5` documentation for [`H5Pclose`](https://portal.hdfgroup.org/display/HDF5/H5P_CLOSE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pclose']).
 """
 function h5p_close(id)
     lock(liblock)
@@ -5840,7 +6564,9 @@ end
 """
     h5p_close_class(plist_id::hid_t)
 
-See `libhdf5` documentation for [`H5Pclose_class`](https://portal.hdfgroup.org/display/HDF5/H5P_CLOSE_CLASS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pclose_class']).
 """
 function h5p_close_class(plist_id)
     lock(liblock)
@@ -5856,7 +6582,9 @@ end
 """
     h5p_copy(plist_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Pcopy`](https://portal.hdfgroup.org/display/HDF5/H5P_COPY).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pcopy']).
 """
 function h5p_copy(plist_id)
     lock(liblock)
@@ -5872,7 +6600,9 @@ end
 """
     h5p_copy_prop(dst_id::hid_t, src_id::hid_t, name::Ptr{Cchar})
 
-See `libhdf5` documentation for [`H5Pcopy_prop`](https://portal.hdfgroup.org/display/HDF5/H5P_COPY_PROP).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pcopy_prop']).
 """
 function h5p_copy_prop(dst_id, src_id, name)
     lock(liblock)
@@ -5888,7 +6618,9 @@ end
 """
     h5p_create(cls_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Pcreate`](https://portal.hdfgroup.org/display/HDF5/H5P_CREATE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pcreate']).
 """
 function h5p_create(cls_id)
     lock(liblock)
@@ -5904,7 +6636,9 @@ end
 """
     h5p_create_class(parent::hid_t, name::Ptr{Cchar}, create::H5P_cls_create_func_t, create_data::Ptr{Cvoid}, copy::H5P_cls_copy_func_t, copy_data::Ptr{Cvoid}, close::H5P_cls_close_func_t, close_data::Ptr{Cvoid}) -> hid_t
 
-See `libhdf5` documentation for [`H5Pcreate_class`](https://portal.hdfgroup.org/display/HDF5/H5P_CREATE_CLASS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pcreate_class']).
 """
 function h5p_create_class(parent, name, create, create_data, copy, copy_data, close, close_data)
     lock(liblock)
@@ -5920,7 +6654,9 @@ end
 """
     h5p_decode(buf::Ptr{Cvoid}) -> hid_t
 
-See `libhdf5` documentation for [`H5Pdecode`](https://portal.hdfgroup.org/display/HDF5/H5P_DECODE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pdecode']).
 """
 function h5p_decode(buf)
     lock(liblock)
@@ -5936,7 +6672,9 @@ end
 """
     h5p_encode(plist_id::hid_t, buf::Ptr{Cvoid}, nalloc::Ptr{Csize_t})
 
-See `libhdf5` documentation for [`H5Pencode1`](https://portal.hdfgroup.org/display/HDF5/H5P_ENCODE1).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pencode1']).
 """
 function h5p_encode(plist_id, buf, nalloc)
     lock(liblock)
@@ -5952,7 +6690,9 @@ end
 """
     h5p_encode(plist_id::hid_t, buf::Ptr{Cvoid}, nalloc::Ptr{Csize_t}, fapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Pencode2`](https://portal.hdfgroup.org/display/HDF5/H5P_ENCODE2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pencode2']).
 """
 function h5p_encode(plist_id, buf, nalloc, fapl_id)
     lock(liblock)
@@ -5968,7 +6708,9 @@ end
 """
     h5p_equal(id1::hid_t, id2::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Pequal`](https://portal.hdfgroup.org/display/HDF5/H5P_EQUAL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pequal']).
 """
 function h5p_equal(id1, id2)
     lock(liblock)
@@ -5984,7 +6726,9 @@ end
 """
     h5p_exist(plist_id::hid_t, name::Ptr{Cchar}) -> Bool
 
-See `libhdf5` documentation for [`H5Pexist`](https://portal.hdfgroup.org/display/HDF5/H5P_EXIST).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pexist']).
 """
 function h5p_exist(plist_id, name)
     lock(liblock)
@@ -6000,7 +6744,9 @@ end
 """
     h5p_fill_value_defined(plist::hid_t, status::Ptr{H5D_fill_value_t})
 
-See `libhdf5` documentation for [`H5Pfill_value_defined`](https://portal.hdfgroup.org/display/HDF5/H5P_FILL_VALUE_DEFINED).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pfill_value_defined']).
 """
 function h5p_fill_value_defined(plist, status)
     lock(liblock)
@@ -6016,7 +6762,9 @@ end
 """
     h5p_free_merge_committed_dtype_paths(plist_id::hid_t)
 
-See `libhdf5` documentation for [`H5Pfree_merge_committed_dtype_paths`](https://portal.hdfgroup.org/display/HDF5/H5P_FREE_MERGE_COMMITTED_DTYPE_PATHS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pfree_merge_committed_dtype_paths']).
 """
 function h5p_free_merge_committed_dtype_paths(plist_id)
     lock(liblock)
@@ -6032,7 +6780,9 @@ end
 """
     h5p_insert(plist_id::hid_t, name::Ptr{Cchar}, size::Csize_t, value::Ptr{Cvoid}, prp_set::H5P_prp_set_func_t, prp_get::H5P_prp_get_func_t, prp_delete::H5P_prp_delete_func_t, prp_copy::H5P_prp_copy_func_t, prp_close::H5P_prp_close_func_t)
 
-See `libhdf5` documentation for [`H5Pinsert1`](https://portal.hdfgroup.org/display/HDF5/H5P_INSERT1).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pinsert1']).
 """
 function h5p_insert(plist_id, name, size, value, prp_set, prp_get, prp_delete, prp_copy, prp_close)
     lock(liblock)
@@ -6048,7 +6798,9 @@ end
 """
     h5p_insert(plist_id::hid_t, name::Ptr{Cchar}, size::Csize_t, value::Ptr{Cvoid}, set::H5P_prp_set_func_t, get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, copy::H5P_prp_copy_func_t, compare::H5P_prp_compare_func_t, close::H5P_prp_close_func_t)
 
-See `libhdf5` documentation for [`H5Pinsert2`](https://portal.hdfgroup.org/display/HDF5/H5P_INSERT2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pinsert2']).
 """
 function h5p_insert(plist_id, name, size, value, set, get, prp_del, copy, compare, close)
     lock(liblock)
@@ -6064,7 +6816,9 @@ end
 """
     h5p_isa_class(plist_id::hid_t, pclass_id::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Pisa_class`](https://portal.hdfgroup.org/display/HDF5/H5P_ISA_CLASS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pisa_class']).
 """
 function h5p_isa_class(plist_id, pclass_id)
     lock(liblock)
@@ -6080,7 +6834,9 @@ end
 """
     h5p_iterate(id::hid_t, idx::Ptr{Cint}, iter_func::H5P_iterate_t, iter_data::Ptr{Cvoid}) -> Int
 
-See `libhdf5` documentation for [`H5Piterate`](https://portal.hdfgroup.org/display/HDF5/H5P_ITERATE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Piterate']).
 """
 function h5p_iterate(id, idx, iter_func, iter_data)
     lock(liblock)
@@ -6096,7 +6852,9 @@ end
 """
     h5p_modify_filter(plist_id::hid_t, filter_id::H5Z_filter_t, flags::Cuint, cd_nelmts::Csize_t, cd_values::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Pmodify_filter`](https://portal.hdfgroup.org/display/HDF5/H5P_MODIFY_FILTER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pmodify_filter']).
 """
 function h5p_modify_filter(plist_id, filter_id, flags, cd_nelmts, cd_values)
     lock(liblock)
@@ -6112,7 +6870,9 @@ end
 """
     h5p_register(cls_id::hid_t, name::Ptr{Cchar}, size::Csize_t, def_value::Ptr{Cvoid}, prp_create::H5P_prp_create_func_t, prp_set::H5P_prp_set_func_t, prp_get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, prp_copy::H5P_prp_copy_func_t, prp_close::H5P_prp_close_func_t)
 
-See `libhdf5` documentation for [`H5Pregister1`](https://portal.hdfgroup.org/display/HDF5/H5P_REGISTER1).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pregister1']).
 """
 function h5p_register(cls_id, name, size, def_value, prp_create, prp_set, prp_get, prp_del, prp_copy, prp_close)
     lock(liblock)
@@ -6128,7 +6888,9 @@ end
 """
     h5p_register(cls_id::hid_t, name::Ptr{Cchar}, size::Csize_t, def_value::Ptr{Cvoid}, create::H5P_prp_create_func_t, set::H5P_prp_set_func_t, get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, copy::H5P_prp_copy_func_t, compare::H5P_prp_compare_func_t, close::H5P_prp_close_func_t)
 
-See `libhdf5` documentation for [`H5Pregister2`](https://portal.hdfgroup.org/display/HDF5/H5P_REGISTER2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Pregister2']).
 """
 function h5p_register(cls_id, name, size, def_value, create, set, get, prp_del, copy, compare, close)
     lock(liblock)
@@ -6144,7 +6906,9 @@ end
 """
     h5p_remove(plist_id::hid_t, name::Ptr{Cchar})
 
-See `libhdf5` documentation for [`H5Premove`](https://portal.hdfgroup.org/display/HDF5/H5P_REMOVE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Premove']).
 """
 function h5p_remove(plist_id, name)
     lock(liblock)
@@ -6160,7 +6924,9 @@ end
 """
     h5p_remove_filter(plist_id::hid_t, filter_id::H5Z_filter_t)
 
-See `libhdf5` documentation for [`H5Premove_filter`](https://portal.hdfgroup.org/display/HDF5/H5P_REMOVE_FILTER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Premove_filter']).
 """
 function h5p_remove_filter(plist_id, filter_id)
     lock(liblock)
@@ -6176,7 +6942,9 @@ end
 """
     h5p_unregister(pclass_id::hid_t, name::Ptr{Cchar})
 
-See `libhdf5` documentation for [`H5Punregister`](https://portal.hdfgroup.org/display/HDF5/H5P_UNREGISTER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5P']/member[name='H5Punregister']).
 """
 function h5p_unregister(pclass_id, name)
     lock(liblock)
@@ -6192,7 +6960,9 @@ end
 """
     h5pl_set_loading_state(plugin_control_mask::Cuint)
 
-See `libhdf5` documentation for [`H5PLset_loading_state`](https://portal.hdfgroup.org/display/HDF5/H5PL_SET_LOADING_STATE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5PL']/member[name='H5PLset_loading_state']).
 """
 function h5pl_set_loading_state(plugin_control_mask)
     lock(liblock)
@@ -6208,7 +6978,9 @@ end
 """
     h5pl_get_loading_state(plugin_control_mask::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5PLget_loading_state`](https://portal.hdfgroup.org/display/HDF5/H5PL_GET_LOADING_STATE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5PL']/member[name='H5PLget_loading_state']).
 """
 function h5pl_get_loading_state(plugin_control_mask)
     lock(liblock)
@@ -6224,7 +6996,9 @@ end
 """
     h5pl_append(search_path::Ptr{Cchar})
 
-See `libhdf5` documentation for [`H5PLappend`](https://portal.hdfgroup.org/display/HDF5/H5PL_APPEND).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5PL']/member[name='H5PLappend']).
 """
 function h5pl_append(search_path)
     lock(liblock)
@@ -6240,7 +7014,9 @@ end
 """
     h5pl_prepend(search_path::Ptr{Cchar})
 
-See `libhdf5` documentation for [`H5PLprepend`](https://portal.hdfgroup.org/display/HDF5/H5PL_PREPEND).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5PL']/member[name='H5PLprepend']).
 """
 function h5pl_prepend(search_path)
     lock(liblock)
@@ -6256,7 +7032,9 @@ end
 """
     h5pl_replace(search_path::Ptr{Cchar}, index::Cuint)
 
-See `libhdf5` documentation for [`H5PLreplace`](https://portal.hdfgroup.org/display/HDF5/H5PL_REPLACE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5PL']/member[name='H5PLreplace']).
 """
 function h5pl_replace(search_path, index)
     lock(liblock)
@@ -6272,7 +7050,9 @@ end
 """
     h5pl_insert(search_path::Ptr{Cchar}, index::Cuint)
 
-See `libhdf5` documentation for [`H5PLinsert`](https://portal.hdfgroup.org/display/HDF5/H5PL_INSERT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5PL']/member[name='H5PLinsert']).
 """
 function h5pl_insert(search_path, index)
     lock(liblock)
@@ -6288,7 +7068,9 @@ end
 """
     h5pl_remove(index::Cuint)
 
-See `libhdf5` documentation for [`H5PLremove`](https://portal.hdfgroup.org/display/HDF5/H5PL_REMOVE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5PL']/member[name='H5PLremove']).
 """
 function h5pl_remove(index)
     lock(liblock)
@@ -6304,7 +7086,9 @@ end
 """
     h5pl_get(index::Cuint, path_buf::Ptr{Cchar}, buf_size::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5PLget`](https://portal.hdfgroup.org/display/HDF5/H5PL_GET).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5PL']/member[name='H5PLget']).
 """
 function h5pl_get(index, path_buf, buf_size)
     lock(liblock)
@@ -6320,7 +7104,9 @@ end
 """
     h5pl_size(num_paths::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5PLsize`](https://portal.hdfgroup.org/display/HDF5/H5PL_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5PL']/member[name='H5PLsize']).
 """
 function h5pl_size(num_paths)
     lock(liblock)
@@ -6336,7 +7122,9 @@ end
 """
     h5r_create(ref::Ptr{Cvoid}, loc_id::hid_t, pathname::Ptr{UInt8}, ref_type::Cint, space_id::hid_t)
 
-See `libhdf5` documentation for [`H5Rcreate`](https://portal.hdfgroup.org/display/HDF5/H5R_CREATE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5R']/member[name='H5Rcreate']).
 """
 function h5r_create(ref, loc_id, pathname, ref_type, space_id)
     lock(liblock)
@@ -6352,7 +7140,9 @@ end
 """
     h5r_dereference(obj_id::hid_t, oapl_id::hid_t, ref_type::Cint, ref::Ptr{Cvoid}) -> hid_t
 
-See `libhdf5` documentation for [`H5Rdereference2`](https://portal.hdfgroup.org/display/HDF5/H5R_DEREFERENCE2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5R']/member[name='H5Rdereference2']).
 """
 function h5r_dereference(obj_id, oapl_id, ref_type, ref)
     lock(liblock)
@@ -6368,7 +7158,9 @@ end
 """
     h5r_get_obj_type(loc_id::hid_t, ref_type::Cint, ref::Ptr{Cvoid}, obj_type::Ptr{Cint})
 
-See `libhdf5` documentation for [`H5Rget_obj_type2`](https://portal.hdfgroup.org/display/HDF5/H5R_GET_OBJ_TYPE2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5R']/member[name='H5Rget_obj_type2']).
 """
 function h5r_get_obj_type(loc_id, ref_type, ref, obj_type)
     lock(liblock)
@@ -6384,7 +7176,9 @@ end
 """
     h5r_get_region(loc_id::hid_t, ref_type::Cint, ref::Ptr{Cvoid}) -> hid_t
 
-See `libhdf5` documentation for [`H5Rget_region`](https://portal.hdfgroup.org/display/HDF5/H5R_GET_REGION).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5R']/member[name='H5Rget_region']).
 """
 function h5r_get_region(loc_id, ref_type, ref)
     lock(liblock)
@@ -6400,7 +7194,9 @@ end
 """
     h5s_close(space_id::hid_t)
 
-See `libhdf5` documentation for [`H5Sclose`](https://portal.hdfgroup.org/display/HDF5/H5S_CLOSE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Sclose']).
 """
 function h5s_close(space_id)
     lock(liblock)
@@ -6417,7 +7213,9 @@ end
     @doc """
         h5s_combine_select(space1_id::hid_t, op::Cint, space2_id::hid_t) -> hid_t
 
-    See `libhdf5` documentation for [`H5Scombine_select`](https://portal.hdfgroup.org/display/HDF5/H5S_COMBINE_SELECT).
+    # External links
+
+    - [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Scombine_select']).
     """
     function h5s_combine_select(space1_id, op, space2_id)
         lock(liblock)
@@ -6434,7 +7232,9 @@ end
 """
     h5s_copy(space_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Scopy`](https://portal.hdfgroup.org/display/HDF5/H5S_COPY).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Scopy']).
 """
 function h5s_copy(space_id)
     lock(liblock)
@@ -6450,7 +7250,9 @@ end
 """
     h5s_create(class::Cint) -> hid_t
 
-See `libhdf5` documentation for [`H5Screate`](https://portal.hdfgroup.org/display/HDF5/H5S_CREATE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Screate']).
 """
 function h5s_create(class)
     lock(liblock)
@@ -6466,7 +7268,9 @@ end
 """
     h5s_create_simple(rank::Cint, current_dims::Ptr{hsize_t}, maximum_dims::Ptr{hsize_t}) -> hid_t
 
-See `libhdf5` documentation for [`H5Screate_simple`](https://portal.hdfgroup.org/display/HDF5/H5S_CREATE_SIMPLE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Screate_simple']).
 """
 function h5s_create_simple(rank, current_dims, maximum_dims)
     lock(liblock)
@@ -6482,7 +7286,9 @@ end
 """
     h5s_extent_equal(space1_id::hid_t, space2_id::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Sextent_equal`](https://portal.hdfgroup.org/display/HDF5/H5S_EXTENT_EQUAL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Sextent_equal']).
 """
 function h5s_extent_equal(space1_id, space2_id)
     lock(liblock)
@@ -6498,7 +7304,9 @@ end
 """
     h5s_get_regular_hyperslab(space_id::hid_t, start::Ptr{hsize_t}, stride::Ptr{hsize_t}, count::Ptr{hsize_t}, block::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Sget_regular_hyperslab`](https://portal.hdfgroup.org/display/HDF5/H5S_GET_REGULAR_HYPERSLAB).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Sget_regular_hyperslab']).
 """
 function h5s_get_regular_hyperslab(space_id, start, stride, count, block)
     lock(liblock)
@@ -6514,7 +7322,9 @@ end
 """
     h5s_get_simple_extent_dims(space_id::hid_t, dims::Ptr{hsize_t}, maxdims::Ptr{hsize_t}) -> Int
 
-See `libhdf5` documentation for [`H5Sget_simple_extent_dims`](https://portal.hdfgroup.org/display/HDF5/H5S_GET_SIMPLE_EXTENT_DIMS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Sget_simple_extent_dims']).
 """
 function h5s_get_simple_extent_dims(space_id, dims, maxdims)
     lock(liblock)
@@ -6530,7 +7340,9 @@ end
 """
     h5s_get_simple_extent_ndims(space_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Sget_simple_extent_ndims`](https://portal.hdfgroup.org/display/HDF5/H5S_GET_SIMPLE_EXTENT_NDIMS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Sget_simple_extent_ndims']).
 """
 function h5s_get_simple_extent_ndims(space_id)
     lock(liblock)
@@ -6546,7 +7358,9 @@ end
 """
     h5s_get_simple_extent_type(space_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Sget_simple_extent_type`](https://portal.hdfgroup.org/display/HDF5/H5S_GET_SIMPLE_EXTENT_TYPE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Sget_simple_extent_type']).
 """
 function h5s_get_simple_extent_type(space_id)
     lock(liblock)
@@ -6562,7 +7376,9 @@ end
 """
     h5s_get_select_hyper_nblocks(space_id::hid_t) -> hssize_t
 
-See `libhdf5` documentation for [`H5Sget_select_hyper_nblocks`](https://portal.hdfgroup.org/display/HDF5/H5S_GET_SELECT_HYPER_NBLOCKS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Sget_select_hyper_nblocks']).
 """
 function h5s_get_select_hyper_nblocks(space_id)
     lock(liblock)
@@ -6578,7 +7394,9 @@ end
 """
     h5s_get_select_npoints(space_id::hid_t) -> hsize_t
 
-See `libhdf5` documentation for [`H5Sget_select_npoints`](https://portal.hdfgroup.org/display/HDF5/H5S_GET_SELECT_NPOINTS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Sget_select_npoints']).
 """
 function h5s_get_select_npoints(space_id)
     lock(liblock)
@@ -6594,7 +7412,9 @@ end
 """
     h5s_get_select_type(space_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Sget_select_type`](https://portal.hdfgroup.org/display/HDF5/H5S_GET_SELECT_TYPE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Sget_select_type']).
 """
 function h5s_get_select_type(space_id)
     lock(liblock)
@@ -6610,7 +7430,9 @@ end
 """
     h5s_is_regular_hyperslab(space_id::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Sis_regular_hyperslab`](https://portal.hdfgroup.org/display/HDF5/H5S_IS_REGULAR_HYPERSLAB).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Sis_regular_hyperslab']).
 """
 function h5s_is_regular_hyperslab(space_id)
     lock(liblock)
@@ -6626,7 +7448,9 @@ end
 """
     h5s_is_simple(space_id::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Sis_simple`](https://portal.hdfgroup.org/display/HDF5/H5S_IS_SIMPLE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Sis_simple']).
 """
 function h5s_is_simple(space_id)
     lock(liblock)
@@ -6642,7 +7466,9 @@ end
 """
     h5s_select_hyperslab(dspace_id::hid_t, seloper::Cint, start::Ptr{hsize_t}, stride::Ptr{hsize_t}, count::Ptr{hsize_t}, block::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Sselect_hyperslab`](https://portal.hdfgroup.org/display/HDF5/H5S_SELECT_HYPERSLAB).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Sselect_hyperslab']).
 """
 function h5s_select_hyperslab(dspace_id, seloper, start, stride, count, block)
     lock(liblock)
@@ -6658,7 +7484,9 @@ end
 """
     h5s_set_extent_simple(dspace_id::hid_t, rank::Cint, current_size::Ptr{hsize_t}, maximum_size::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5Sset_extent_simple`](https://portal.hdfgroup.org/display/HDF5/H5S_SET_EXTENT_SIMPLE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5S']/member[name='H5Sset_extent_simple']).
 """
 function h5s_set_extent_simple(dspace_id, rank, current_size, maximum_size)
     lock(liblock)
@@ -6674,7 +7502,9 @@ end
 """
     h5t_array_create(basetype_id::hid_t, ndims::Cuint, sz::Ptr{hsize_t}) -> hid_t
 
-See `libhdf5` documentation for [`H5Tarray_create2`](https://portal.hdfgroup.org/display/HDF5/H5T_ARRAY_CREATE2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tarray_create2']).
 """
 function h5t_array_create(basetype_id, ndims, sz)
     lock(liblock)
@@ -6690,7 +7520,9 @@ end
 """
     h5t_close(dtype_id::hid_t)
 
-See `libhdf5` documentation for [`H5Tclose`](https://portal.hdfgroup.org/display/HDF5/H5T_CLOSE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tclose']).
 """
 function h5t_close(dtype_id)
     lock(liblock)
@@ -6706,7 +7538,9 @@ end
 """
     h5t_committed(dtype_id::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Tcommitted`](https://portal.hdfgroup.org/display/HDF5/H5T_COMMITTED).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tcommitted']).
 """
 function h5t_committed(dtype_id)
     lock(liblock)
@@ -6722,7 +7556,9 @@ end
 """
     h5t_commit(loc_id::hid_t, name::Ptr{UInt8}, dtype_id::hid_t, lcpl_id::hid_t, tcpl_id::hid_t, tapl_id::hid_t)
 
-See `libhdf5` documentation for [`H5Tcommit2`](https://portal.hdfgroup.org/display/HDF5/H5T_COMMIT2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tcommit2']).
 """
 function h5t_commit(loc_id, name, dtype_id, lcpl_id, tcpl_id, tapl_id)
     lock(liblock)
@@ -6738,7 +7574,9 @@ end
 """
     h5t_copy(dtype_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Tcopy`](https://portal.hdfgroup.org/display/HDF5/H5T_COPY).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tcopy']).
 """
 function h5t_copy(dtype_id)
     lock(liblock)
@@ -6754,7 +7592,9 @@ end
 """
     h5t_create(class_id::Cint, sz::Csize_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Tcreate`](https://portal.hdfgroup.org/display/HDF5/H5T_CREATE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tcreate']).
 """
 function h5t_create(class_id, sz)
     lock(liblock)
@@ -6770,7 +7610,9 @@ end
 """
     h5t_enum_insert(dtype_id::hid_t, name::Cstring, value::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5Tenum_insert`](https://portal.hdfgroup.org/display/HDF5/H5T_ENUM_INSERT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tenum_insert']).
 """
 function h5t_enum_insert(dtype_id, name, value)
     lock(liblock)
@@ -6786,7 +7628,9 @@ end
 """
     h5t_equal(dtype_id1::hid_t, dtype_id2::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Tequal`](https://portal.hdfgroup.org/display/HDF5/H5T_EQUAL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tequal']).
 """
 function h5t_equal(dtype_id1, dtype_id2)
     lock(liblock)
@@ -6802,7 +7646,9 @@ end
 """
     h5t_get_array_dims(dtype_id::hid_t, dims::Ptr{hsize_t}) -> Int
 
-See `libhdf5` documentation for [`H5Tget_array_dims2`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_ARRAY_DIMS2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_array_dims2']).
 """
 function h5t_get_array_dims(dtype_id, dims)
     lock(liblock)
@@ -6818,7 +7664,9 @@ end
 """
     h5t_get_array_ndims(dtype_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Tget_array_ndims`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_ARRAY_NDIMS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_array_ndims']).
 """
 function h5t_get_array_ndims(dtype_id)
     lock(liblock)
@@ -6834,7 +7682,9 @@ end
 """
     h5t_get_class(dtype_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Tget_class`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_CLASS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_class']).
 """
 function h5t_get_class(dtype_id)
     lock(liblock)
@@ -6850,7 +7700,9 @@ end
 """
     h5t_get_cset(dtype_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Tget_cset`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_CSET).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_cset']).
 """
 function h5t_get_cset(dtype_id)
     lock(liblock)
@@ -6866,7 +7718,9 @@ end
 """
     h5t_get_ebias(dtype_id::hid_t) -> Csize_t
 
-See `libhdf5` documentation for [`H5Tget_ebias`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_EBIAS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_ebias']).
 """
 function h5t_get_ebias(dtype_id)
     lock(liblock)
@@ -6882,7 +7736,9 @@ end
 """
     h5t_get_fields(dtype_id::hid_t, spos::Ref{Csize_t}, epos::Ref{Csize_t}, esize::Ref{Csize_t}, mpos::Ref{Csize_t}, msize::Ref{Csize_t})
 
-See `libhdf5` documentation for [`H5Tget_fields`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_FIELDS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_fields']).
 """
 function h5t_get_fields(dtype_id, spos, epos, esize, mpos, msize)
     lock(liblock)
@@ -6898,7 +7754,9 @@ end
 """
     h5t_get_member_class(dtype_id::hid_t, index::Cuint) -> Int
 
-See `libhdf5` documentation for [`H5Tget_member_class`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_MEMBER_CLASS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_member_class']).
 """
 function h5t_get_member_class(dtype_id, index)
     lock(liblock)
@@ -6914,7 +7772,9 @@ end
 """
     h5t_get_member_index(dtype_id::hid_t, membername::Ptr{UInt8}) -> Int
 
-See `libhdf5` documentation for [`H5Tget_member_index`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_MEMBER_INDEX).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_member_index']).
 """
 function h5t_get_member_index(dtype_id, membername)
     lock(liblock)
@@ -6930,7 +7790,9 @@ end
 """
     h5t_get_member_offset(dtype_id::hid_t, index::Cuint) -> Csize_t
 
-See `libhdf5` documentation for [`H5Tget_member_offset`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_MEMBER_OFFSET).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_member_offset']).
 """
 function h5t_get_member_offset(dtype_id, index)
     lock(liblock)
@@ -6946,7 +7808,9 @@ end
 """
     h5t_get_member_type(dtype_id::hid_t, index::Cuint) -> hid_t
 
-See `libhdf5` documentation for [`H5Tget_member_type`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_MEMBER_TYPE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_member_type']).
 """
 function h5t_get_member_type(dtype_id, index)
     lock(liblock)
@@ -6962,7 +7826,9 @@ end
 """
     h5t_get_native_type(dtype_id::hid_t, direction::Cint) -> hid_t
 
-See `libhdf5` documentation for [`H5Tget_native_type`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_NATIVE_TYPE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_native_type']).
 """
 function h5t_get_native_type(dtype_id, direction)
     lock(liblock)
@@ -6978,7 +7844,9 @@ end
 """
     h5t_get_nmembers(dtype_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Tget_nmembers`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_NMEMBERS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_nmembers']).
 """
 function h5t_get_nmembers(dtype_id)
     lock(liblock)
@@ -6994,7 +7862,9 @@ end
 """
     h5t_get_offset(dtype_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Tget_offset`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_OFFSET).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_offset']).
 """
 function h5t_get_offset(dtype_id)
     lock(liblock)
@@ -7010,7 +7880,9 @@ end
 """
     h5t_get_order(dtype_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Tget_order`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_ORDER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_order']).
 """
 function h5t_get_order(dtype_id)
     lock(liblock)
@@ -7026,7 +7898,9 @@ end
 """
     h5t_get_precision(dtype_id::hid_t) -> Csize_t
 
-See `libhdf5` documentation for [`H5Tget_precision`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_PRECISION).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_precision']).
 """
 function h5t_get_precision(dtype_id)
     lock(liblock)
@@ -7042,7 +7916,9 @@ end
 """
     h5t_get_sign(dtype_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Tget_sign`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_SIGN).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_sign']).
 """
 function h5t_get_sign(dtype_id)
     lock(liblock)
@@ -7058,7 +7934,9 @@ end
 """
     h5t_get_size(dtype_id::hid_t) -> Csize_t
 
-See `libhdf5` documentation for [`H5Tget_size`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_size']).
 """
 function h5t_get_size(dtype_id)
     lock(liblock)
@@ -7074,7 +7952,9 @@ end
 """
     h5t_get_strpad(dtype_id::hid_t) -> Int
 
-See `libhdf5` documentation for [`H5Tget_strpad`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_STRPAD).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_strpad']).
 """
 function h5t_get_strpad(dtype_id)
     lock(liblock)
@@ -7090,7 +7970,9 @@ end
 """
     h5t_get_super(dtype_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Tget_super`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_SUPER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tget_super']).
 """
 function h5t_get_super(dtype_id)
     lock(liblock)
@@ -7106,7 +7988,9 @@ end
 """
     h5t_insert(dtype_id::hid_t, fieldname::Ptr{UInt8}, offset::Csize_t, field_id::hid_t)
 
-See `libhdf5` documentation for [`H5Tinsert`](https://portal.hdfgroup.org/display/HDF5/H5T_INSERT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tinsert']).
 """
 function h5t_insert(dtype_id, fieldname, offset, field_id)
     lock(liblock)
@@ -7122,7 +8006,9 @@ end
 """
     h5t_is_variable_str(type_id::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5Tis_variable_str`](https://portal.hdfgroup.org/display/HDF5/H5T_IS_VARIABLE_STR).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tis_variable_str']).
 """
 function h5t_is_variable_str(type_id)
     lock(liblock)
@@ -7138,7 +8024,9 @@ end
 """
     h5t_lock(type_id::hid_t)
 
-See `libhdf5` documentation for [`H5Tlock`](https://portal.hdfgroup.org/display/HDF5/H5T_LOCK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tlock']).
 """
 function h5t_lock(type_id)
     lock(liblock)
@@ -7154,7 +8042,9 @@ end
 """
     h5t_open(loc_id::hid_t, name::Ptr{UInt8}, tapl_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Topen2`](https://portal.hdfgroup.org/display/HDF5/H5T_OPEN2).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Topen2']).
 """
 function h5t_open(loc_id, name, tapl_id)
     lock(liblock)
@@ -7170,7 +8060,9 @@ end
 """
     h5t_set_cset(dtype_id::hid_t, cset::Cint)
 
-See `libhdf5` documentation for [`H5Tset_cset`](https://portal.hdfgroup.org/display/HDF5/H5T_SET_CSET).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tset_cset']).
 """
 function h5t_set_cset(dtype_id, cset)
     lock(liblock)
@@ -7186,7 +8078,9 @@ end
 """
     h5t_set_ebias(dtype_id::hid_t, ebias::Csize_t)
 
-See `libhdf5` documentation for [`H5Tset_ebias`](https://portal.hdfgroup.org/display/HDF5/H5T_SET_EBIAS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tset_ebias']).
 """
 function h5t_set_ebias(dtype_id, ebias)
     lock(liblock)
@@ -7202,7 +8096,9 @@ end
 """
     h5t_set_fields(dtype_id::hid_t, spos::Csize_t, epos::Csize_t, esize::Csize_t, mpos::Csize_t, msize::Csize_t)
 
-See `libhdf5` documentation for [`H5Tset_fields`](https://portal.hdfgroup.org/display/HDF5/H5T_SET_FIELDS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tset_fields']).
 """
 function h5t_set_fields(dtype_id, spos, epos, esize, mpos, msize)
     lock(liblock)
@@ -7218,7 +8114,9 @@ end
 """
     h5t_set_offset(dtype_id::hid_t, offset::Csize_t)
 
-See `libhdf5` documentation for [`H5Tset_offset`](https://portal.hdfgroup.org/display/HDF5/H5T_SET_OFFSET).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tset_offset']).
 """
 function h5t_set_offset(dtype_id, offset)
     lock(liblock)
@@ -7234,7 +8132,9 @@ end
 """
     h5t_set_order(dtype_id::hid_t, order::Cint)
 
-See `libhdf5` documentation for [`H5Tset_order`](https://portal.hdfgroup.org/display/HDF5/H5T_SET_ORDER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tset_order']).
 """
 function h5t_set_order(dtype_id, order)
     lock(liblock)
@@ -7250,7 +8150,9 @@ end
 """
     h5t_set_precision(dtype_id::hid_t, sz::Csize_t)
 
-See `libhdf5` documentation for [`H5Tset_precision`](https://portal.hdfgroup.org/display/HDF5/H5T_SET_PRECISION).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tset_precision']).
 """
 function h5t_set_precision(dtype_id, sz)
     lock(liblock)
@@ -7266,7 +8168,9 @@ end
 """
     h5t_set_size(dtype_id::hid_t, sz::Csize_t)
 
-See `libhdf5` documentation for [`H5Tset_size`](https://portal.hdfgroup.org/display/HDF5/H5T_SET_SIZE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tset_size']).
 """
 function h5t_set_size(dtype_id, sz)
     lock(liblock)
@@ -7282,7 +8186,9 @@ end
 """
     h5t_set_strpad(dtype_id::hid_t, sz::Cint)
 
-See `libhdf5` documentation for [`H5Tset_strpad`](https://portal.hdfgroup.org/display/HDF5/H5T_SET_STRPAD).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tset_strpad']).
 """
 function h5t_set_strpad(dtype_id, sz)
     lock(liblock)
@@ -7298,7 +8204,9 @@ end
 """
     h5t_set_tag(dtype_id::hid_t, tag::Cstring)
 
-See `libhdf5` documentation for [`H5Tset_tag`](https://portal.hdfgroup.org/display/HDF5/H5T_SET_TAG).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tset_tag']).
 """
 function h5t_set_tag(dtype_id, tag)
     lock(liblock)
@@ -7314,7 +8222,9 @@ end
 """
     h5t_vlen_create(base_type_id::hid_t) -> hid_t
 
-See `libhdf5` documentation for [`H5Tvlen_create`](https://portal.hdfgroup.org/display/HDF5/H5T_VLEN_CREATE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5T']/member[name='H5Tvlen_create']).
 """
 function h5t_vlen_create(base_type_id)
     lock(liblock)
@@ -7330,7 +8240,9 @@ end
 """
     h5do_append(dset_id::hid_t, dxpl_id::hid_t, index::Cuint, num_elem::hsize_t, memtype::hid_t, buffer::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5DOappend`](https://portal.hdfgroup.org/display/HDF5/H5DO_APPEND).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5DO']/member[name='H5DOappend']).
 """
 function h5do_append(dset_id, dxpl_id, index, num_elem, memtype, buffer)
     lock(liblock)
@@ -7346,7 +8258,9 @@ end
 """
     h5do_write_chunk(dset_id::hid_t, dxpl_id::hid_t, filter_mask::UInt32, offset::Ptr{hsize_t}, bufsize::Csize_t, buf::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5DOwrite_chunk`](https://portal.hdfgroup.org/display/HDF5/H5DO_WRITE_CHUNK).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5DO']/member[name='H5DOwrite_chunk']).
 """
 function h5do_write_chunk(dset_id, dxpl_id, filter_mask, offset, bufsize, buf)
     lock(liblock)
@@ -7362,7 +8276,9 @@ end
 """
     h5ds_attach_scale(did::hid_t, dsid::hid_t, idx::Cuint)
 
-See `libhdf5` documentation for [`H5DSattach_scale`](https://portal.hdfgroup.org/display/HDF5/H5DS_ATTACH_SCALE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5DS']/member[name='H5DSattach_scale']).
 """
 function h5ds_attach_scale(did, dsid, idx)
     lock(liblock)
@@ -7378,7 +8294,9 @@ end
 """
     h5ds_detach_scale(did::hid_t, dsid::hid_t, idx::Cuint)
 
-See `libhdf5` documentation for [`H5DSdetach_scale`](https://portal.hdfgroup.org/display/HDF5/H5DS_DETACH_SCALE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5DS']/member[name='H5DSdetach_scale']).
 """
 function h5ds_detach_scale(did, dsid, idx)
     lock(liblock)
@@ -7394,7 +8312,9 @@ end
 """
     h5ds_get_label(did::hid_t, idx::Cuint, label::Ptr{UInt8}, size::hsize_t)
 
-See `libhdf5` documentation for [`H5DSget_label`](https://portal.hdfgroup.org/display/HDF5/H5DS_GET_LABEL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5DS']/member[name='H5DSget_label']).
 """
 function h5ds_get_label(did, idx, label, size)
     lock(liblock)
@@ -7410,7 +8330,9 @@ end
 """
     h5ds_get_num_scales(did::hid_t, idx::Cuint) -> Int
 
-See `libhdf5` documentation for [`H5DSget_num_scales`](https://portal.hdfgroup.org/display/HDF5/H5DS_GET_NUM_SCALES).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5DS']/member[name='H5DSget_num_scales']).
 """
 function h5ds_get_num_scales(did, idx)
     lock(liblock)
@@ -7426,7 +8348,9 @@ end
 """
     h5ds_get_scale_name(did::hid_t, name::Ptr{UInt8}, size::Csize_t) -> Cssize_t
 
-See `libhdf5` documentation for [`H5DSget_scale_name`](https://portal.hdfgroup.org/display/HDF5/H5DS_GET_SCALE_NAME).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5DS']/member[name='H5DSget_scale_name']).
 """
 function h5ds_get_scale_name(did, name, size)
     lock(liblock)
@@ -7442,7 +8366,9 @@ end
 """
     h5ds_is_attached(did::hid_t, dsid::hid_t, idx::Cuint) -> Bool
 
-See `libhdf5` documentation for [`H5DSis_attached`](https://portal.hdfgroup.org/display/HDF5/H5DS_IS_ATTACHED).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5DS']/member[name='H5DSis_attached']).
 """
 function h5ds_is_attached(did, dsid, idx)
     lock(liblock)
@@ -7458,7 +8384,9 @@ end
 """
     h5ds_is_scale(did::hid_t) -> Bool
 
-See `libhdf5` documentation for [`H5DSis_scale`](https://portal.hdfgroup.org/display/HDF5/H5DS_IS_SCALE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5DS']/member[name='H5DSis_scale']).
 """
 function h5ds_is_scale(did)
     lock(liblock)
@@ -7474,7 +8402,9 @@ end
 """
     h5ds_set_label(did::hid_t, idx::Cuint, label::Ref{UInt8})
 
-See `libhdf5` documentation for [`H5DSset_label`](https://portal.hdfgroup.org/display/HDF5/H5DS_SET_LABEL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5DS']/member[name='H5DSset_label']).
 """
 function h5ds_set_label(did, idx, label)
     lock(liblock)
@@ -7490,7 +8420,9 @@ end
 """
     h5ds_set_scale(dsid::hid_t, dimname::Ptr{UInt8})
 
-See `libhdf5` documentation for [`H5DSset_scale`](https://portal.hdfgroup.org/display/HDF5/H5DS_SET_SCALE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5DS']/member[name='H5DSset_scale']).
 """
 function h5ds_set_scale(dsid, dimname)
     lock(liblock)
@@ -7506,7 +8438,9 @@ end
 """
     h5lt_dtype_to_text(datatype::hid_t, str::Ptr{UInt8}, lang_type::Cint, len::Ref{Csize_t})
 
-See `libhdf5` documentation for [`H5LTdtype_to_text`](https://portal.hdfgroup.org/display/HDF5/H5LT_DTYPE_TO_TEXT).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5LT']/member[name='H5LTdtype_to_text']).
 """
 function h5lt_dtype_to_text(datatype, str, lang_type, len)
     lock(liblock)
@@ -7522,7 +8456,9 @@ end
 """
     h5tb_append_records(loc_id::hid_t, dset_name::Ptr{UInt8}, nrecords::hsize_t, type_size::Csize_t, field_offset::Ptr{Csize_t}, field_sizes::Ptr{Csize_t}, data::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5TBappend_records`](https://portal.hdfgroup.org/display/HDF5/H5TB_APPEND_RECORDS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5TB']/member[name='H5TBappend_records']).
 """
 function h5tb_append_records(loc_id, dset_name, nrecords, type_size, field_offset, field_sizes, data)
     lock(liblock)
@@ -7538,7 +8474,9 @@ end
 """
     h5tb_get_field_info(loc_id::hid_t, table_name::Ptr{UInt8}, field_names::Ptr{Ptr{UInt8}}, field_sizes::Ptr{Csize_t}, field_offsets::Ptr{Csize_t}, type_size::Ptr{Csize_t})
 
-See `libhdf5` documentation for [`H5TBget_field_info`](https://portal.hdfgroup.org/display/HDF5/H5TB_GET_FIELD_INFO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5TB']/member[name='H5TBget_field_info']).
 """
 function h5tb_get_field_info(loc_id, table_name, field_names, field_sizes, field_offsets, type_size)
     lock(liblock)
@@ -7554,7 +8492,9 @@ end
 """
     h5tb_get_table_info(loc_id::hid_t, table_name::Ptr{UInt8}, nfields::Ptr{hsize_t}, nrecords::Ptr{hsize_t})
 
-See `libhdf5` documentation for [`H5TBget_table_info`](https://portal.hdfgroup.org/display/HDF5/H5TB_GET_TABLE_INFO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5TB']/member[name='H5TBget_table_info']).
 """
 function h5tb_get_table_info(loc_id, table_name, nfields, nrecords)
     lock(liblock)
@@ -7570,7 +8510,9 @@ end
 """
     h5tb_make_table(table_title::Ptr{UInt8}, loc_id::hid_t, dset_name::Ptr{UInt8}, nfields::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_names::Ptr{Ptr{UInt8}}, field_offset::Ptr{Csize_t}, field_types::Ptr{hid_t}, chunk_size::hsize_t, fill_data::Ptr{Cvoid}, compress::Cint, data::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5TBmake_table`](https://portal.hdfgroup.org/display/HDF5/H5TB_MAKE_TABLE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5TB']/member[name='H5TBmake_table']).
 """
 function h5tb_make_table(table_title, loc_id, dset_name, nfields, nrecords, type_size, field_names, field_offset, field_types, chunk_size, fill_data, compress, data)
     lock(liblock)
@@ -7586,7 +8528,9 @@ end
 """
     h5tb_read_records(loc_id::hid_t, table_name::Ptr{UInt8}, start::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_offsets::Ptr{Csize_t}, dst_sizes::Ptr{Csize_t}, data::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5TBread_records`](https://portal.hdfgroup.org/display/HDF5/H5TB_READ_RECORDS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5TB']/member[name='H5TBread_records']).
 """
 function h5tb_read_records(loc_id, table_name, start, nrecords, type_size, field_offsets, dst_sizes, data)
     lock(liblock)
@@ -7602,7 +8546,9 @@ end
 """
     h5tb_read_table(loc_id::hid_t, table_name::Ptr{UInt8}, dst_size::Csize_t, dst_offset::Ptr{Csize_t}, dst_sizes::Ptr{Csize_t}, dst_buf::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5TBread_table`](https://portal.hdfgroup.org/display/HDF5/H5TB_READ_TABLE).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5TB']/member[name='H5TBread_table']).
 """
 function h5tb_read_table(loc_id, table_name, dst_size, dst_offset, dst_sizes, dst_buf)
     lock(liblock)
@@ -7618,7 +8564,9 @@ end
 """
     h5tb_write_records(loc_id::hid_t, table_name::Ptr{UInt8}, start::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_offsets::Ptr{UInt8}, field_sizes::Ptr{UInt8}, data::Ptr{Cvoid})
 
-See `libhdf5` documentation for [`H5TBwrite_records`](https://portal.hdfgroup.org/display/HDF5/H5TB_WRITE_RECORDS).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5TB']/member[name='H5TBwrite_records']).
 """
 function h5tb_write_records(loc_id, table_name, start, nrecords, type_size, field_offsets, field_sizes, data)
     lock(liblock)
@@ -7634,7 +8582,9 @@ end
 """
     h5z_register(filter_class::Ref{H5Z_class_t})
 
-See `libhdf5` documentation for [`H5Zregister`](https://portal.hdfgroup.org/display/HDF5/H5Z_REGISTER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5Z']/member[name='H5Zregister']).
 """
 function h5z_register(filter_class)
     lock(liblock)
@@ -7650,7 +8600,9 @@ end
 """
     h5z_unregister(id::H5Z_filter_t)
 
-See `libhdf5` documentation for [`H5Zunregister`](https://portal.hdfgroup.org/display/HDF5/H5Z_UNREGISTER).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5Z']/member[name='H5Zunregister']).
 """
 function h5z_unregister(id)
     lock(liblock)
@@ -7666,7 +8618,9 @@ end
 """
     h5z_filter_avail(id::H5Z_filter_t) -> Bool
 
-See `libhdf5` documentation for [`H5Zfilter_avail`](https://portal.hdfgroup.org/display/HDF5/H5Z_FILTER_AVAIL).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5Z']/member[name='H5Zfilter_avail']).
 """
 function h5z_filter_avail(id)
     lock(liblock)
@@ -7682,7 +8636,9 @@ end
 """
     h5z_get_filter_info(filter::H5Z_filter_t, filter_config_flags::Ptr{Cuint})
 
-See `libhdf5` documentation for [`H5Zget_filter_info`](https://portal.hdfgroup.org/display/HDF5/H5Z_GET_FILTER_INFO).
+# External links
+
+- [](@doxygen /tagfile/compound[name='H5Z']/member[name='H5Zget_filter_info']).
 """
 function h5z_get_filter_info(filter, filter_config_flags)
     lock(liblock)

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -10,6 +10,11 @@ group, every object must be a member of at least one group.
 
 - [`create_group`](@ref)
 - [`open_group`](@ref)
+
+# External links
+
+- [](@doxygen /tagfile/compound[title='The HDF5 Data Model and File Structure']/docanchor[@title='Group'])
+
 """
 Group
 


### PR DESCRIPTION
This was my effort at #1029, as an alternative to #1043. It adds a pass to Documenter that expands `@doxygen` tags based on XML xpaths.

Still not quite complete, as the xpaths are a bit complicated.