### PR TITLE
Create a channel to iterate attributes

### DIFF
--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -103,6 +103,48 @@ function h5a_iterate(@nospecialize(f), obj_id, idx_type, order, idx=0)
     return idxref[]
 end
 
+"""
+    h5a_iterate(Channel, loc_id, idx_type, order; kwargs...)
+    h5a_iterate(f, Channel, loc_id, idx_type, order; kwargs...)
+
+Create a `Channel{Tuple{hid_t,Ptr{Cchar},Ptr{H5A_info_t}}}` to iterate over the
+attributes. If a function `f` or a do block is provided the channel will be
+closed after the function or block returns.
+
+# Examples
+```julia-repl
+julia> HDF5.API.h5a_iterate(Channel, obj, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_INC) do ch
+           for (loc, name, info) in ch
+               println(unsafe_string(name))
+           end
+       end
+```
+"""
+function h5a_iterate(::Type{Channel}, loc_id, idx_type, order, idx=0; kwargs...)
+    ch = Channel{Tuple{hid_t,Ptr{Cchar},Ptr{H5A_info_t}}}(0; kwargs...) do ch
+        h5a_iterate(loc_id, idx_type, order, idx) do loc, name, info
+            # release API lock
+            unlock(liblock)
+            try
+                put!(ch, (loc, name, info))
+            finally
+                # restore API lock
+                lock(liblock)
+            end
+            return false
+        end
+    end
+    return ch
+end
+function h5a_iterate(@nospecialize(f::Function), ::Type{Channel}, args...; kwargs...)
+    ch = h5a_iterate(Channel, args...; kwargs...)
+    try
+        return f(ch)
+    finally
+        close(ch)
+    end
+end
+
 ###
 ### Dataset Interface
 ###

--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -126,6 +126,7 @@ function h5a_iterate(::Type{Channel}, loc_id, idx_type, order, idx=0; kwargs...)
             # release API lock
             unlock(liblock)
             try
+                isopen(ch) || return true
                 put!(ch, (loc, name, info))
             finally
                 # restore API lock


### PR DESCRIPTION
This is a proof of concept to show how we can turn the HDF5 iterate functions into `Channel` iterators. Below we produce a `Channel` that is passed to `map`. The `Channel` is closed at the end of the `do` block. If no function or do block is provided, the `Channel` is returned, and the user is responsible for closing the channel.

```julia
julia> h5open("test.h5","w", libver_bounds=v"1.8", meta_block_size=4096) do h5f
           attrs(h5f)["first"] = "Mark"
           attrs(h5f)["last"] = "Kittisopikul"
       end;

julia> h5open("test.h5") do h5f
           HDF5.API.h5a_iterate(Channel, h5f, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_INC) do ch
               map(ch) do (loc, name, info)
                   name = unsafe_string(name)
                   name => attrs(h5f)[name]
               end
           end
       end
2-element Vector{Pair{String, String}}:
 "first" => "Mark"
  "last" => "Kittisopikul"
```