### PR TITLE
Always load even if deps aren't satisfied

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -57,10 +57,10 @@ else
 
     function check_deps()
         if libhdf5_size != filesize(Libdl.dlpath(libhdf5))
-            error("HDF5 library has changed, re-run Pkg.build(\\\"HDF5\\\")")
+            @error("HDF5 library has changed, re-run Pkg.build(\\\"HDF5\\\")")
         end
         if h5_get_libversion() < v"1.10.4"
-            error("HDF5.jl requires ≥ v1.10.4 of the HDF5 library.")
+            @error("HDF5.jl requires ≥ v1.10.4 of the HDF5 library.")
         end
     end
     $(:(const libhdf5 = $libhdf5))

--- a/src/api/api.jl
+++ b/src/api/api.jl
@@ -7,7 +7,7 @@ const depsfile = joinpath(@__DIR__, "..", "..", "deps", "deps.jl")
 if isfile(depsfile)
     include(depsfile)
 else
-    error(
+    @error(
         "HDF5 is not properly installed. Please run Pkg.build(\"HDF5\") ",
         "and restart Julia."
     )


### PR DESCRIPTION
In my opinion, it's bad practice to have a package fail to load just because some binary dependencies aren't available or correctly built, because it causes all downstream users of the package to fail to load, even if they don't ever rely on the functionality in HDF5.

I ran into this while trying to load ProxAL.jl so that I could open a file generated by Julia's serializer; because HDF5 refused to load (due to being unable to find `libhdf5_hl` in the build step), it caused ProxAL to fail to load, which was infuriating because I didn't actually need HDF5 at all for what I was doing.

As a similar example, AMDGPU.jl (one of the packages I maintain) also had this behavior, and would fail to load for any number of reasons relating to binary dependencies (even those pulled in via JLL). That behavior caused a massive lack of uptake in the ecosystem because AMDGPU would "poison" packages which had it as a dependency, making life miserable for users who might not even have an AMD GPU (or didn't desire to use it). Fixing that required some careful tracking of binary dependencies, but it was overall a very positive move.