### PR TITLE
use Cstring in ccall

### DIFF
--- a/gen/api_defs.jl
+++ b/gen/api_defs.jl
@@ -36,21 +36,21 @@
 ###
 
 @bind h5a_close(id::hid_t)::herr_t "Error closing attribute"
-@bind h5a_create2(loc_id::hid_t, attr_name::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t)::hid_t string("Error creating attribute ", attr_name, " for object ", h5i_get_name(loc_id))
-@bind h5a_create_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t, lapl_id::hid_t)::hid_t string("Error creating attribute ", attr_name, " for object ", obj_name)
-@bind h5a_delete(loc_id::hid_t, attr_name::Ptr{UInt8})::herr_t string("Error deleting attribute ", attr_name)
-@bind h5a_delete_by_idx(loc_id::hid_t, obj_name::Ptr{UInt8}, idx_type::Cint, order::Cint, n::hsize_t, lapl_id::hid_t)::herr_t string("Error deleting attribute ", n, " from object ", obj_name)
-@bind h5a_delete_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, lapl_id::hid_t)::herr_t string("Error removing attribute ", attr_name, " from object ", obj_name)
-@bind h5a_exists(obj_id::hid_t, attr_name::Ptr{UInt8})::htri_t string("Error checking whether attribute ", attr_name, " exists")
-@bind h5a_exists_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, lapl_id::hid_t)::htri_t string("Error checking whether object ", obj_name, " has attribute ", attr_name)
+@bind h5a_create2(loc_id::hid_t, attr_name::Cstring, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t)::hid_t string("Error creating attribute ", attr_name, " for object ", h5i_get_name(loc_id))
+@bind h5a_create_by_name(loc_id::hid_t, obj_name::Cstring, attr_name::Cstring, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t, lapl_id::hid_t)::hid_t string("Error creating attribute ", attr_name, " for object ", obj_name)
+@bind h5a_delete(loc_id::hid_t, attr_name::Cstring)::herr_t string("Error deleting attribute ", attr_name)
+@bind h5a_delete_by_idx(loc_id::hid_t, obj_name::Cstring, idx_type::Cint, order::Cint, n::hsize_t, lapl_id::hid_t)::herr_t string("Error deleting attribute ", n, " from object ", obj_name)
+@bind h5a_delete_by_name(loc_id::hid_t, obj_name::Cstring, attr_name::Cstring, lapl_id::hid_t)::herr_t string("Error removing attribute ", attr_name, " from object ", obj_name)
+@bind h5a_exists(obj_id::hid_t, attr_name::Cstring)::htri_t string("Error checking whether attribute ", attr_name, " exists")
+@bind h5a_exists_by_name(loc_id::hid_t, obj_name::Cstring, attr_name::Cstring, lapl_id::hid_t)::htri_t string("Error checking whether object ", obj_name, " has attribute ", attr_name)
 @bind h5a_get_create_plist(attr_id::hid_t)::hid_t "Cannot get creation property list"
 @bind h5a_get_name(attr_id::hid_t, buf_size::Csize_t, buf::Ptr{UInt8})::Cssize_t "Error getting attribute name"
 @bind h5a_get_name_by_idx(loc_id::hid_t, obj_name::Cstring, index_type::Cint, order::Cint, idx::hsize_t, name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t)::Cssize_t "Error getting attribute name"
 @bind h5a_get_space(attr_id::hid_t)::hid_t "Error getting attribute dataspace"
 @bind h5a_get_type(attr_id::hid_t)::hid_t "Error getting attribute type"
 @bind h5a_iterate2(obj_id::hid_t, idx_type::Cint, order::Cint, n::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Any)::herr_t string("Error iterating attributes in object ", h5i_get_name(obj_id))
-@bind h5a_open(obj_id::hid_t, attr_name::Ptr{UInt8}, aapl_id::hid_t)::hid_t string("Error opening attribute ", attr_name, " for object ", h5i_get_name(obj_id))
-@bind h5a_open_by_idx(obj_id::hid_t, pathname::Ptr{UInt8}, idx_type::Cint, order::Cint, n::hsize_t, aapl_id::hid_t, lapl_id::hid_t)::hid_t string("Error opening attribute ", n, " of ", h5i_get_name(obj_id), "/", pathname)
+@bind h5a_open(obj_id::hid_t, attr_name::Cstring, aapl_id::hid_t)::hid_t string("Error opening attribute ", attr_name, " for object ", h5i_get_name(obj_id))
+@bind h5a_open_by_idx(obj_id::hid_t, pathname::Cstring, idx_type::Cint, order::Cint, n::hsize_t, aapl_id::hid_t, lapl_id::hid_t)::hid_t string("Error opening attribute ", n, " of ", h5i_get_name(obj_id), "/", pathname)
 @bind h5a_read(attr_id::hid_t, mem_type_id::hid_t, buf::Ptr{Cvoid})::herr_t string("Error reading attribute ", h5a_get_name(attr_id))
 @bind h5a_rename(loc_id::hid_t, old_attr_name::Cstring, new_attr_name::Cstring)::herr_t string("Could not rename attribute")
 @bind h5a_write(attr_hid::hid_t, mem_type_id::hid_t, buf::Ptr{Cvoid})::herr_t "Error writing attribute data"
@@ -60,7 +60,7 @@
 ###
 
 @bind h5d_close(dataset_id::hid_t)::herr_t "Error closing dataset"
-@bind h5d_create2(loc_id::hid_t, pathname::Ptr{UInt8}, dtype_id::hid_t, space_id::hid_t, lcpl_id::hid_t, dcpl_id::hid_t, dapl_id::hid_t)::hid_t string("Error creating dataset ", h5i_get_name(loc_id), "/", pathname)
+@bind h5d_create2(loc_id::hid_t, pathname::Cstring, dtype_id::hid_t, space_id::hid_t, lcpl_id::hid_t, dcpl_id::hid_t, dapl_id::hid_t)::hid_t string("Error creating dataset ", h5i_get_name(loc_id), "/", pathname)
 @bind h5d_create_anon(loc_id::hid_t, type_id::hid_t, space_id::hid_t, dcpl_id::hid_t, dapl_id::hid_t)::hid_t "Error in creating anonymous dataset"
 @bind h5d_extend(dataset_id::hid_t, size::Ptr{hsize_t})::herr_t "Error extending dataset" # deprecated in favor of h5d_set_extent
 @bind h5d_fill(fill::Ptr{Cvoid}, fill_type_id::hid_t, buf::Ptr{Cvoid}, buf_type_id::hid_t, space_id::hid_t)::herr_t "Error filling dataset"
@@ -78,7 +78,7 @@
 @bind h5d_get_storage_size(dataset_id::hid_t)::hsize_t "Error getting storage size"
 @bind h5d_get_type(dataset_id::hid_t)::hid_t "Error getting dataspace type"
 @bind h5d_iterate(buf::Ptr{Cvoid}, type_id::hid_t, space_id::hid_t, operator::Ptr{Cvoid}, operator_data::Any)::herr_t "Error iterating dataset"
-@bind h5d_open2(loc_id::hid_t, pathname::Ptr{UInt8}, dapl_id::hid_t)::hid_t string("Error opening dataset ", h5i_get_name(loc_id), "/", pathname)
+@bind h5d_open2(loc_id::hid_t, pathname::Cstring, dapl_id::hid_t)::hid_t string("Error opening dataset ", h5i_get_name(loc_id), "/", pathname)
 @bind h5d_read(dataset_id::hid_t, mem_type_id::hid_t, mem_space_id::hid_t, file_space_id::hid_t, xfer_plist_id::hid_t, buf::Ptr{Cvoid})::herr_t string("Error reading dataset ", h5i_get_name(dataset_id))
 @bind h5d_read_chunk(dset::hid_t, dxpl_id::hid_t, offset::Ptr{hsize_t}, filters::Ptr{UInt32}, buf::Ptr{Cvoid})::herr_t "Error reading chunk"
 @bind h5d_refresh(dataset_id::hid_t)::herr_t "Error refreshing dataset"
@@ -107,8 +107,8 @@
 
 @bind h5f_clear_elink_file_cache(file_id::hid_t)::herr_t "Error in h5f_clear_elink_file_cache (not annotated)"
 @bind h5f_close(file_id::hid_t)::herr_t "Error closing file"
-@bind h5f_create(pathname::Ptr{UInt8}, flags::Cuint, fcpl_id::hid_t, fapl_id::hid_t)::hid_t "Error creating file $pathname"
-@bind h5f_delete(filename::Ptr{Cchar}, fapl_id::hid_t)::herr_t "Error in h5f_delete (not annotated)"
+@bind h5f_create(pathname::Cstring, flags::Cuint, fcpl_id::hid_t, fapl_id::hid_t)::hid_t "Error creating file $pathname"
+@bind h5f_delete(filename::Cstring, fapl_id::hid_t)::herr_t "Error in h5f_delete (not annotated)"
 @bind h5f_flush(object_id::hid_t, scope::Cint)::herr_t "Error flushing object to file"
 @bind h5f_format_convert(fid::hid_t)::herr_t "Error in h5f_format_convert (not annotated)"
 @bind h5f_get_access_plist(file_id::hid_t)::hid_t "Error getting file access property list"
@@ -135,9 +135,9 @@
 @bind h5f_get_page_buffering_stats(file_id::hid_t, accesses::Ptr{Cuint}, hits::Ptr{Cuint}, misses::Ptr{Cuint}, evictions::Ptr{Cuint}, bypasses::Ptr{Cuint})::herr_t "Error in h5f_get_page_buffering_stats (not annotated)"
 @bind h5f_get_vfd_handle(file_id::hid_t, fapl_id::hid_t, file_handle::Ref{Ptr{Cvoid}})::herr_t "Error getting VFD handle"
 @bind h5f_increment_filesize(file_id::hid_t, increment::hsize_t)::herr_t "Error in h5f_increment_filesize (not annotated)"
-@bind h5f_is_accessible(container_name::Ptr{Cchar}, fapl_id::hid_t)::htri_t "Error in h5f_is_accessible (not annotated)"
+@bind h5f_is_accessible(container_name::Cstring, fapl_id::hid_t)::htri_t "Error in h5f_is_accessible (not annotated)"
 @bind h5f_is_hdf5(pathname::Cstring)::htri_t "Unable to access file $pathname"
-@bind h5f_mount(loc::hid_t, name::Ptr{Cchar}, child::hid_t, plist::hid_t)::herr_t "Error in h5f_mount (not annotated)"
+@bind h5f_mount(loc::hid_t, name::Cstring, child::hid_t, plist::hid_t)::herr_t "Error in h5f_mount (not annotated)"
 @bind h5f_open(pathname::Cstring, flags::Cuint, fapl_id::hid_t)::hid_t "Error opening file $pathname"
 @bind h5f_reopen(file_id::hid_t)::hid_t "Error in h5f_reopen (not annotated)"
 @bind h5f_reset_mdc_hit_rate_stats(file_id::hid_t)::herr_t "Error in h5f_reset_mdc_hit_rate_stats (not annotated)"
@@ -149,19 +149,19 @@
 @bind h5f_start_mdc_logging(file_id::hid_t)::herr_t "Error in h5f_start_mdc_logging (not annotated)"
 @bind h5f_start_swmr_write(id::hid_t)::herr_t "Error starting SWMR write"
 @bind h5f_stop_mdc_logging(file_id::hid_t)::herr_t "Error in h5f_stop_mdc_logging (not annotated)"
-@bind h5f_unmount(loc::hid_t, name::Ptr{Cchar})::herr_t "Error in h5f_unmount (not annotated)"
+@bind h5f_unmount(loc::hid_t, name::Cstring)::herr_t "Error in h5f_unmount (not annotated)"
 
 ###
 ### Group Interface
 ###
 
 @bind h5g_close(group_id::hid_t)::herr_t "Error closing group"
-@bind h5g_create2(loc_id::hid_t, pathname::Ptr{UInt8}, lcpl_id::hid_t, gcpl_id::hid_t, gapl_id::hid_t)::hid_t "Error creating group $(h5i_get_name(loc_id))/$(pathname)"
+@bind h5g_create2(loc_id::hid_t, pathname::Cstring, lcpl_id::hid_t, gcpl_id::hid_t, gapl_id::hid_t)::hid_t "Error creating group $(h5i_get_name(loc_id))/$(pathname)"
 @bind h5g_get_create_plist(group_id::hid_t)::hid_t "Error getting group create property list"
 @bind h5g_get_info(group_id::hid_t, buf::Ptr{H5G_info_t})::herr_t "Error getting group info"
 @bind h5g_get_num_objs(loc_id::hid_t, num_obj::Ptr{hsize_t})::hid_t "Error getting group length"
 @bind h5g_get_objname_by_idx(loc_id::hid_t, idx::hsize_t, pathname::Ptr{UInt8}, size::Csize_t)::Cssize_t "Error getting group object name $(h5i_get_name(loc_id))/$(pathname)"
-@bind h5g_open2(loc_id::hid_t, pathname::Ptr{UInt8}, gapl_id::hid_t)::hid_t "Error opening group $(h5i_get_name(loc_id))/$(pathname)"
+@bind h5g_open2(loc_id::hid_t, pathname::Cstring, gapl_id::hid_t)::hid_t "Error opening group $(h5i_get_name(loc_id))/$(pathname)"
 
 ###
 ### Identifier Interface
@@ -179,14 +179,14 @@
 ### Link Interface
 ###
 
-@bind h5l_create_external(target_file_name::Ptr{UInt8}, target_obj_name::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)::herr_t string("Error creating external link ", link_name, " pointing to ", target_obj_name, " in file ", target_file_name)
-@bind h5l_create_hard(obj_loc_id::hid_t, obj_name::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)::herr_t string("Error creating hard link ", link_name, " pointing to ", obj_name)
-@bind h5l_create_soft(target_path::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)::herr_t string("Error creating soft link ", link_name, " pointing to ", target_path)
-@bind h5l_delete(obj_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t)::herr_t string("Error deleting ", h5i_get_name(obj_id), "/", pathname)
-@bind h5l_move(src_obj_id::hid_t, src_name::Ptr{UInt8}, dest_obj_id::hid_t, dest_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)::herr_t string("Error moving ", h5i_get_name(src_obj_id), "/", src_name, " to ", h5i_get_name(dest_obj_id), "/", dest_name)
-@bind h5l_exists(loc_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t)::htri_t string("Cannot determine whether ", pathname, " exists")
-@bind h5l_get_info(link_loc_id::hid_t, link_name::Ptr{UInt8}, link_buf::Ptr{H5L_info_t}, lapl_id::hid_t)::herr_t string("Error getting info for link ", link_name)
-@bind h5l_get_name_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_field::Cint, order::Cint, n::hsize_t, name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t)::Cssize_t "Error getting object name"
+@bind h5l_create_external(target_file_name::Cstring, target_obj_name::Cstring, link_loc_id::hid_t, link_name::Cstring, lcpl_id::hid_t, lapl_id::hid_t)::herr_t string("Error creating external link ", link_name, " pointing to ", target_obj_name, " in file ", target_file_name)
+@bind h5l_create_hard(obj_loc_id::hid_t, obj_name::Cstring, link_loc_id::hid_t, link_name::Cstring, lcpl_id::hid_t, lapl_id::hid_t)::herr_t string("Error creating hard link ", link_name, " pointing to ", obj_name)
+@bind h5l_create_soft(target_path::Cstring, link_loc_id::hid_t, link_name::Cstring, lcpl_id::hid_t, lapl_id::hid_t)::herr_t string("Error creating soft link ", link_name, " pointing to ", target_path)
+@bind h5l_delete(obj_id::hid_t, pathname::Cstring, lapl_id::hid_t)::herr_t string("Error deleting ", h5i_get_name(obj_id), "/", pathname)
+@bind h5l_move(src_obj_id::hid_t, src_name::Cstring, dest_obj_id::hid_t, dest_name::Cstring, lcpl_id::hid_t, lapl_id::hid_t)::herr_t string("Error moving ", h5i_get_name(src_obj_id), "/", src_name, " to ", h5i_get_name(dest_obj_id), "/", dest_name)
+@bind h5l_exists(loc_id::hid_t, pathname::Cstring, lapl_id::hid_t)::htri_t string("Cannot determine whether ", pathname, " exists")
+@bind h5l_get_info(link_loc_id::hid_t, link_name::Cstring, link_buf::Ptr{H5L_info_t}, lapl_id::hid_t)::herr_t string("Error getting info for link ", link_name)
+@bind h5l_get_name_by_idx(loc_id::hid_t, group_name::Cstring, index_field::Cint, order::Cint, n::hsize_t, name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t)::Cssize_t "Error getting object name"
 # libhdf5 v1.10 provides the name H5Literate
 # libhdf5 v1.12 provides the same under H5Literate1, and a newer interface on H5Literate2
 @bind h5l_iterate(group_id::hid_t, idx_type::Cint, order::Cint, idx::Ptr{hsize_t}, op::Ptr{Cvoid}, op_data::Any)::herr_t string("Error iterating through links in group ", h5i_get_name(group_id)) (nothing, v"1.12")
@@ -199,50 +199,50 @@
 
 @bind h5o_are_mdc_flushes_disabled(object_id::hid_t, are_disabled::Ptr{hbool_t})::herr_t "Error in h5o_are_mdc_flushes_disabled (not annotated)"
 @bind h5o_close(object_id::hid_t)::herr_t "Error closing object"
-@bind h5o_copy(src_loc_id::hid_t, src_name::Ptr{UInt8}, dst_loc_id::hid_t, dst_name::Ptr{UInt8}, ocpypl_id::hid_t, lcpl_id::hid_t)::herr_t string("Error copying object ", h5i_get_name(src_loc_id), "/", src_name, " to ", h5i_get_name(dst_loc_id), "/", dst_name)
+@bind h5o_copy(src_loc_id::hid_t, src_name::Cstring, dst_loc_id::hid_t, dst_name::Cstring, ocpypl_id::hid_t, lcpl_id::hid_t)::herr_t string("Error copying object ", h5i_get_name(src_loc_id), "/", src_name, " to ", h5i_get_name(dst_loc_id), "/", dst_name)
 @bind h5o_decr_refcount(object_id::hid_t)::herr_t "Error in h5o_decr_refcount (not annotated)"
 @bind h5o_disable_mdc_flushes(object_id::hid_t)::herr_t "Error in h5o_disable_mdc_flushes (not annotated)"
 @bind h5o_enable_mdc_flushes(object_id::hid_t)::herr_t "Error in h5o_enable_mdc_flushes (not annotated)"
-@bind h5o_exists_by_name(loc_id::hid_t, name::Ptr{Cchar}, lapl_id::hid_t)::htri_t "Error in h5o_exists_by_name (not annotated)"
+@bind h5o_exists_by_name(loc_id::hid_t, name::Cstring, lapl_id::hid_t)::htri_t "Error in h5o_exists_by_name (not annotated)"
 @bind h5o_flush(obj_id::hid_t)::herr_t "Error in h5o_flush (not annotated)"
 @bind h5o_get_comment(obj_id::hid_t, comment::Ptr{Cchar}, bufsize::Csize_t)::Cssize_t "Error in h5o_get_comment (not annotated)"
-@bind h5o_get_comment_by_name(loc_id::hid_t, name::Ptr{Cchar}, comment::Ptr{Cchar}, bufsize::Csize_t, lapl_id::hid_t)::Cssize_t "Error in h5o_get_comment_by_name (not annotated)"
+@bind h5o_get_comment_by_name(loc_id::hid_t, name::Cstring, comment::Ptr{Cchar}, bufsize::Csize_t, lapl_id::hid_t)::Cssize_t "Error in h5o_get_comment_by_name (not annotated)"
 @bind h5o_get_info1(object_id::hid_t, buf::Ptr{H5O_info1_t})::herr_t "Error getting object info" (nothing, v"1.10.3")
 @bind h5o_get_info2(loc_id::hid_t, oinfo::Ptr{H5O_info1_t}, fields::Cuint)::herr_t "Error in h5o_get_info2 (not annotated)" (v"1.10.3", v"1.12.0")
 @bind h5o_get_info3(loc_id::hid_t, oinfo::Ptr{H5O_info2_t}, fields::Cuint)::herr_t "Error in h5o_get_info3 (not annotated)" (v"1.12.0", nothing)
-@bind h5o_get_info_by_idx1(loc_id::hid_t, group_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info1_t}, lapl_id::hid_t)::herr_t "Error in h5o_get_info_by_idx1 (not annotated)" (nothing, v"1.10.3")
-@bind h5o_get_info_by_idx2(loc_id::hid_t, group_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info1_t}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_get_info_by_idx2 (not annotated)" (v"1.10.3", v"1.12.0")
-@bind h5o_get_info_by_idx3(loc_id::hid_t, group_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info2_t}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_get_info_by_idx3 (not annotated)" (v"1.12.0", nothing)
-@bind h5o_get_info_by_name1(loc_id::hid_t, name::Ptr{Cchar}, oinfo::Ptr{H5O_info1_t}, lapl_id::hid_t)::herr_t "Error in h5o_get_info_by_name1 (not annotated)" (nothing, v"1.10.3")
-@bind h5o_get_info_by_name2(loc_id::hid_t, name::Ptr{Cchar}, oinfo::Ptr{H5O_info1_t}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_get_info_by_name2 (not annotated)" (v"1.10.3", v"1.12.0")
-@bind h5o_get_info_by_name3(loc_id::hid_t, name::Ptr{Cchar}, oinfo::Ptr{H5O_info2_t}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_get_info_by_name3 (not annotated)" (v"1.12.0", nothing)
+@bind h5o_get_info_by_idx1(loc_id::hid_t, group_name::Cstring, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info1_t}, lapl_id::hid_t)::herr_t "Error in h5o_get_info_by_idx1 (not annotated)" (nothing, v"1.10.3")
+@bind h5o_get_info_by_idx2(loc_id::hid_t, group_name::Cstring, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info1_t}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_get_info_by_idx2 (not annotated)" (v"1.10.3", v"1.12.0")
+@bind h5o_get_info_by_idx3(loc_id::hid_t, group_name::Cstring, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info2_t}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_get_info_by_idx3 (not annotated)" (v"1.12.0", nothing)
+@bind h5o_get_info_by_name1(loc_id::hid_t, name::Cstring, oinfo::Ptr{H5O_info1_t}, lapl_id::hid_t)::herr_t "Error in h5o_get_info_by_name1 (not annotated)" (nothing, v"1.10.3")
+@bind h5o_get_info_by_name2(loc_id::hid_t, name::Cstring, oinfo::Ptr{H5O_info1_t}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_get_info_by_name2 (not annotated)" (v"1.10.3", v"1.12.0")
+@bind h5o_get_info_by_name3(loc_id::hid_t, name::Cstring, oinfo::Ptr{H5O_info2_t}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_get_info_by_name3 (not annotated)" (v"1.12.0", nothing)
 @bind h5o_get_native_info(loc_id::hid_t, oinfo::Ptr{H5O_native_info_t}, fields::Cuint)::herr_t "Error in h5o_get_native_info (not annotated)"
-@bind h5o_get_native_info_by_idx(loc_id::hid_t, group_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_native_info_t}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_get_native_info_by_idx (not annotated)"
-@bind h5o_get_native_info_by_name(loc_id::hid_t, name::Ptr{Cchar}, oinfo::Ptr{H5O_native_info_t}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_get_native_info_by_name (not annotated)"
+@bind h5o_get_native_info_by_idx(loc_id::hid_t, group_name::Cstring, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_native_info_t}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_get_native_info_by_idx (not annotated)"
+@bind h5o_get_native_info_by_name(loc_id::hid_t, name::Cstring, oinfo::Ptr{H5O_native_info_t}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_get_native_info_by_name (not annotated)"
 @bind h5o_incr_refcount(object_id::hid_t)::herr_t "Error in h5o_incr_refcount (not annotated)"
-@bind h5o_link(obj_id::hid_t, new_loc_id::hid_t, new_name::Ptr{Cchar}, lcpl_id::hid_t, lapl_id::hid_t)::herr_t "Error in h5o_link (not annotated)"
-@bind h5o_open(loc_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t)::hid_t string("Error opening object ", h5i_get_name(loc_id), "/", pathname)
+@bind h5o_link(obj_id::hid_t, new_loc_id::hid_t, new_name::Cstring, lcpl_id::hid_t, lapl_id::hid_t)::herr_t "Error in h5o_link (not annotated)"
+@bind h5o_open(loc_id::hid_t, pathname::Cstring, lapl_id::hid_t)::hid_t string("Error opening object ", h5i_get_name(loc_id), "/", pathname)
 @bind h5o_open_by_addr(loc_id::hid_t, addr::haddr_t)::hid_t "Error opening object by address"
-@bind h5o_open_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_type::Cint, order::Cint, n::hsize_t, lapl_id::hid_t)::hid_t string("Error opening object of index ", n)
+@bind h5o_open_by_idx(loc_id::hid_t, group_name::Cstring, index_type::Cint, order::Cint, n::hsize_t, lapl_id::hid_t)::hid_t string("Error opening object of index ", n)
 @bind h5o_refresh(oid::hid_t)::herr_t "Error in h5o_refresh (not annotated)"
-@bind h5o_set_comment(obj_id::hid_t, comment::Ptr{Cchar})::herr_t "Error in h5o_set_comment (not annotated)"
-@bind h5o_set_comment_by_name(loc_id::hid_t, name::Ptr{Cchar}, comment::Ptr{Cchar}, lapl_id::hid_t)::herr_t "Error in h5o_set_comment_by_name (not annotated)"
+@bind h5o_set_comment(obj_id::hid_t, comment::Cstring)::herr_t "Error in h5o_set_comment (not annotated)"
+@bind h5o_set_comment_by_name(loc_id::hid_t, name::Cstring, comment::Cstring, lapl_id::hid_t)::herr_t "Error in h5o_set_comment_by_name (not annotated)"
 @bind h5o_token_cmp(loc_id::hid_t, token1::Ptr{H5O_token_t}, token2::Ptr{H5O_token_t}, cmp_value::Ptr{Cint})::herr_t "Error in h5o_token_cmp (not annotated)"
-@bind h5o_token_from_str(loc_id::hid_t, token_str::Ptr{Cchar}, token::Ptr{H5O_token_t})::herr_t "Error in h5o_token_from_str (not annotated)"
+@bind h5o_token_from_str(loc_id::hid_t, token_str::Cstring, token::Ptr{H5O_token_t})::herr_t "Error in h5o_token_from_str (not annotated)"
 @bind h5o_token_to_str(loc_id::hid_t, token::Ptr{H5O_token_t}, token_str::Ptr{Ptr{Cchar}})::herr_t "Error in h5o_token_to_str (not annotated)"
 @bind h5o_visit1(obj_id::hid_t, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate1_t, op_data::Ptr{Cvoid})::herr_t "Error in h5o_visit1 (not annotated)" (nothing, v"1.12.0")
 #@bind h5o_visit2(obj_id::hid_t, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate1_t, op_data::Ptr{Cvoid}, fields::Cuint)::herr_t "Error in h5o_visit2 (not annotated)"
 @bind h5o_visit3(obj_id::hid_t, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate2_t, op_data::Ptr{Cvoid}, fields::Cuint)::herr_t "Error in h5o_visit3 (not annotated)" (v"1.12.0", nothing)
-@bind h5o_visit_by_name1(loc_id::hid_t, obj_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate1_t, op_data::Ptr{Cvoid}, lapl_id::hid_t)::herr_t "Error in h5o_visit_by_name1 (not annotated)" (nothing, v"1.12.0")
-#@bind h5o_visit_by_name2(loc_id::hid_t, obj_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate1_t, op_data::Ptr{Cvoid}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_visit_by_name2 (not annotated)"
-@bind h5o_visit_by_name3(loc_id::hid_t, obj_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate2_t, op_data::Ptr{Cvoid}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_visit_by_name3 (not annotated)" (v"1.12.0", nothing)
+@bind h5o_visit_by_name1(loc_id::hid_t, obj_name::Cstring, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate1_t, op_data::Ptr{Cvoid}, lapl_id::hid_t)::herr_t "Error in h5o_visit_by_name1 (not annotated)" (nothing, v"1.12.0")
+#@bind h5o_visit_by_name2(loc_id::hid_t, obj_name::Cstring, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate1_t, op_data::Ptr{Cvoid}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_visit_by_name2 (not annotated)"
+@bind h5o_visit_by_name3(loc_id::hid_t, obj_name::Cstring, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate2_t, op_data::Ptr{Cvoid}, fields::Cuint, lapl_id::hid_t)::herr_t "Error in h5o_visit_by_name3 (not annotated)" (v"1.12.0", nothing)
 
 ###
 ### Property Interface
 ###
 
 # get
-@bind h5p_get(plist_id::hid_t, name::Ptr{Cchar}, value::Ptr{Cvoid})::herr_t "Error in h5p_get (not annotated)"
+@bind h5p_get(plist_id::hid_t, name::Cstring, value::Ptr{Cvoid})::herr_t "Error in h5p_get (not annotated)"
 @bind h5p_get_alignment(fapl_id::hid_t, threshold::Ref{hsize_t}, alignment::Ref{hsize_t})::herr_t "Error getting alignment"
 @bind h5p_get_alloc_time(plist_id::hid_t, alloc_time::Ptr{Cint})::herr_t "Error getting allocation timing"
 @bind h5p_get_append_flush(dapl_id::hid_t, dims::Cuint, boundary::Ptr{hsize_t}, func::Ptr{H5D_append_cb_t}, udata::Ptr{Ptr{Cvoid}})::herr_t "Error in h5p_get_append_flush (not annotated)"
@@ -341,7 +341,7 @@
 @bind h5p_get_vol_info(plist_id::hid_t, vol_info::Ptr{Ptr{Cvoid}})::herr_t "Error in h5p_get_vol_info (not annotated)"
 
 # set
-@bind h5p_set(plist_id::hid_t, name::Ptr{Cchar}, value::Ptr{Cvoid})::herr_t "Error in h5p_set (not annotated)"
+@bind h5p_set(plist_id::hid_t, name::Cstring, value::Ptr{Cvoid})::herr_t "Error in h5p_set (not annotated)"
 @bind h5p_set_alignment(plist_id::hid_t, threshold::hsize_t, alignment::hsize_t)::herr_t "Error setting alignment"
 @bind h5p_set_alloc_time(plist_id::hid_t, alloc_time::Cint)::herr_t "Error setting allocation timing"
 @bind h5p_set_append_flush(dapl_id::hid_t, ndims::Cuint, boundary::Ptr{hsize_t}, func::H5D_append_cb_t, udata::Ptr{Cvoid})::herr_t "Error in h5p_set_append_flush (not annotated)"
@@ -357,30 +357,30 @@
 @bind h5p_set_copy_object(plist_id::hid_t, copy_options::Cuint)::herr_t "Error in h5p_set_copy_object (not annotated)"
 @bind h5p_set_core_write_tracking(fapl_id::hid_t, is_enabled::hbool_t, page_size::Csize_t)::herr_t "Error in h5p_set_core_write_tracking (not annotated)"
 @bind h5p_set_create_intermediate_group(plist_id::hid_t, setting::Cuint)::herr_t "Error setting create intermediate group"
-@bind h5p_set_data_transform(plist_id::hid_t, expression::Ptr{Cchar})::herr_t "Error in h5p_set_data_transform (not annotated)"
+@bind h5p_set_data_transform(plist_id::hid_t, expression::Cstring)::herr_t "Error in h5p_set_data_transform (not annotated)"
 @bind h5p_set_deflate(plist_id::hid_t, setting::Cuint)::herr_t "Error setting compression method and level (deflate)"
 @bind h5p_set_driver(plist_id::hid_t, driver_id::hid_t, driver_info::Ptr{Cvoid})::herr_t "Error in h5p_set_driver (not annotated)"
 @bind h5p_set_dset_no_attrs_hint(dcpl_id::hid_t, minimize::hbool_t)::herr_t "Error in setting dataset no attributes hint property"
 @bind h5p_set_dxpl_mpio(dxpl_id::hid_t, xfer_mode::Cint)::herr_t "Error setting MPIO transfer mode"
 @bind h5p_set_edc_check(plist_id::hid_t, check::H5Z_EDC_t)::herr_t "Error in h5p_set_edc_check (not annotated)"
-@bind h5p_set_efile_prefix(plist_id::hid_t, prefix::Ptr{UInt8})::herr_t "Error setting external file prefix"
+@bind h5p_set_efile_prefix(plist_id::hid_t, prefix::Cstring)::herr_t "Error setting external file prefix"
 @bind h5p_set_elink_acc_flags(lapl_id::hid_t, flags::Cuint)::herr_t "Error in h5p_set_elink_acc_flags (not annotated)"
 @bind h5p_set_elink_cb(lapl_id::hid_t, func::H5L_elink_traverse_t, op_data::Ptr{Cvoid})::herr_t "Error in h5p_set_elink_cb (not annotated)"
 @bind h5p_set_elink_fapl(lapl_id::hid_t, fapl_id::hid_t)::herr_t "Error in h5p_set_elink_fapl (not annotated)"
 @bind h5p_set_elink_file_cache_size(plist_id::hid_t, efc_size::Cuint)::herr_t "Error in h5p_set_elink_file_cache_size (not annotated)"
-@bind h5p_set_elink_prefix(plist_id::hid_t, prefix::Ptr{Cchar})::herr_t "Error in h5p_set_elink_prefix (not annotated)"
+@bind h5p_set_elink_prefix(plist_id::hid_t, prefix::Cstring)::herr_t "Error in h5p_set_elink_prefix (not annotated)"
 @bind h5p_set_est_link_info(plist_id::hid_t, est_num_entries::Cuint, est_name_len::Cuint)::herr_t "Error in h5p_set_est_link_info (not annotated)"
 @bind h5p_set_evict_on_close(fapl_id::hid_t, evict_on_close::hbool_t)::herr_t "Error in h5p_set_evict_on_close (not annotated)"
-@bind h5p_set_external(plist_id::hid_t, name::Ptr{Cchar}, offset::off_t, size::hsize_t)::herr_t "Error setting external property"
+@bind h5p_set_external(plist_id::hid_t, name::Cstring, offset::off_t, size::hsize_t)::herr_t "Error setting external property"
 @bind h5p_set_family_offset(fapl_id::hid_t, offset::hsize_t)::herr_t "Error in h5p_set_family_offset (not annotated)"
 @bind h5p_set_fapl_core(fapl_id::hid_t, increment::Csize_t, backing_store::hbool_t)::herr_t "Error in h5p_set_fapl_core (not annotated)"
 @bind h5p_set_fapl_family(fapl_id::hid_t, memb_size::hsize_t, memb_fapl_id::hid_t)::herr_t "Error in h5p_set_fapl_family (not annotated)"
 @bind h5p_set_fapl_hdfs(fapl_id::hid_t, fa::Ptr{H5FD_hdfs_fapl_t})::herr_t "Error in h5p_set_fapl_hdfs (not annotated)"
-@bind h5p_set_fapl_log(fapl_id::hid_t, logfile::Ptr{Cchar}, flags::Culonglong, buf_size::Csize_t)::herr_t "Error in h5p_set_fapl_log (not annotated)"
-@bind h5p_set_fapl_multi(fapl_id::hid_t, memb_map::Ptr{H5FD_mem_t}, memb_fapl::Ptr{hid_t}, memb_name::Ptr{Ptr{Cchar}}, memb_addr::Ptr{haddr_t}, relax::hbool_t)::herr_t "Error in h5p_set_fapl_multi (not annotated)"
+@bind h5p_set_fapl_log(fapl_id::hid_t, logfile::Cstring, flags::Culonglong, buf_size::Csize_t)::herr_t "Error in h5p_set_fapl_log (not annotated)"
+@bind h5p_set_fapl_multi(fapl_id::hid_t, memb_map::Ptr{H5FD_mem_t}, memb_fapl::Ptr{hid_t}, memb_name::Ptr{Cstring}, memb_addr::Ptr{haddr_t}, relax::hbool_t)::herr_t "Error in h5p_set_fapl_multi (not annotated)"
 @bind h5p_set_fapl_sec2(fapl_id::hid_t)::herr_t "Error setting Sec2 properties"
 @bind h5p_set_fapl_ros3(fapl_id::hid_t, fa::Ptr{H5FD_ros3_fapl_t})::herr_t "Error in setting ros3 properties"
-@bind h5p_set_fapl_split(fapl::hid_t, meta_ext::Ptr{Cchar}, meta_plist_id::hid_t, raw_ext::Ptr{Cchar}, raw_plist_id::hid_t)::herr_t "Error in h5p_set_fapl_split (not annotated)"
+@bind h5p_set_fapl_split(fapl::hid_t, meta_ext::Cstring, meta_plist_id::hid_t, raw_ext::Cstring, raw_plist_id::hid_t)::herr_t "Error in h5p_set_fapl_split (not annotated)"
 @bind h5p_set_fapl_splitter(fapl_id::hid_t, config_ptr::Ptr{H5FD_splitter_vfd_config_t})::herr_t "Error in h5p_set_fapl_splitter (not annotated)"
 @bind h5p_set_fapl_stdio(fapl_id::hid_t)::herr_t "Error in h5p_set_fapl_stdio (not annotated)"
 @bind h5p_set_fapl_windows(fapl_id::hid_t)::herr_t "Error in h5p_set_fapl_windows (not annotated)"
@@ -407,7 +407,7 @@
 @bind h5p_set_mcdt_search_cb(plist_id::hid_t, func::H5O_mcdt_search_cb_t, op_data::Ptr{Cvoid})::herr_t "Error in h5p_set_mcdt_search_cb (not annotated)"
 @bind h5p_set_mdc_config(plist_id::hid_t, config_ptr::Ptr{H5AC_cache_config_t})::herr_t "Error in h5p_set_mdc_config (not annotated)"
 @bind h5p_set_mdc_image_config(plist_id::hid_t, config_ptr::Ptr{H5AC_cache_image_config_t})::herr_t "Error in h5p_set_mdc_image_config (not annotated)"
-@bind h5p_set_mdc_log_options(plist_id::hid_t, is_enabled::hbool_t, location::Ptr{Cchar}, start_on_access::hbool_t)::herr_t "Error in h5p_set_mdc_log_options (not annotated)"
+@bind h5p_set_mdc_log_options(plist_id::hid_t, is_enabled::hbool_t, location::Cstring, start_on_access::hbool_t)::herr_t "Error in h5p_set_mdc_log_options (not annotated)"
 @bind h5p_set_meta_block_size(fapl_id::hid_t, size::hsize_t)::herr_t "Error in h5p_set_meta_block_size (not annotated)"
 @bind h5p_set_metadata_read_attempts(plist_id::hid_t, attempts::Cuint)::herr_t "Error in h5p_set_metadata_read_attempts (not annotated)"
 @bind h5p_set_multi_type(fapl_id::hid_t, type::H5FD_mem_t)::herr_t "Error in h5p_set_multi_type (not annotated)"
@@ -429,8 +429,8 @@
 @bind h5p_set_szip(plist_id::hid_t, options_mask::Cuint, pixels_per_block::Cuint)::herr_t "Error enabling szip filter"
 @bind h5p_set_type_conv_cb(dxpl_id::hid_t, op::H5T_conv_except_func_t, operate_data::Ptr{Cvoid})::herr_t "Error in h5p_set_type_conv_cb (not annotated)"
 @bind h5p_set_userblock(plist_id::hid_t, len::hsize_t)::herr_t "Error setting userblock"
-@bind h5p_set_virtual(dcpl_id::hid_t, vspace_id::hid_t, src_file_name::Ptr{UInt8}, src_dset_name::Ptr{UInt8}, src_space_id::hid_t)::herr_t "Error setting virtual"
-@bind h5p_set_virtual_prefix(dapl_id::hid_t, prefix::Ptr{Cchar})::herr_t "Error in h5p_set_virtual_prefix (not annotated)"
+@bind h5p_set_virtual(dcpl_id::hid_t, vspace_id::hid_t, src_file_name::Cstring, src_dset_name::Cstring, src_space_id::hid_t)::herr_t "Error setting virtual"
+@bind h5p_set_virtual_prefix(dapl_id::hid_t, prefix::Cstring)::herr_t "Error in h5p_set_virtual_prefix (not annotated)"
 @bind h5p_set_virtual_printf_gap(dapl_id::hid_t, gap_size::hsize_t)::herr_t "Error in h5p_set_virtual_printf_gap (not annotated)"
 @bind h5p_set_virtual_view(dapl_id::hid_t, view::H5D_vds_view_t)::herr_t "Error in h5p_set_virtual_view (not annotated)"
 @bind h5p_set_vlen_mem_manager(plist_id::hid_t, alloc_func::H5MM_allocate_t, alloc_info::Ptr{Cvoid}, free_func::H5MM_free_t, free_info::Ptr{Cvoid})::herr_t "Error in h5p_set_vlen_mem_manager (not annotated)"
@@ -438,31 +438,31 @@
 
 # others
 
-@bind h5p_add_merge_committed_dtype_path(plist_id::hid_t, path::Ptr{Cchar})::herr_t "Error in h5p_add_merge_committed_dtype_path (not annotated)"
+@bind h5p_add_merge_committed_dtype_path(plist_id::hid_t, path::Cstring)::herr_t "Error in h5p_add_merge_committed_dtype_path (not annotated)"
 @bind h5p_all_filters_avail(plist_id::hid_t)::htri_t "Error in h5p_all_filters_avail (not annotated)"
 @bind h5p_close(id::hid_t)::herr_t "Error closing property list"
 @bind h5p_close_class(plist_id::hid_t)::herr_t "Error in h5p_close_class (not annotated)"
 @bind h5p_copy(plist_id::hid_t)::hid_t "Error in h5p_copy (not annotated)"
-@bind h5p_copy_prop(dst_id::hid_t, src_id::hid_t, name::Ptr{Cchar})::herr_t "Error in h5p_copy_prop (not annotated)"
+@bind h5p_copy_prop(dst_id::hid_t, src_id::hid_t, name::Cstring)::herr_t "Error in h5p_copy_prop (not annotated)"
 @bind h5p_create(cls_id::hid_t)::hid_t "Error creating property list"
-@bind h5p_create_class(parent::hid_t, name::Ptr{Cchar}, create::H5P_cls_create_func_t, create_data::Ptr{Cvoid}, copy::H5P_cls_copy_func_t, copy_data::Ptr{Cvoid}, close::H5P_cls_close_func_t, close_data::Ptr{Cvoid})::hid_t "Error in h5p_create_class (not annotated)"
+@bind h5p_create_class(parent::hid_t, name::Cstring, create::H5P_cls_create_func_t, create_data::Ptr{Cvoid}, copy::H5P_cls_copy_func_t, copy_data::Ptr{Cvoid}, close::H5P_cls_close_func_t, close_data::Ptr{Cvoid})::hid_t "Error in h5p_create_class (not annotated)"
 @bind h5p_decode(buf::Ptr{Cvoid})::hid_t "Error in h5p_decode (not annotated)"
 @bind h5p_encode1(plist_id::hid_t, buf::Ptr{Cvoid}, nalloc::Ptr{Csize_t})::herr_t "Error in h5p_encode1 (not annotated)"
 @bind h5p_encode2(plist_id::hid_t, buf::Ptr{Cvoid}, nalloc::Ptr{Csize_t}, fapl_id::hid_t)::herr_t "Error in h5p_encode2 (not annotated)"
 @bind h5p_equal(id1::hid_t, id2::hid_t)::htri_t "Error in h5p_equal (not annotated)"
-@bind h5p_exist(plist_id::hid_t, name::Ptr{Cchar})::htri_t "Error in h5p_exist (not annotated)"
+@bind h5p_exist(plist_id::hid_t, name::Cstring)::htri_t "Error in h5p_exist (not annotated)"
 @bind h5p_fill_value_defined(plist::hid_t, status::Ptr{H5D_fill_value_t})::herr_t "Error in h5p_fill_value_defined (not annotated)"
 @bind h5p_free_merge_committed_dtype_paths(plist_id::hid_t)::herr_t "Error in h5p_free_merge_committed_dtype_paths (not annotated)"
-@bind h5p_insert1(plist_id::hid_t, name::Ptr{Cchar}, size::Csize_t, value::Ptr{Cvoid}, prp_set::H5P_prp_set_func_t, prp_get::H5P_prp_get_func_t, prp_delete::H5P_prp_delete_func_t, prp_copy::H5P_prp_copy_func_t, prp_close::H5P_prp_close_func_t)::herr_t "Error in h5p_insert1 (not annotated)"
-@bind h5p_insert2(plist_id::hid_t, name::Ptr{Cchar}, size::Csize_t, value::Ptr{Cvoid}, set::H5P_prp_set_func_t, get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, copy::H5P_prp_copy_func_t, compare::H5P_prp_compare_func_t, close::H5P_prp_close_func_t)::herr_t "Error in h5p_insert2 (not annotated)"
+@bind h5p_insert1(plist_id::hid_t, name::Cstring, size::Csize_t, value::Ptr{Cvoid}, prp_set::H5P_prp_set_func_t, prp_get::H5P_prp_get_func_t, prp_delete::H5P_prp_delete_func_t, prp_copy::H5P_prp_copy_func_t, prp_close::H5P_prp_close_func_t)::herr_t "Error in h5p_insert1 (not annotated)"
+@bind h5p_insert2(plist_id::hid_t, name::Cstring, size::Csize_t, value::Ptr{Cvoid}, set::H5P_prp_set_func_t, get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, copy::H5P_prp_copy_func_t, compare::H5P_prp_compare_func_t, close::H5P_prp_close_func_t)::herr_t "Error in h5p_insert2 (not annotated)"
 @bind h5p_isa_class(plist_id::hid_t, pclass_id::hid_t)::htri_t "Error in h5p_isa_class (not annotated)"
 @bind h5p_iterate(id::hid_t, idx::Ptr{Cint}, iter_func::H5P_iterate_t, iter_data::Ptr{Cvoid})::Cint "Error in h5p_iterate (not annotated)"
 @bind h5p_modify_filter(plist_id::hid_t, filter_id::H5Z_filter_t, flags::Cuint, cd_nelmts::Csize_t, cd_values::Ptr{Cuint})::herr_t "Error modifying filter"
-@bind h5p_register1(cls_id::hid_t, name::Ptr{Cchar}, size::Csize_t, def_value::Ptr{Cvoid}, prp_create::H5P_prp_create_func_t, prp_set::H5P_prp_set_func_t, prp_get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, prp_copy::H5P_prp_copy_func_t, prp_close::H5P_prp_close_func_t)::herr_t "Error in h5p_register1 (not annotated)"
-@bind h5p_register2(cls_id::hid_t, name::Ptr{Cchar}, size::Csize_t, def_value::Ptr{Cvoid}, create::H5P_prp_create_func_t, set::H5P_prp_set_func_t, get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, copy::H5P_prp_copy_func_t, compare::H5P_prp_compare_func_t, close::H5P_prp_close_func_t)::herr_t "Error in h5p_register2 (not annotated)"
-@bind h5p_remove(plist_id::hid_t, name::Ptr{Cchar})::herr_t "Error in h5p_remove (not annotated)"
+@bind h5p_register1(cls_id::hid_t, name::Cstring, size::Csize_t, def_value::Ptr{Cvoid}, prp_create::H5P_prp_create_func_t, prp_set::H5P_prp_set_func_t, prp_get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, prp_copy::H5P_prp_copy_func_t, prp_close::H5P_prp_close_func_t)::herr_t "Error in h5p_register1 (not annotated)"
+@bind h5p_register2(cls_id::hid_t, name::Cstring, size::Csize_t, def_value::Ptr{Cvoid}, create::H5P_prp_create_func_t, set::H5P_prp_set_func_t, get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, copy::H5P_prp_copy_func_t, compare::H5P_prp_compare_func_t, close::H5P_prp_close_func_t)::herr_t "Error in h5p_register2 (not annotated)"
+@bind h5p_remove(plist_id::hid_t, name::Cstring)::herr_t "Error in h5p_remove (not annotated)"
 @bind h5p_remove_filter(plist_id::hid_t, filter_id::H5Z_filter_t)::herr_t "Error removing filter"
-@bind h5p_unregister(pclass_id::hid_t, name::Ptr{Cchar})::herr_t "Error in h5p_unregister (not annotated)"
+@bind h5p_unregister(pclass_id::hid_t, name::Cstring)::herr_t "Error in h5p_unregister (not annotated)"
 
 ###
 ### Plugin Interface
@@ -470,10 +470,10 @@
 
 @bind h5pl_set_loading_state(plugin_control_mask::Cuint)::herr_t "Error setting plugin loading state"
 @bind h5pl_get_loading_state(plugin_control_mask::Ptr{Cuint})::herr_t "Error getting plugin loading state"
-@bind h5pl_append(search_path::Ptr{Cchar})::herr_t "Error appending plugin path"
-@bind h5pl_prepend(search_path::Ptr{Cchar})::herr_t "Error prepending plugin path"
-@bind h5pl_replace(search_path::Ptr{Cchar}, index::Cuint)::herr_t "Error replacing plugin path"
-@bind h5pl_insert(search_path::Ptr{Cchar}, index::Cuint)::herr_t "Error inserting plugin path"
+@bind h5pl_append(search_path::Cstring)::herr_t "Error appending plugin path"
+@bind h5pl_prepend(search_path::Cstring)::herr_t "Error prepending plugin path"
+@bind h5pl_replace(search_path::Cstring, index::Cuint)::herr_t "Error replacing plugin path"
+@bind h5pl_insert(search_path::Cstring, index::Cuint)::herr_t "Error inserting plugin path"
 @bind h5pl_remove(index::Cuint)::herr_t "Error removing plugin path"
 @bind h5pl_get(index::Cuint, path_buf::Ptr{Cchar}, buf_size::Csize_t)::Cssize_t "Error getting plugin path"
 @bind h5pl_size(num_paths::Ptr{Cuint})::herr_t "Error in getting number of plugins paths"
@@ -482,7 +482,7 @@
 ### Reference Interface
 ###
 
-@bind h5r_create(ref::Ptr{Cvoid}, loc_id::hid_t, pathname::Ptr{UInt8}, ref_type::Cint, space_id::hid_t)::herr_t string("Error creating reference to object ", h5i_get_name(loc_id), "/", pathname)
+@bind h5r_create(ref::Ptr{Cvoid}, loc_id::hid_t, pathname::Cstring, ref_type::Cint, space_id::hid_t)::herr_t string("Error creating reference to object ", h5i_get_name(loc_id), "/", pathname)
 @bind h5r_dereference2(obj_id::hid_t, oapl_id::hid_t, ref_type::Cint, ref::Ptr{Cvoid})::hid_t "Error dereferencing object"
 @bind h5r_get_obj_type2(loc_id::hid_t, ref_type::Cint, ref::Ptr{Cvoid}, obj_type::Ptr{Cint})::herr_t "Error getting object type"
 @bind h5r_get_region(loc_id::hid_t, ref_type::Cint, ref::Ptr{Cvoid})::hid_t "Error getting region from reference"
@@ -516,7 +516,7 @@
 @bind h5t_array_create2(basetype_id::hid_t, ndims::Cuint, sz::Ptr{hsize_t})::hid_t string("Error creating H5T_ARRAY of id ", basetype_id, " and size ", sz)
 @bind h5t_close(dtype_id::hid_t)::herr_t "Error closing datatype"
 @bind h5t_committed(dtype_id::hid_t)::htri_t "Error determining whether datatype is committed"
-@bind h5t_commit2(loc_id::hid_t, name::Ptr{UInt8}, dtype_id::hid_t, lcpl_id::hid_t, tcpl_id::hid_t, tapl_id::hid_t)::herr_t "Error committing type"
+@bind h5t_commit2(loc_id::hid_t, name::Cstring, dtype_id::hid_t, lcpl_id::hid_t, tcpl_id::hid_t, tapl_id::hid_t)::herr_t "Error committing type"
 # @bind h5t_commit_anon
 # @bind h5t_compiler_conv
 @bind h5t_copy(dtype_id::hid_t)::hid_t "Error copying datatype"
@@ -537,7 +537,7 @@
 @bind h5t_get_ebias(dtype_id::hid_t)::Csize_t "Error getting exponent bias"
 @bind h5t_get_fields(dtype_id::hid_t, spos::Ref{Csize_t}, epos::Ref{Csize_t}, esize::Ref{Csize_t}, mpos::Ref{Csize_t}, msize::Ref{Csize_t})::herr_t "Error getting datatype floating point bit positions"
 @bind h5t_get_member_class(dtype_id::hid_t, index::Cuint)::Cint string("Error getting class of compound datatype member #", index)
-@bind h5t_get_member_index(dtype_id::hid_t, membername::Ptr{UInt8})::Cint string("Error getting index of compound datatype member \"", membername, "\"")
+@bind h5t_get_member_index(dtype_id::hid_t, membername::Cstring)::Cint string("Error getting index of compound datatype member \"", membername, "\"")
 # @bind h5t_get_member_name(dtype_id::hid_t, index::Cuint)::Cstring string("Error getting name of compound datatype member #", index) # See below
 @bind h5t_get_member_offset(dtype_id::hid_t, index::Cuint)::Csize_t "Error getting offset of compound datatype #$(index)"
 @bind h5t_get_member_type(dtype_id::hid_t, index::Cuint)::hid_t string("Error getting type of compound datatype member #", index)
@@ -554,10 +554,10 @@
 @bind h5t_get_strpad(dtype_id::hid_t)::Cint "Error getting string padding"
 @bind h5t_get_super(dtype_id::hid_t)::hid_t "Error getting super type"
 # @bind h5t_get_tag(type_id::hid_t)::Cstring "Error getting datatype opaque tag" # See below
-@bind h5t_insert(dtype_id::hid_t, fieldname::Ptr{UInt8}, offset::Csize_t, field_id::hid_t)::herr_t string("Error adding field ", fieldname, " to compound datatype")
+@bind h5t_insert(dtype_id::hid_t, fieldname::Cstring, offset::Csize_t, field_id::hid_t)::herr_t string("Error adding field ", fieldname, " to compound datatype")
 @bind h5t_is_variable_str(type_id::hid_t)::htri_t "Error determining whether string is of variable length"
 @bind h5t_lock(type_id::hid_t)::herr_t "Error locking type"
-@bind h5t_open2(loc_id::hid_t, name::Ptr{UInt8}, tapl_id::hid_t)::hid_t string("Error opening type ", h5i_get_name(loc_id), "/", name)
+@bind h5t_open2(loc_id::hid_t, name::Cstring, tapl_id::hid_t)::hid_t string("Error opening type ", h5i_get_name(loc_id), "/", name)
 # @bind h5t_pack
 # @bind h5t_reclaim
 # @bind h5t_refresh
@@ -600,7 +600,7 @@
 @bind h5ds_is_attached(did::hid_t, dsid::hid_t, idx::Cuint)::htri_t "Unable to check if dimension is attached"
 @bind h5ds_is_scale(did::hid_t)::htri_t "Unable to check if dataset is scale"
 @bind h5ds_set_label(did::hid_t, idx::Cuint, label::Ref{UInt8})::herr_t "Unable to set label"
-@bind h5ds_set_scale(dsid::hid_t, dimname::Ptr{UInt8})::herr_t "Unable to set scale"
+@bind h5ds_set_scale(dsid::hid_t, dimname::Cstring)::herr_t "Unable to set scale"
 
 
 ###
@@ -612,14 +612,14 @@
 ###
 ### Table Interface
 ###
-@bind h5tb_append_records(loc_id::hid_t, dset_name::Ptr{UInt8}, nrecords::hsize_t, type_size::Csize_t, field_offset::Ptr{Csize_t}, field_sizes::Ptr{Csize_t}, data::Ptr{Cvoid})::herr_t "Error adding record to table"
-@bind h5tb_get_field_info(loc_id::hid_t, table_name::Ptr{UInt8}, field_names::Ptr{Ptr{UInt8}}, field_sizes::Ptr{Csize_t}, field_offsets::Ptr{Csize_t}, type_size::Ptr{Csize_t})::herr_t "Error getting field information"
-@bind h5tb_get_table_info(loc_id::hid_t, table_name::Ptr{UInt8}, nfields::Ptr{hsize_t}, nrecords::Ptr{hsize_t})::herr_t "Error getting table information"
+@bind h5tb_append_records(loc_id::hid_t, dset_name::Cstring, nrecords::hsize_t, type_size::Csize_t, field_offset::Ptr{Csize_t}, field_sizes::Ptr{Csize_t}, data::Ptr{Cvoid})::herr_t "Error adding record to table"
+@bind h5tb_get_field_info(loc_id::hid_t, table_name::Cstring, field_names::Ptr{Ptr{UInt8}}, field_sizes::Ptr{Csize_t}, field_offsets::Ptr{Csize_t}, type_size::Ptr{Csize_t})::herr_t "Error getting field information"
+@bind h5tb_get_table_info(loc_id::hid_t, table_name::Cstring, nfields::Ptr{hsize_t}, nrecords::Ptr{hsize_t})::herr_t "Error getting table information"
 # NOTE: The HDF5 docs incorrectly specify type_size::hsize_t where as it should be type_size::Csize_t
-@bind h5tb_make_table(table_title::Ptr{UInt8}, loc_id::hid_t, dset_name::Ptr{UInt8}, nfields::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_names::Ptr{Ptr{UInt8}}, field_offset::Ptr{Csize_t}, field_types::Ptr{hid_t}, chunk_size::hsize_t, fill_data::Ptr{Cvoid}, compress::Cint, data::Ptr{Cvoid})::herr_t "Error creating and writing dataset to table"
-@bind h5tb_read_records(loc_id::hid_t, table_name::Ptr{UInt8}, start::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_offsets::Ptr{Csize_t}, dst_sizes::Ptr{Csize_t}, data::Ptr{Cvoid})::herr_t "Error reading record from table"
-@bind h5tb_read_table(loc_id::hid_t, table_name::Ptr{UInt8}, dst_size::Csize_t, dst_offset::Ptr{Csize_t}, dst_sizes::Ptr{Csize_t}, dst_buf::Ptr{Cvoid})::herr_t "Error reading table"
-@bind h5tb_write_records(loc_id::hid_t, table_name::Ptr{UInt8}, start::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_offsets::Ptr{UInt8}, field_sizes::Ptr{UInt8}, data::Ptr{Cvoid})::herr_t "Error writing record to table"
+@bind h5tb_make_table(table_title::Cstring, loc_id::hid_t, dset_name::Cstring, nfields::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_names::Ptr{Cstring}, field_offset::Ptr{Csize_t}, field_types::Ptr{hid_t}, chunk_size::hsize_t, fill_data::Ptr{Cvoid}, compress::Cint, data::Ptr{Cvoid})::herr_t "Error creating and writing dataset to table"
+@bind h5tb_read_records(loc_id::hid_t, table_name::Cstring, start::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_offsets::Ptr{Csize_t}, dst_sizes::Ptr{Csize_t}, data::Ptr{Cvoid})::herr_t "Error reading record from table"
+@bind h5tb_read_table(loc_id::hid_t, table_name::Cstring, dst_size::Csize_t, dst_offset::Ptr{Csize_t}, dst_sizes::Ptr{Csize_t}, dst_buf::Ptr{Cvoid})::herr_t "Error reading table"
+@bind h5tb_write_records(loc_id::hid_t, table_name::Cstring, start::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_offsets::Ptr{Csize_t}, field_sizes::Ptr{Csize_t}, data::Ptr{Cvoid})::herr_t "Error writing record to table"
 
 ###
 ### Filter Interface

--- a/src/api/functions.jl
+++ b/src/api/functions.jl
@@ -156,14 +156,14 @@ function h5a_close(id)
 end
 
 """
-    h5a_create(loc_id::hid_t, attr_name::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t) -> hid_t
+    h5a_create(loc_id::hid_t, attr_name::Cstring, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Acreate2`](https://portal.hdfgroup.org/display/HDF5/H5A_CREATE2).
 """
 function h5a_create(loc_id, attr_name, type_id, space_id, acpl_id, aapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Acreate2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t, hid_t, hid_t, hid_t), loc_id, attr_name, type_id, space_id, acpl_id, aapl_id)
+            ccall((:H5Acreate2, libhdf5), hid_t, (hid_t, Cstring, hid_t, hid_t, hid_t, hid_t), loc_id, attr_name, type_id, space_id, acpl_id, aapl_id)
         finally
             unlock(liblock)
         end
@@ -172,14 +172,14 @@ function h5a_create(loc_id, attr_name, type_id, space_id, acpl_id, aapl_id)
 end
 
 """
-    h5a_create_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t, lapl_id::hid_t) -> hid_t
+    h5a_create_by_name(loc_id::hid_t, obj_name::Cstring, attr_name::Cstring, type_id::hid_t, space_id::hid_t, acpl_id::hid_t, aapl_id::hid_t, lapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Acreate_by_name`](https://portal.hdfgroup.org/display/HDF5/H5A_CREATE_BY_NAME).
 """
 function h5a_create_by_name(loc_id, obj_name, attr_name, type_id, space_id, acpl_id, aapl_id, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Acreate_by_name, libhdf5), hid_t, (hid_t, Ptr{UInt8}, Ptr{UInt8}, hid_t, hid_t, hid_t, hid_t, hid_t), loc_id, obj_name, attr_name, type_id, space_id, acpl_id, aapl_id, lapl_id)
+            ccall((:H5Acreate_by_name, libhdf5), hid_t, (hid_t, Cstring, Cstring, hid_t, hid_t, hid_t, hid_t, hid_t), loc_id, obj_name, attr_name, type_id, space_id, acpl_id, aapl_id, lapl_id)
         finally
             unlock(liblock)
         end
@@ -188,14 +188,14 @@ function h5a_create_by_name(loc_id, obj_name, attr_name, type_id, space_id, acpl
 end
 
 """
-    h5a_delete(loc_id::hid_t, attr_name::Ptr{UInt8})
+    h5a_delete(loc_id::hid_t, attr_name::Cstring)
 
 See `libhdf5` documentation for [`H5Adelete`](https://portal.hdfgroup.org/display/HDF5/H5A_DELETE).
 """
 function h5a_delete(loc_id, attr_name)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Adelete, libhdf5), herr_t, (hid_t, Ptr{UInt8}), loc_id, attr_name)
+            ccall((:H5Adelete, libhdf5), herr_t, (hid_t, Cstring), loc_id, attr_name)
         finally
             unlock(liblock)
         end
@@ -204,14 +204,14 @@ function h5a_delete(loc_id, attr_name)
 end
 
 """
-    h5a_delete_by_idx(loc_id::hid_t, obj_name::Ptr{UInt8}, idx_type::Cint, order::Cint, n::hsize_t, lapl_id::hid_t)
+    h5a_delete_by_idx(loc_id::hid_t, obj_name::Cstring, idx_type::Cint, order::Cint, n::hsize_t, lapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Adelete_by_idx`](https://portal.hdfgroup.org/display/HDF5/H5A_DELETE_BY_IDX).
 """
 function h5a_delete_by_idx(loc_id, obj_name, idx_type, order, n, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Adelete_by_idx, libhdf5), herr_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t, hid_t), loc_id, obj_name, idx_type, order, n, lapl_id)
+            ccall((:H5Adelete_by_idx, libhdf5), herr_t, (hid_t, Cstring, Cint, Cint, hsize_t, hid_t), loc_id, obj_name, idx_type, order, n, lapl_id)
         finally
             unlock(liblock)
         end
@@ -220,14 +220,14 @@ function h5a_delete_by_idx(loc_id, obj_name, idx_type, order, n, lapl_id)
 end
 
 """
-    h5a_delete_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, lapl_id::hid_t)
+    h5a_delete_by_name(loc_id::hid_t, obj_name::Cstring, attr_name::Cstring, lapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Adelete_by_name`](https://portal.hdfgroup.org/display/HDF5/H5A_DELETE_BY_NAME).
 """
 function h5a_delete_by_name(loc_id, obj_name, attr_name, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Adelete_by_name, libhdf5), herr_t, (hid_t, Ptr{UInt8}, Ptr{UInt8}, hid_t), loc_id, obj_name, attr_name, lapl_id)
+            ccall((:H5Adelete_by_name, libhdf5), herr_t, (hid_t, Cstring, Cstring, hid_t), loc_id, obj_name, attr_name, lapl_id)
         finally
             unlock(liblock)
         end
@@ -236,14 +236,14 @@ function h5a_delete_by_name(loc_id, obj_name, attr_name, lapl_id)
 end
 
 """
-    h5a_exists(obj_id::hid_t, attr_name::Ptr{UInt8}) -> Bool
+    h5a_exists(obj_id::hid_t, attr_name::Cstring) -> Bool
 
 See `libhdf5` documentation for [`H5Aexists`](https://portal.hdfgroup.org/display/HDF5/H5A_EXISTS).
 """
 function h5a_exists(obj_id, attr_name)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Aexists, libhdf5), htri_t, (hid_t, Ptr{UInt8}), obj_id, attr_name)
+            ccall((:H5Aexists, libhdf5), htri_t, (hid_t, Cstring), obj_id, attr_name)
         finally
             unlock(liblock)
         end
@@ -252,14 +252,14 @@ function h5a_exists(obj_id, attr_name)
 end
 
 """
-    h5a_exists_by_name(loc_id::hid_t, obj_name::Ptr{UInt8}, attr_name::Ptr{UInt8}, lapl_id::hid_t) -> Bool
+    h5a_exists_by_name(loc_id::hid_t, obj_name::Cstring, attr_name::Cstring, lapl_id::hid_t) -> Bool
 
 See `libhdf5` documentation for [`H5Aexists_by_name`](https://portal.hdfgroup.org/display/HDF5/H5A_EXISTS_BY_NAME).
 """
 function h5a_exists_by_name(loc_id, obj_name, attr_name, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Aexists_by_name, libhdf5), htri_t, (hid_t, Ptr{UInt8}, Ptr{UInt8}, hid_t), loc_id, obj_name, attr_name, lapl_id)
+            ccall((:H5Aexists_by_name, libhdf5), htri_t, (hid_t, Cstring, Cstring, hid_t), loc_id, obj_name, attr_name, lapl_id)
         finally
             unlock(liblock)
         end
@@ -364,14 +364,14 @@ function h5a_iterate(obj_id, idx_type, order, n, op, op_data)
 end
 
 """
-    h5a_open(obj_id::hid_t, attr_name::Ptr{UInt8}, aapl_id::hid_t) -> hid_t
+    h5a_open(obj_id::hid_t, attr_name::Cstring, aapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Aopen`](https://portal.hdfgroup.org/display/HDF5/H5A_OPEN).
 """
 function h5a_open(obj_id, attr_name, aapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Aopen, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t), obj_id, attr_name, aapl_id)
+            ccall((:H5Aopen, libhdf5), hid_t, (hid_t, Cstring, hid_t), obj_id, attr_name, aapl_id)
         finally
             unlock(liblock)
         end
@@ -380,14 +380,14 @@ function h5a_open(obj_id, attr_name, aapl_id)
 end
 
 """
-    h5a_open_by_idx(obj_id::hid_t, pathname::Ptr{UInt8}, idx_type::Cint, order::Cint, n::hsize_t, aapl_id::hid_t, lapl_id::hid_t) -> hid_t
+    h5a_open_by_idx(obj_id::hid_t, pathname::Cstring, idx_type::Cint, order::Cint, n::hsize_t, aapl_id::hid_t, lapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Aopen_by_idx`](https://portal.hdfgroup.org/display/HDF5/H5A_OPEN_BY_IDX).
 """
 function h5a_open_by_idx(obj_id, pathname, idx_type, order, n, aapl_id, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Aopen_by_idx, libhdf5), hid_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t, hid_t, hid_t), obj_id, pathname, idx_type, order, n, aapl_id, lapl_id)
+            ccall((:H5Aopen_by_idx, libhdf5), hid_t, (hid_t, Cstring, Cint, Cint, hsize_t, hid_t, hid_t), obj_id, pathname, idx_type, order, n, aapl_id, lapl_id)
         finally
             unlock(liblock)
         end
@@ -460,14 +460,14 @@ function h5d_close(dataset_id)
 end
 
 """
-    h5d_create(loc_id::hid_t, pathname::Ptr{UInt8}, dtype_id::hid_t, space_id::hid_t, lcpl_id::hid_t, dcpl_id::hid_t, dapl_id::hid_t) -> hid_t
+    h5d_create(loc_id::hid_t, pathname::Cstring, dtype_id::hid_t, space_id::hid_t, lcpl_id::hid_t, dcpl_id::hid_t, dapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Dcreate2`](https://portal.hdfgroup.org/display/HDF5/H5D_CREATE2).
 """
 function h5d_create(loc_id, pathname, dtype_id, space_id, lcpl_id, dcpl_id, dapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Dcreate2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t, hid_t, hid_t, hid_t, hid_t), loc_id, pathname, dtype_id, space_id, lcpl_id, dcpl_id, dapl_id)
+            ccall((:H5Dcreate2, libhdf5), hid_t, (hid_t, Cstring, hid_t, hid_t, hid_t, hid_t, hid_t), loc_id, pathname, dtype_id, space_id, lcpl_id, dcpl_id, dapl_id)
         finally
             unlock(liblock)
         end
@@ -752,14 +752,14 @@ function h5d_iterate(buf, type_id, space_id, operator, operator_data)
 end
 
 """
-    h5d_open(loc_id::hid_t, pathname::Ptr{UInt8}, dapl_id::hid_t) -> hid_t
+    h5d_open(loc_id::hid_t, pathname::Cstring, dapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Dopen2`](https://portal.hdfgroup.org/display/HDF5/H5D_OPEN2).
 """
 function h5d_open(loc_id, pathname, dapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Dopen2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t), loc_id, pathname, dapl_id)
+            ccall((:H5Dopen2, libhdf5), hid_t, (hid_t, Cstring, hid_t), loc_id, pathname, dapl_id)
         finally
             unlock(liblock)
         end
@@ -1056,14 +1056,14 @@ function h5f_close(file_id)
 end
 
 """
-    h5f_create(pathname::Ptr{UInt8}, flags::Cuint, fcpl_id::hid_t, fapl_id::hid_t) -> hid_t
+    h5f_create(pathname::Cstring, flags::Cuint, fcpl_id::hid_t, fapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Fcreate`](https://portal.hdfgroup.org/display/HDF5/H5F_CREATE).
 """
 function h5f_create(pathname, flags, fcpl_id, fapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Fcreate, libhdf5), hid_t, (Ptr{UInt8}, Cuint, hid_t, hid_t), pathname, flags, fcpl_id, fapl_id)
+            ccall((:H5Fcreate, libhdf5), hid_t, (Cstring, Cuint, hid_t, hid_t), pathname, flags, fcpl_id, fapl_id)
         finally
             unlock(liblock)
         end
@@ -1072,14 +1072,14 @@ function h5f_create(pathname, flags, fcpl_id, fapl_id)
 end
 
 """
-    h5f_delete(filename::Ptr{Cchar}, fapl_id::hid_t)
+    h5f_delete(filename::Cstring, fapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Fdelete`](https://portal.hdfgroup.org/display/HDF5/H5F_DELETE).
 """
 function h5f_delete(filename, fapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Fdelete, libhdf5), herr_t, (Ptr{Cchar}, hid_t), filename, fapl_id)
+            ccall((:H5Fdelete, libhdf5), herr_t, (Cstring, hid_t), filename, fapl_id)
         finally
             unlock(liblock)
         end
@@ -1504,14 +1504,14 @@ function h5f_increment_filesize(file_id, increment)
 end
 
 """
-    h5f_is_accessible(container_name::Ptr{Cchar}, fapl_id::hid_t) -> Bool
+    h5f_is_accessible(container_name::Cstring, fapl_id::hid_t) -> Bool
 
 See `libhdf5` documentation for [`H5Fis_accessible`](https://portal.hdfgroup.org/display/HDF5/H5F_IS_ACCESSIBLE).
 """
 function h5f_is_accessible(container_name, fapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Fis_accessible, libhdf5), htri_t, (Ptr{Cchar}, hid_t), container_name, fapl_id)
+            ccall((:H5Fis_accessible, libhdf5), htri_t, (Cstring, hid_t), container_name, fapl_id)
         finally
             unlock(liblock)
         end
@@ -1536,14 +1536,14 @@ function h5f_is_hdf5(pathname)
 end
 
 """
-    h5f_mount(loc::hid_t, name::Ptr{Cchar}, child::hid_t, plist::hid_t)
+    h5f_mount(loc::hid_t, name::Cstring, child::hid_t, plist::hid_t)
 
 See `libhdf5` documentation for [`H5Fmount`](https://portal.hdfgroup.org/display/HDF5/H5F_MOUNT).
 """
 function h5f_mount(loc, name, child, plist)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Fmount, libhdf5), herr_t, (hid_t, Ptr{Cchar}, hid_t, hid_t), loc, name, child, plist)
+            ccall((:H5Fmount, libhdf5), herr_t, (hid_t, Cstring, hid_t, hid_t), loc, name, child, plist)
         finally
             unlock(liblock)
         end
@@ -1728,14 +1728,14 @@ function h5f_stop_mdc_logging(file_id)
 end
 
 """
-    h5f_unmount(loc::hid_t, name::Ptr{Cchar})
+    h5f_unmount(loc::hid_t, name::Cstring)
 
 See `libhdf5` documentation for [`H5Funmount`](https://portal.hdfgroup.org/display/HDF5/H5F_UNMOUNT).
 """
 function h5f_unmount(loc, name)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Funmount, libhdf5), herr_t, (hid_t, Ptr{Cchar}), loc, name)
+            ccall((:H5Funmount, libhdf5), herr_t, (hid_t, Cstring), loc, name)
         finally
             unlock(liblock)
         end
@@ -1760,14 +1760,14 @@ function h5g_close(group_id)
 end
 
 """
-    h5g_create(loc_id::hid_t, pathname::Ptr{UInt8}, lcpl_id::hid_t, gcpl_id::hid_t, gapl_id::hid_t) -> hid_t
+    h5g_create(loc_id::hid_t, pathname::Cstring, lcpl_id::hid_t, gcpl_id::hid_t, gapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Gcreate2`](https://portal.hdfgroup.org/display/HDF5/H5G_CREATE2).
 """
 function h5g_create(loc_id, pathname, lcpl_id, gcpl_id, gapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Gcreate2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t, hid_t, hid_t), loc_id, pathname, lcpl_id, gcpl_id, gapl_id)
+            ccall((:H5Gcreate2, libhdf5), hid_t, (hid_t, Cstring, hid_t, hid_t, hid_t), loc_id, pathname, lcpl_id, gcpl_id, gapl_id)
         finally
             unlock(liblock)
         end
@@ -1840,14 +1840,14 @@ function h5g_get_objname_by_idx(loc_id, idx, pathname, size)
 end
 
 """
-    h5g_open(loc_id::hid_t, pathname::Ptr{UInt8}, gapl_id::hid_t) -> hid_t
+    h5g_open(loc_id::hid_t, pathname::Cstring, gapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Gopen2`](https://portal.hdfgroup.org/display/HDF5/H5G_OPEN2).
 """
 function h5g_open(loc_id, pathname, gapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Gopen2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t), loc_id, pathname, gapl_id)
+            ccall((:H5Gopen2, libhdf5), hid_t, (hid_t, Cstring, hid_t), loc_id, pathname, gapl_id)
         finally
             unlock(liblock)
         end
@@ -1968,14 +1968,14 @@ function h5i_is_valid(obj_id)
 end
 
 """
-    h5l_create_external(target_file_name::Ptr{UInt8}, target_obj_name::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)
+    h5l_create_external(target_file_name::Cstring, target_obj_name::Cstring, link_loc_id::hid_t, link_name::Cstring, lcpl_id::hid_t, lapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Lcreate_external`](https://portal.hdfgroup.org/display/HDF5/H5L_CREATE_EXTERNAL).
 """
 function h5l_create_external(target_file_name, target_obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Lcreate_external, libhdf5), herr_t, (Ptr{UInt8}, Ptr{UInt8}, hid_t, Ptr{UInt8}, hid_t, hid_t), target_file_name, target_obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
+            ccall((:H5Lcreate_external, libhdf5), herr_t, (Cstring, Cstring, hid_t, Cstring, hid_t, hid_t), target_file_name, target_obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
         finally
             unlock(liblock)
         end
@@ -1984,14 +1984,14 @@ function h5l_create_external(target_file_name, target_obj_name, link_loc_id, lin
 end
 
 """
-    h5l_create_hard(obj_loc_id::hid_t, obj_name::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)
+    h5l_create_hard(obj_loc_id::hid_t, obj_name::Cstring, link_loc_id::hid_t, link_name::Cstring, lcpl_id::hid_t, lapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Lcreate_hard`](https://portal.hdfgroup.org/display/HDF5/H5L_CREATE_HARD).
 """
 function h5l_create_hard(obj_loc_id, obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Lcreate_hard, libhdf5), herr_t, (hid_t, Ptr{UInt8}, hid_t, Ptr{UInt8}, hid_t, hid_t), obj_loc_id, obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
+            ccall((:H5Lcreate_hard, libhdf5), herr_t, (hid_t, Cstring, hid_t, Cstring, hid_t, hid_t), obj_loc_id, obj_name, link_loc_id, link_name, lcpl_id, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2000,14 +2000,14 @@ function h5l_create_hard(obj_loc_id, obj_name, link_loc_id, link_name, lcpl_id, 
 end
 
 """
-    h5l_create_soft(target_path::Ptr{UInt8}, link_loc_id::hid_t, link_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)
+    h5l_create_soft(target_path::Cstring, link_loc_id::hid_t, link_name::Cstring, lcpl_id::hid_t, lapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Lcreate_soft`](https://portal.hdfgroup.org/display/HDF5/H5L_CREATE_SOFT).
 """
 function h5l_create_soft(target_path, link_loc_id, link_name, lcpl_id, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Lcreate_soft, libhdf5), herr_t, (Ptr{UInt8}, hid_t, Ptr{UInt8}, hid_t, hid_t), target_path, link_loc_id, link_name, lcpl_id, lapl_id)
+            ccall((:H5Lcreate_soft, libhdf5), herr_t, (Cstring, hid_t, Cstring, hid_t, hid_t), target_path, link_loc_id, link_name, lcpl_id, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2016,14 +2016,14 @@ function h5l_create_soft(target_path, link_loc_id, link_name, lcpl_id, lapl_id)
 end
 
 """
-    h5l_delete(obj_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t)
+    h5l_delete(obj_id::hid_t, pathname::Cstring, lapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Ldelete`](https://portal.hdfgroup.org/display/HDF5/H5L_DELETE).
 """
 function h5l_delete(obj_id, pathname, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Ldelete, libhdf5), herr_t, (hid_t, Ptr{UInt8}, hid_t), obj_id, pathname, lapl_id)
+            ccall((:H5Ldelete, libhdf5), herr_t, (hid_t, Cstring, hid_t), obj_id, pathname, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2032,14 +2032,14 @@ function h5l_delete(obj_id, pathname, lapl_id)
 end
 
 """
-    h5l_move(src_obj_id::hid_t, src_name::Ptr{UInt8}, dest_obj_id::hid_t, dest_name::Ptr{UInt8}, lcpl_id::hid_t, lapl_id::hid_t)
+    h5l_move(src_obj_id::hid_t, src_name::Cstring, dest_obj_id::hid_t, dest_name::Cstring, lcpl_id::hid_t, lapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Lmove`](https://portal.hdfgroup.org/display/HDF5/H5L_MOVE).
 """
 function h5l_move(src_obj_id, src_name, dest_obj_id, dest_name, lcpl_id, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Lmove, libhdf5), herr_t, (hid_t, Ptr{UInt8}, hid_t, Ptr{UInt8}, hid_t, hid_t), src_obj_id, src_name, dest_obj_id, dest_name, lcpl_id, lapl_id)
+            ccall((:H5Lmove, libhdf5), herr_t, (hid_t, Cstring, hid_t, Cstring, hid_t, hid_t), src_obj_id, src_name, dest_obj_id, dest_name, lcpl_id, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2048,14 +2048,14 @@ function h5l_move(src_obj_id, src_name, dest_obj_id, dest_name, lcpl_id, lapl_id
 end
 
 """
-    h5l_exists(loc_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t) -> Bool
+    h5l_exists(loc_id::hid_t, pathname::Cstring, lapl_id::hid_t) -> Bool
 
 See `libhdf5` documentation for [`H5Lexists`](https://portal.hdfgroup.org/display/HDF5/H5L_EXISTS).
 """
 function h5l_exists(loc_id, pathname, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Lexists, libhdf5), htri_t, (hid_t, Ptr{UInt8}, hid_t), loc_id, pathname, lapl_id)
+            ccall((:H5Lexists, libhdf5), htri_t, (hid_t, Cstring, hid_t), loc_id, pathname, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2064,14 +2064,14 @@ function h5l_exists(loc_id, pathname, lapl_id)
 end
 
 """
-    h5l_get_info(link_loc_id::hid_t, link_name::Ptr{UInt8}, link_buf::Ptr{H5L_info_t}, lapl_id::hid_t)
+    h5l_get_info(link_loc_id::hid_t, link_name::Cstring, link_buf::Ptr{H5L_info_t}, lapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Lget_info`](https://portal.hdfgroup.org/display/HDF5/H5L_GET_INFO).
 """
 function h5l_get_info(link_loc_id, link_name, link_buf, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Lget_info, libhdf5), herr_t, (hid_t, Ptr{UInt8}, Ptr{H5L_info_t}, hid_t), link_loc_id, link_name, link_buf, lapl_id)
+            ccall((:H5Lget_info, libhdf5), herr_t, (hid_t, Cstring, Ptr{H5L_info_t}, hid_t), link_loc_id, link_name, link_buf, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2080,14 +2080,14 @@ function h5l_get_info(link_loc_id, link_name, link_buf, lapl_id)
 end
 
 """
-    h5l_get_name_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_field::Cint, order::Cint, n::hsize_t, name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t) -> Cssize_t
+    h5l_get_name_by_idx(loc_id::hid_t, group_name::Cstring, index_field::Cint, order::Cint, n::hsize_t, name::Ptr{UInt8}, size::Csize_t, lapl_id::hid_t) -> Cssize_t
 
 See `libhdf5` documentation for [`H5Lget_name_by_idx`](https://portal.hdfgroup.org/display/HDF5/H5L_GET_NAME_BY_IDX).
 """
 function h5l_get_name_by_idx(loc_id, group_name, index_field, order, n, name, size, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Lget_name_by_idx, libhdf5), Cssize_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t, Ptr{UInt8}, Csize_t, hid_t), loc_id, group_name, index_field, order, n, name, size, lapl_id)
+            ccall((:H5Lget_name_by_idx, libhdf5), Cssize_t, (hid_t, Cstring, Cint, Cint, hsize_t, Ptr{UInt8}, Csize_t, hid_t), loc_id, group_name, index_field, order, n, name, size, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2164,14 +2164,14 @@ function h5o_close(object_id)
 end
 
 """
-    h5o_copy(src_loc_id::hid_t, src_name::Ptr{UInt8}, dst_loc_id::hid_t, dst_name::Ptr{UInt8}, ocpypl_id::hid_t, lcpl_id::hid_t)
+    h5o_copy(src_loc_id::hid_t, src_name::Cstring, dst_loc_id::hid_t, dst_name::Cstring, ocpypl_id::hid_t, lcpl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Ocopy`](https://portal.hdfgroup.org/display/HDF5/H5O_COPY).
 """
 function h5o_copy(src_loc_id, src_name, dst_loc_id, dst_name, ocpypl_id, lcpl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Ocopy, libhdf5), herr_t, (hid_t, Ptr{UInt8}, hid_t, Ptr{UInt8}, hid_t, hid_t), src_loc_id, src_name, dst_loc_id, dst_name, ocpypl_id, lcpl_id)
+            ccall((:H5Ocopy, libhdf5), herr_t, (hid_t, Cstring, hid_t, Cstring, hid_t, hid_t), src_loc_id, src_name, dst_loc_id, dst_name, ocpypl_id, lcpl_id)
         finally
             unlock(liblock)
         end
@@ -2228,14 +2228,14 @@ function h5o_enable_mdc_flushes(object_id)
 end
 
 """
-    h5o_exists_by_name(loc_id::hid_t, name::Ptr{Cchar}, lapl_id::hid_t) -> Bool
+    h5o_exists_by_name(loc_id::hid_t, name::Cstring, lapl_id::hid_t) -> Bool
 
 See `libhdf5` documentation for [`H5Oexists_by_name`](https://portal.hdfgroup.org/display/HDF5/H5O_EXISTS_BY_NAME).
 """
 function h5o_exists_by_name(loc_id, name, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Oexists_by_name, libhdf5), htri_t, (hid_t, Ptr{Cchar}, hid_t), loc_id, name, lapl_id)
+            ccall((:H5Oexists_by_name, libhdf5), htri_t, (hid_t, Cstring, hid_t), loc_id, name, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2276,14 +2276,14 @@ function h5o_get_comment(obj_id, comment, bufsize)
 end
 
 """
-    h5o_get_comment_by_name(loc_id::hid_t, name::Ptr{Cchar}, comment::Ptr{Cchar}, bufsize::Csize_t, lapl_id::hid_t) -> Cssize_t
+    h5o_get_comment_by_name(loc_id::hid_t, name::Cstring, comment::Ptr{Cchar}, bufsize::Csize_t, lapl_id::hid_t) -> Cssize_t
 
 See `libhdf5` documentation for [`H5Oget_comment_by_name`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_COMMENT_BY_NAME).
 """
 function h5o_get_comment_by_name(loc_id, name, comment, bufsize, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Oget_comment_by_name, libhdf5), Cssize_t, (hid_t, Ptr{Cchar}, Ptr{Cchar}, Csize_t, hid_t), loc_id, name, comment, bufsize, lapl_id)
+            ccall((:H5Oget_comment_by_name, libhdf5), Cssize_t, (hid_t, Cstring, Ptr{Cchar}, Csize_t, hid_t), loc_id, name, comment, bufsize, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2347,14 +2347,14 @@ end
 
 @static if _libhdf5_build_ver < v"1.10.3"
     @doc """
-        h5o_get_info_by_idx(loc_id::hid_t, group_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info1_t}, lapl_id::hid_t)
+        h5o_get_info_by_idx(loc_id::hid_t, group_name::Cstring, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info1_t}, lapl_id::hid_t)
 
     See `libhdf5` documentation for [`H5Oget_info_by_idx1`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO_BY_IDX1).
     """
     function h5o_get_info_by_idx(loc_id, group_name, idx_type, order, n, oinfo, lapl_id)
         lock(liblock)
         var"#status#" = try
-                ccall((:H5Oget_info_by_idx1, libhdf5), herr_t, (hid_t, Ptr{Cchar}, H5_index_t, H5_iter_order_t, hsize_t, Ptr{H5O_info1_t}, hid_t), loc_id, group_name, idx_type, order, n, oinfo, lapl_id)
+                ccall((:H5Oget_info_by_idx1, libhdf5), herr_t, (hid_t, Cstring, H5_index_t, H5_iter_order_t, hsize_t, Ptr{H5O_info1_t}, hid_t), loc_id, group_name, idx_type, order, n, oinfo, lapl_id)
             finally
                 unlock(liblock)
             end
@@ -2365,14 +2365,14 @@ end
 
 @static if v"1.10.3" ≤ _libhdf5_build_ver < v"1.12.0"
     @doc """
-        h5o_get_info_by_idx(loc_id::hid_t, group_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info1_t}, fields::Cuint, lapl_id::hid_t)
+        h5o_get_info_by_idx(loc_id::hid_t, group_name::Cstring, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info1_t}, fields::Cuint, lapl_id::hid_t)
 
     See `libhdf5` documentation for [`H5Oget_info_by_idx2`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO_BY_IDX2).
     """
     function h5o_get_info_by_idx(loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id)
         lock(liblock)
         var"#status#" = try
-                ccall((:H5Oget_info_by_idx2, libhdf5), herr_t, (hid_t, Ptr{Cchar}, H5_index_t, H5_iter_order_t, hsize_t, Ptr{H5O_info1_t}, Cuint, hid_t), loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id)
+                ccall((:H5Oget_info_by_idx2, libhdf5), herr_t, (hid_t, Cstring, H5_index_t, H5_iter_order_t, hsize_t, Ptr{H5O_info1_t}, Cuint, hid_t), loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id)
             finally
                 unlock(liblock)
             end
@@ -2383,14 +2383,14 @@ end
 
 @static if v"1.12.0" ≤ _libhdf5_build_ver
     @doc """
-        h5o_get_info_by_idx(loc_id::hid_t, group_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info2_t}, fields::Cuint, lapl_id::hid_t)
+        h5o_get_info_by_idx(loc_id::hid_t, group_name::Cstring, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_info2_t}, fields::Cuint, lapl_id::hid_t)
 
     See `libhdf5` documentation for [`H5Oget_info_by_idx3`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO_BY_IDX3).
     """
     function h5o_get_info_by_idx(loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id)
         lock(liblock)
         var"#status#" = try
-                ccall((:H5Oget_info_by_idx3, libhdf5), herr_t, (hid_t, Ptr{Cchar}, H5_index_t, H5_iter_order_t, hsize_t, Ptr{H5O_info2_t}, Cuint, hid_t), loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id)
+                ccall((:H5Oget_info_by_idx3, libhdf5), herr_t, (hid_t, Cstring, H5_index_t, H5_iter_order_t, hsize_t, Ptr{H5O_info2_t}, Cuint, hid_t), loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id)
             finally
                 unlock(liblock)
             end
@@ -2401,14 +2401,14 @@ end
 
 @static if _libhdf5_build_ver < v"1.10.3"
     @doc """
-        h5o_get_info_by_name(loc_id::hid_t, name::Ptr{Cchar}, oinfo::Ptr{H5O_info1_t}, lapl_id::hid_t)
+        h5o_get_info_by_name(loc_id::hid_t, name::Cstring, oinfo::Ptr{H5O_info1_t}, lapl_id::hid_t)
 
     See `libhdf5` documentation for [`H5Oget_info_by_name1`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO_BY_NAME1).
     """
     function h5o_get_info_by_name(loc_id, name, oinfo, lapl_id)
         lock(liblock)
         var"#status#" = try
-                ccall((:H5Oget_info_by_name1, libhdf5), herr_t, (hid_t, Ptr{Cchar}, Ptr{H5O_info1_t}, hid_t), loc_id, name, oinfo, lapl_id)
+                ccall((:H5Oget_info_by_name1, libhdf5), herr_t, (hid_t, Cstring, Ptr{H5O_info1_t}, hid_t), loc_id, name, oinfo, lapl_id)
             finally
                 unlock(liblock)
             end
@@ -2419,14 +2419,14 @@ end
 
 @static if v"1.10.3" ≤ _libhdf5_build_ver < v"1.12.0"
     @doc """
-        h5o_get_info_by_name(loc_id::hid_t, name::Ptr{Cchar}, oinfo::Ptr{H5O_info1_t}, fields::Cuint, lapl_id::hid_t)
+        h5o_get_info_by_name(loc_id::hid_t, name::Cstring, oinfo::Ptr{H5O_info1_t}, fields::Cuint, lapl_id::hid_t)
 
     See `libhdf5` documentation for [`H5Oget_info_by_name2`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO_BY_NAME2).
     """
     function h5o_get_info_by_name(loc_id, name, oinfo, fields, lapl_id)
         lock(liblock)
         var"#status#" = try
-                ccall((:H5Oget_info_by_name2, libhdf5), herr_t, (hid_t, Ptr{Cchar}, Ptr{H5O_info1_t}, Cuint, hid_t), loc_id, name, oinfo, fields, lapl_id)
+                ccall((:H5Oget_info_by_name2, libhdf5), herr_t, (hid_t, Cstring, Ptr{H5O_info1_t}, Cuint, hid_t), loc_id, name, oinfo, fields, lapl_id)
             finally
                 unlock(liblock)
             end
@@ -2437,14 +2437,14 @@ end
 
 @static if v"1.12.0" ≤ _libhdf5_build_ver
     @doc """
-        h5o_get_info_by_name(loc_id::hid_t, name::Ptr{Cchar}, oinfo::Ptr{H5O_info2_t}, fields::Cuint, lapl_id::hid_t)
+        h5o_get_info_by_name(loc_id::hid_t, name::Cstring, oinfo::Ptr{H5O_info2_t}, fields::Cuint, lapl_id::hid_t)
 
     See `libhdf5` documentation for [`H5Oget_info_by_name3`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO_BY_NAME3).
     """
     function h5o_get_info_by_name(loc_id, name, oinfo, fields, lapl_id)
         lock(liblock)
         var"#status#" = try
-                ccall((:H5Oget_info_by_name3, libhdf5), herr_t, (hid_t, Ptr{Cchar}, Ptr{H5O_info2_t}, Cuint, hid_t), loc_id, name, oinfo, fields, lapl_id)
+                ccall((:H5Oget_info_by_name3, libhdf5), herr_t, (hid_t, Cstring, Ptr{H5O_info2_t}, Cuint, hid_t), loc_id, name, oinfo, fields, lapl_id)
             finally
                 unlock(liblock)
             end
@@ -2470,14 +2470,14 @@ function h5o_get_native_info(loc_id, oinfo, fields)
 end
 
 """
-    h5o_get_native_info_by_idx(loc_id::hid_t, group_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_native_info_t}, fields::Cuint, lapl_id::hid_t)
+    h5o_get_native_info_by_idx(loc_id::hid_t, group_name::Cstring, idx_type::H5_index_t, order::H5_iter_order_t, n::hsize_t, oinfo::Ptr{H5O_native_info_t}, fields::Cuint, lapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Oget_native_info_by_idx`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_NATIVE_INFO_BY_IDX).
 """
 function h5o_get_native_info_by_idx(loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Oget_native_info_by_idx, libhdf5), herr_t, (hid_t, Ptr{Cchar}, H5_index_t, H5_iter_order_t, hsize_t, Ptr{H5O_native_info_t}, Cuint, hid_t), loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id)
+            ccall((:H5Oget_native_info_by_idx, libhdf5), herr_t, (hid_t, Cstring, H5_index_t, H5_iter_order_t, hsize_t, Ptr{H5O_native_info_t}, Cuint, hid_t), loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2486,14 +2486,14 @@ function h5o_get_native_info_by_idx(loc_id, group_name, idx_type, order, n, oinf
 end
 
 """
-    h5o_get_native_info_by_name(loc_id::hid_t, name::Ptr{Cchar}, oinfo::Ptr{H5O_native_info_t}, fields::Cuint, lapl_id::hid_t)
+    h5o_get_native_info_by_name(loc_id::hid_t, name::Cstring, oinfo::Ptr{H5O_native_info_t}, fields::Cuint, lapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Oget_native_info_by_name`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_NATIVE_INFO_BY_NAME).
 """
 function h5o_get_native_info_by_name(loc_id, name, oinfo, fields, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Oget_native_info_by_name, libhdf5), herr_t, (hid_t, Ptr{Cchar}, Ptr{H5O_native_info_t}, Cuint, hid_t), loc_id, name, oinfo, fields, lapl_id)
+            ccall((:H5Oget_native_info_by_name, libhdf5), herr_t, (hid_t, Cstring, Ptr{H5O_native_info_t}, Cuint, hid_t), loc_id, name, oinfo, fields, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2518,14 +2518,14 @@ function h5o_incr_refcount(object_id)
 end
 
 """
-    h5o_link(obj_id::hid_t, new_loc_id::hid_t, new_name::Ptr{Cchar}, lcpl_id::hid_t, lapl_id::hid_t)
+    h5o_link(obj_id::hid_t, new_loc_id::hid_t, new_name::Cstring, lcpl_id::hid_t, lapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Olink`](https://portal.hdfgroup.org/display/HDF5/H5O_LINK).
 """
 function h5o_link(obj_id, new_loc_id, new_name, lcpl_id, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Olink, libhdf5), herr_t, (hid_t, hid_t, Ptr{Cchar}, hid_t, hid_t), obj_id, new_loc_id, new_name, lcpl_id, lapl_id)
+            ccall((:H5Olink, libhdf5), herr_t, (hid_t, hid_t, Cstring, hid_t, hid_t), obj_id, new_loc_id, new_name, lcpl_id, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2534,14 +2534,14 @@ function h5o_link(obj_id, new_loc_id, new_name, lcpl_id, lapl_id)
 end
 
 """
-    h5o_open(loc_id::hid_t, pathname::Ptr{UInt8}, lapl_id::hid_t) -> hid_t
+    h5o_open(loc_id::hid_t, pathname::Cstring, lapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Oopen`](https://portal.hdfgroup.org/display/HDF5/H5O_OPEN).
 """
 function h5o_open(loc_id, pathname, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Oopen, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t), loc_id, pathname, lapl_id)
+            ccall((:H5Oopen, libhdf5), hid_t, (hid_t, Cstring, hid_t), loc_id, pathname, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2566,14 +2566,14 @@ function h5o_open_by_addr(loc_id, addr)
 end
 
 """
-    h5o_open_by_idx(loc_id::hid_t, group_name::Ptr{UInt8}, index_type::Cint, order::Cint, n::hsize_t, lapl_id::hid_t) -> hid_t
+    h5o_open_by_idx(loc_id::hid_t, group_name::Cstring, index_type::Cint, order::Cint, n::hsize_t, lapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Oopen_by_idx`](https://portal.hdfgroup.org/display/HDF5/H5O_OPEN_BY_IDX).
 """
 function h5o_open_by_idx(loc_id, group_name, index_type, order, n, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Oopen_by_idx, libhdf5), hid_t, (hid_t, Ptr{UInt8}, Cint, Cint, hsize_t, hid_t), loc_id, group_name, index_type, order, n, lapl_id)
+            ccall((:H5Oopen_by_idx, libhdf5), hid_t, (hid_t, Cstring, Cint, Cint, hsize_t, hid_t), loc_id, group_name, index_type, order, n, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2598,14 +2598,14 @@ function h5o_refresh(oid)
 end
 
 """
-    h5o_set_comment(obj_id::hid_t, comment::Ptr{Cchar})
+    h5o_set_comment(obj_id::hid_t, comment::Cstring)
 
 See `libhdf5` documentation for [`H5Oset_comment`](https://portal.hdfgroup.org/display/HDF5/H5O_SET_COMMENT).
 """
 function h5o_set_comment(obj_id, comment)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Oset_comment, libhdf5), herr_t, (hid_t, Ptr{Cchar}), obj_id, comment)
+            ccall((:H5Oset_comment, libhdf5), herr_t, (hid_t, Cstring), obj_id, comment)
         finally
             unlock(liblock)
         end
@@ -2614,14 +2614,14 @@ function h5o_set_comment(obj_id, comment)
 end
 
 """
-    h5o_set_comment_by_name(loc_id::hid_t, name::Ptr{Cchar}, comment::Ptr{Cchar}, lapl_id::hid_t)
+    h5o_set_comment_by_name(loc_id::hid_t, name::Cstring, comment::Cstring, lapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Oset_comment_by_name`](https://portal.hdfgroup.org/display/HDF5/H5O_SET_COMMENT_BY_NAME).
 """
 function h5o_set_comment_by_name(loc_id, name, comment, lapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Oset_comment_by_name, libhdf5), herr_t, (hid_t, Ptr{Cchar}, Ptr{Cchar}, hid_t), loc_id, name, comment, lapl_id)
+            ccall((:H5Oset_comment_by_name, libhdf5), herr_t, (hid_t, Cstring, Cstring, hid_t), loc_id, name, comment, lapl_id)
         finally
             unlock(liblock)
         end
@@ -2646,14 +2646,14 @@ function h5o_token_cmp(loc_id, token1, token2, cmp_value)
 end
 
 """
-    h5o_token_from_str(loc_id::hid_t, token_str::Ptr{Cchar}, token::Ptr{H5O_token_t})
+    h5o_token_from_str(loc_id::hid_t, token_str::Cstring, token::Ptr{H5O_token_t})
 
 See `libhdf5` documentation for [`H5Otoken_from_str`](https://portal.hdfgroup.org/display/HDF5/H5O_TOKEN_FROM_STR).
 """
 function h5o_token_from_str(loc_id, token_str, token)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Otoken_from_str, libhdf5), herr_t, (hid_t, Ptr{Cchar}, Ptr{H5O_token_t}), loc_id, token_str, token)
+            ccall((:H5Otoken_from_str, libhdf5), herr_t, (hid_t, Cstring, Ptr{H5O_token_t}), loc_id, token_str, token)
         finally
             unlock(liblock)
         end
@@ -2715,14 +2715,14 @@ end
 
 @static if _libhdf5_build_ver < v"1.12.0"
     @doc """
-        h5o_visit_by_name(loc_id::hid_t, obj_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate1_t, op_data::Ptr{Cvoid}, lapl_id::hid_t)
+        h5o_visit_by_name(loc_id::hid_t, obj_name::Cstring, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate1_t, op_data::Ptr{Cvoid}, lapl_id::hid_t)
 
     See `libhdf5` documentation for [`H5Ovisit_by_name1`](https://portal.hdfgroup.org/display/HDF5/H5O_VISIT_BY_NAME1).
     """
     function h5o_visit_by_name(loc_id, obj_name, idx_type, order, op, op_data, lapl_id)
         lock(liblock)
         var"#status#" = try
-                ccall((:H5Ovisit_by_name1, libhdf5), herr_t, (hid_t, Ptr{Cchar}, H5_index_t, H5_iter_order_t, H5O_iterate1_t, Ptr{Cvoid}, hid_t), loc_id, obj_name, idx_type, order, op, op_data, lapl_id)
+                ccall((:H5Ovisit_by_name1, libhdf5), herr_t, (hid_t, Cstring, H5_index_t, H5_iter_order_t, H5O_iterate1_t, Ptr{Cvoid}, hid_t), loc_id, obj_name, idx_type, order, op, op_data, lapl_id)
             finally
                 unlock(liblock)
             end
@@ -2733,14 +2733,14 @@ end
 
 @static if v"1.12.0" ≤ _libhdf5_build_ver
     @doc """
-        h5o_visit_by_name(loc_id::hid_t, obj_name::Ptr{Cchar}, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate2_t, op_data::Ptr{Cvoid}, fields::Cuint, lapl_id::hid_t)
+        h5o_visit_by_name(loc_id::hid_t, obj_name::Cstring, idx_type::H5_index_t, order::H5_iter_order_t, op::H5O_iterate2_t, op_data::Ptr{Cvoid}, fields::Cuint, lapl_id::hid_t)
 
     See `libhdf5` documentation for [`H5Ovisit_by_name3`](https://portal.hdfgroup.org/display/HDF5/H5O_VISIT_BY_NAME3).
     """
     function h5o_visit_by_name(loc_id, obj_name, idx_type, order, op, op_data, fields, lapl_id)
         lock(liblock)
         var"#status#" = try
-                ccall((:H5Ovisit_by_name3, libhdf5), herr_t, (hid_t, Ptr{Cchar}, H5_index_t, H5_iter_order_t, H5O_iterate2_t, Ptr{Cvoid}, Cuint, hid_t), loc_id, obj_name, idx_type, order, op, op_data, fields, lapl_id)
+                ccall((:H5Ovisit_by_name3, libhdf5), herr_t, (hid_t, Cstring, H5_index_t, H5_iter_order_t, H5O_iterate2_t, Ptr{Cvoid}, Cuint, hid_t), loc_id, obj_name, idx_type, order, op, op_data, fields, lapl_id)
             finally
                 unlock(liblock)
             end
@@ -2750,14 +2750,14 @@ end
 end
 
 """
-    h5p_get(plist_id::hid_t, name::Ptr{Cchar}, value::Ptr{Cvoid})
+    h5p_get(plist_id::hid_t, name::Cstring, value::Ptr{Cvoid})
 
 See `libhdf5` documentation for [`H5Pget`](https://portal.hdfgroup.org/display/HDF5/H5P_GET).
 """
 function h5p_get(plist_id, name, value)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pget, libhdf5), herr_t, (hid_t, Ptr{Cchar}, Ptr{Cvoid}), plist_id, name, value)
+            ccall((:H5Pget, libhdf5), herr_t, (hid_t, Cstring, Ptr{Cvoid}), plist_id, name, value)
         finally
             unlock(liblock)
         end
@@ -4286,14 +4286,14 @@ function h5p_get_vol_info(plist_id, vol_info)
 end
 
 """
-    h5p_set(plist_id::hid_t, name::Ptr{Cchar}, value::Ptr{Cvoid})
+    h5p_set(plist_id::hid_t, name::Cstring, value::Ptr{Cvoid})
 
 See `libhdf5` documentation for [`H5Pset`](https://portal.hdfgroup.org/display/HDF5/H5P_SET).
 """
 function h5p_set(plist_id, name, value)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pset, libhdf5), herr_t, (hid_t, Ptr{Cchar}, Ptr{Cvoid}), plist_id, name, value)
+            ccall((:H5Pset, libhdf5), herr_t, (hid_t, Cstring, Ptr{Cvoid}), plist_id, name, value)
         finally
             unlock(liblock)
         end
@@ -4542,14 +4542,14 @@ function h5p_set_create_intermediate_group(plist_id, setting)
 end
 
 """
-    h5p_set_data_transform(plist_id::hid_t, expression::Ptr{Cchar})
+    h5p_set_data_transform(plist_id::hid_t, expression::Cstring)
 
 See `libhdf5` documentation for [`H5Pset_data_transform`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_DATA_TRANSFORM).
 """
 function h5p_set_data_transform(plist_id, expression)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pset_data_transform, libhdf5), herr_t, (hid_t, Ptr{Cchar}), plist_id, expression)
+            ccall((:H5Pset_data_transform, libhdf5), herr_t, (hid_t, Cstring), plist_id, expression)
         finally
             unlock(liblock)
         end
@@ -4638,14 +4638,14 @@ function h5p_set_edc_check(plist_id, check)
 end
 
 """
-    h5p_set_efile_prefix(plist_id::hid_t, prefix::Ptr{UInt8})
+    h5p_set_efile_prefix(plist_id::hid_t, prefix::Cstring)
 
 See `libhdf5` documentation for [`H5Pset_efile_prefix`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_EFILE_PREFIX).
 """
 function h5p_set_efile_prefix(plist_id, prefix)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pset_efile_prefix, libhdf5), herr_t, (hid_t, Ptr{UInt8}), plist_id, prefix)
+            ccall((:H5Pset_efile_prefix, libhdf5), herr_t, (hid_t, Cstring), plist_id, prefix)
         finally
             unlock(liblock)
         end
@@ -4718,14 +4718,14 @@ function h5p_set_elink_file_cache_size(plist_id, efc_size)
 end
 
 """
-    h5p_set_elink_prefix(plist_id::hid_t, prefix::Ptr{Cchar})
+    h5p_set_elink_prefix(plist_id::hid_t, prefix::Cstring)
 
 See `libhdf5` documentation for [`H5Pset_elink_prefix`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_ELINK_PREFIX).
 """
 function h5p_set_elink_prefix(plist_id, prefix)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pset_elink_prefix, libhdf5), herr_t, (hid_t, Ptr{Cchar}), plist_id, prefix)
+            ccall((:H5Pset_elink_prefix, libhdf5), herr_t, (hid_t, Cstring), plist_id, prefix)
         finally
             unlock(liblock)
         end
@@ -4766,14 +4766,14 @@ function h5p_set_evict_on_close(fapl_id, evict_on_close)
 end
 
 """
-    h5p_set_external(plist_id::hid_t, name::Ptr{Cchar}, offset::off_t, size::hsize_t)
+    h5p_set_external(plist_id::hid_t, name::Cstring, offset::off_t, size::hsize_t)
 
 See `libhdf5` documentation for [`H5Pset_external`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_EXTERNAL).
 """
 function h5p_set_external(plist_id, name, offset, size)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pset_external, libhdf5), herr_t, (hid_t, Ptr{Cchar}, off_t, hsize_t), plist_id, name, offset, size)
+            ccall((:H5Pset_external, libhdf5), herr_t, (hid_t, Cstring, off_t, hsize_t), plist_id, name, offset, size)
         finally
             unlock(liblock)
         end
@@ -4846,14 +4846,14 @@ function h5p_set_fapl_hdfs(fapl_id, fa)
 end
 
 """
-    h5p_set_fapl_log(fapl_id::hid_t, logfile::Ptr{Cchar}, flags::Culonglong, buf_size::Csize_t)
+    h5p_set_fapl_log(fapl_id::hid_t, logfile::Cstring, flags::Culonglong, buf_size::Csize_t)
 
 See `libhdf5` documentation for [`H5Pset_fapl_log`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_LOG).
 """
 function h5p_set_fapl_log(fapl_id, logfile, flags, buf_size)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pset_fapl_log, libhdf5), herr_t, (hid_t, Ptr{Cchar}, Culonglong, Csize_t), fapl_id, logfile, flags, buf_size)
+            ccall((:H5Pset_fapl_log, libhdf5), herr_t, (hid_t, Cstring, Culonglong, Csize_t), fapl_id, logfile, flags, buf_size)
         finally
             unlock(liblock)
         end
@@ -4862,14 +4862,14 @@ function h5p_set_fapl_log(fapl_id, logfile, flags, buf_size)
 end
 
 """
-    h5p_set_fapl_multi(fapl_id::hid_t, memb_map::Ptr{H5FD_mem_t}, memb_fapl::Ptr{hid_t}, memb_name::Ptr{Ptr{Cchar}}, memb_addr::Ptr{haddr_t}, relax::hbool_t)
+    h5p_set_fapl_multi(fapl_id::hid_t, memb_map::Ptr{H5FD_mem_t}, memb_fapl::Ptr{hid_t}, memb_name::Ptr{Cstring}, memb_addr::Ptr{haddr_t}, relax::hbool_t)
 
 See `libhdf5` documentation for [`H5Pset_fapl_multi`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_MULTI).
 """
 function h5p_set_fapl_multi(fapl_id, memb_map, memb_fapl, memb_name, memb_addr, relax)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pset_fapl_multi, libhdf5), herr_t, (hid_t, Ptr{H5FD_mem_t}, Ptr{hid_t}, Ptr{Ptr{Cchar}}, Ptr{haddr_t}, hbool_t), fapl_id, memb_map, memb_fapl, memb_name, memb_addr, relax)
+            ccall((:H5Pset_fapl_multi, libhdf5), herr_t, (hid_t, Ptr{H5FD_mem_t}, Ptr{hid_t}, Ptr{Cstring}, Ptr{haddr_t}, hbool_t), fapl_id, memb_map, memb_fapl, memb_name, memb_addr, relax)
         finally
             unlock(liblock)
         end
@@ -4910,14 +4910,14 @@ function h5p_set_fapl_ros3(fapl_id, fa)
 end
 
 """
-    h5p_set_fapl_split(fapl::hid_t, meta_ext::Ptr{Cchar}, meta_plist_id::hid_t, raw_ext::Ptr{Cchar}, raw_plist_id::hid_t)
+    h5p_set_fapl_split(fapl::hid_t, meta_ext::Cstring, meta_plist_id::hid_t, raw_ext::Cstring, raw_plist_id::hid_t)
 
 See `libhdf5` documentation for [`H5Pset_fapl_split`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_FAPL_SPLIT).
 """
 function h5p_set_fapl_split(fapl, meta_ext, meta_plist_id, raw_ext, raw_plist_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pset_fapl_split, libhdf5), herr_t, (hid_t, Ptr{Cchar}, hid_t, Ptr{Cchar}, hid_t), fapl, meta_ext, meta_plist_id, raw_ext, raw_plist_id)
+            ccall((:H5Pset_fapl_split, libhdf5), herr_t, (hid_t, Cstring, hid_t, Cstring, hid_t), fapl, meta_ext, meta_plist_id, raw_ext, raw_plist_id)
         finally
             unlock(liblock)
         end
@@ -5342,14 +5342,14 @@ function h5p_set_mdc_image_config(plist_id, config_ptr)
 end
 
 """
-    h5p_set_mdc_log_options(plist_id::hid_t, is_enabled::hbool_t, location::Ptr{Cchar}, start_on_access::hbool_t)
+    h5p_set_mdc_log_options(plist_id::hid_t, is_enabled::hbool_t, location::Cstring, start_on_access::hbool_t)
 
 See `libhdf5` documentation for [`H5Pset_mdc_log_options`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_MDC_LOG_OPTIONS).
 """
 function h5p_set_mdc_log_options(plist_id, is_enabled, location, start_on_access)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pset_mdc_log_options, libhdf5), herr_t, (hid_t, hbool_t, Ptr{Cchar}, hbool_t), plist_id, is_enabled, location, start_on_access)
+            ccall((:H5Pset_mdc_log_options, libhdf5), herr_t, (hid_t, hbool_t, Cstring, hbool_t), plist_id, is_enabled, location, start_on_access)
         finally
             unlock(liblock)
         end
@@ -5694,14 +5694,14 @@ function h5p_set_userblock(plist_id, len)
 end
 
 """
-    h5p_set_virtual(dcpl_id::hid_t, vspace_id::hid_t, src_file_name::Ptr{UInt8}, src_dset_name::Ptr{UInt8}, src_space_id::hid_t)
+    h5p_set_virtual(dcpl_id::hid_t, vspace_id::hid_t, src_file_name::Cstring, src_dset_name::Cstring, src_space_id::hid_t)
 
 See `libhdf5` documentation for [`H5Pset_virtual`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_VIRTUAL).
 """
 function h5p_set_virtual(dcpl_id, vspace_id, src_file_name, src_dset_name, src_space_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pset_virtual, libhdf5), herr_t, (hid_t, hid_t, Ptr{UInt8}, Ptr{UInt8}, hid_t), dcpl_id, vspace_id, src_file_name, src_dset_name, src_space_id)
+            ccall((:H5Pset_virtual, libhdf5), herr_t, (hid_t, hid_t, Cstring, Cstring, hid_t), dcpl_id, vspace_id, src_file_name, src_dset_name, src_space_id)
         finally
             unlock(liblock)
         end
@@ -5710,14 +5710,14 @@ function h5p_set_virtual(dcpl_id, vspace_id, src_file_name, src_dset_name, src_s
 end
 
 """
-    h5p_set_virtual_prefix(dapl_id::hid_t, prefix::Ptr{Cchar})
+    h5p_set_virtual_prefix(dapl_id::hid_t, prefix::Cstring)
 
 See `libhdf5` documentation for [`H5Pset_virtual_prefix`](https://portal.hdfgroup.org/display/HDF5/H5P_SET_VIRTUAL_PREFIX).
 """
 function h5p_set_virtual_prefix(dapl_id, prefix)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pset_virtual_prefix, libhdf5), herr_t, (hid_t, Ptr{Cchar}), dapl_id, prefix)
+            ccall((:H5Pset_virtual_prefix, libhdf5), herr_t, (hid_t, Cstring), dapl_id, prefix)
         finally
             unlock(liblock)
         end
@@ -5790,14 +5790,14 @@ function h5p_set_vol(plist_id, new_vol_id, new_vol_info)
 end
 
 """
-    h5p_add_merge_committed_dtype_path(plist_id::hid_t, path::Ptr{Cchar})
+    h5p_add_merge_committed_dtype_path(plist_id::hid_t, path::Cstring)
 
 See `libhdf5` documentation for [`H5Padd_merge_committed_dtype_path`](https://portal.hdfgroup.org/display/HDF5/H5P_ADD_MERGE_COMMITTED_DTYPE_PATH).
 """
 function h5p_add_merge_committed_dtype_path(plist_id, path)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Padd_merge_committed_dtype_path, libhdf5), herr_t, (hid_t, Ptr{Cchar}), plist_id, path)
+            ccall((:H5Padd_merge_committed_dtype_path, libhdf5), herr_t, (hid_t, Cstring), plist_id, path)
         finally
             unlock(liblock)
         end
@@ -5870,14 +5870,14 @@ function h5p_copy(plist_id)
 end
 
 """
-    h5p_copy_prop(dst_id::hid_t, src_id::hid_t, name::Ptr{Cchar})
+    h5p_copy_prop(dst_id::hid_t, src_id::hid_t, name::Cstring)
 
 See `libhdf5` documentation for [`H5Pcopy_prop`](https://portal.hdfgroup.org/display/HDF5/H5P_COPY_PROP).
 """
 function h5p_copy_prop(dst_id, src_id, name)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pcopy_prop, libhdf5), herr_t, (hid_t, hid_t, Ptr{Cchar}), dst_id, src_id, name)
+            ccall((:H5Pcopy_prop, libhdf5), herr_t, (hid_t, hid_t, Cstring), dst_id, src_id, name)
         finally
             unlock(liblock)
         end
@@ -5902,14 +5902,14 @@ function h5p_create(cls_id)
 end
 
 """
-    h5p_create_class(parent::hid_t, name::Ptr{Cchar}, create::H5P_cls_create_func_t, create_data::Ptr{Cvoid}, copy::H5P_cls_copy_func_t, copy_data::Ptr{Cvoid}, close::H5P_cls_close_func_t, close_data::Ptr{Cvoid}) -> hid_t
+    h5p_create_class(parent::hid_t, name::Cstring, create::H5P_cls_create_func_t, create_data::Ptr{Cvoid}, copy::H5P_cls_copy_func_t, copy_data::Ptr{Cvoid}, close::H5P_cls_close_func_t, close_data::Ptr{Cvoid}) -> hid_t
 
 See `libhdf5` documentation for [`H5Pcreate_class`](https://portal.hdfgroup.org/display/HDF5/H5P_CREATE_CLASS).
 """
 function h5p_create_class(parent, name, create, create_data, copy, copy_data, close, close_data)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pcreate_class, libhdf5), hid_t, (hid_t, Ptr{Cchar}, H5P_cls_create_func_t, Ptr{Cvoid}, H5P_cls_copy_func_t, Ptr{Cvoid}, H5P_cls_close_func_t, Ptr{Cvoid}), parent, name, create, create_data, copy, copy_data, close, close_data)
+            ccall((:H5Pcreate_class, libhdf5), hid_t, (hid_t, Cstring, H5P_cls_create_func_t, Ptr{Cvoid}, H5P_cls_copy_func_t, Ptr{Cvoid}, H5P_cls_close_func_t, Ptr{Cvoid}), parent, name, create, create_data, copy, copy_data, close, close_data)
         finally
             unlock(liblock)
         end
@@ -5982,14 +5982,14 @@ function h5p_equal(id1, id2)
 end
 
 """
-    h5p_exist(plist_id::hid_t, name::Ptr{Cchar}) -> Bool
+    h5p_exist(plist_id::hid_t, name::Cstring) -> Bool
 
 See `libhdf5` documentation for [`H5Pexist`](https://portal.hdfgroup.org/display/HDF5/H5P_EXIST).
 """
 function h5p_exist(plist_id, name)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pexist, libhdf5), htri_t, (hid_t, Ptr{Cchar}), plist_id, name)
+            ccall((:H5Pexist, libhdf5), htri_t, (hid_t, Cstring), plist_id, name)
         finally
             unlock(liblock)
         end
@@ -6030,14 +6030,14 @@ function h5p_free_merge_committed_dtype_paths(plist_id)
 end
 
 """
-    h5p_insert(plist_id::hid_t, name::Ptr{Cchar}, size::Csize_t, value::Ptr{Cvoid}, prp_set::H5P_prp_set_func_t, prp_get::H5P_prp_get_func_t, prp_delete::H5P_prp_delete_func_t, prp_copy::H5P_prp_copy_func_t, prp_close::H5P_prp_close_func_t)
+    h5p_insert(plist_id::hid_t, name::Cstring, size::Csize_t, value::Ptr{Cvoid}, prp_set::H5P_prp_set_func_t, prp_get::H5P_prp_get_func_t, prp_delete::H5P_prp_delete_func_t, prp_copy::H5P_prp_copy_func_t, prp_close::H5P_prp_close_func_t)
 
 See `libhdf5` documentation for [`H5Pinsert1`](https://portal.hdfgroup.org/display/HDF5/H5P_INSERT1).
 """
 function h5p_insert(plist_id, name, size, value, prp_set, prp_get, prp_delete, prp_copy, prp_close)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pinsert1, libhdf5), herr_t, (hid_t, Ptr{Cchar}, Csize_t, Ptr{Cvoid}, H5P_prp_set_func_t, H5P_prp_get_func_t, H5P_prp_delete_func_t, H5P_prp_copy_func_t, H5P_prp_close_func_t), plist_id, name, size, value, prp_set, prp_get, prp_delete, prp_copy, prp_close)
+            ccall((:H5Pinsert1, libhdf5), herr_t, (hid_t, Cstring, Csize_t, Ptr{Cvoid}, H5P_prp_set_func_t, H5P_prp_get_func_t, H5P_prp_delete_func_t, H5P_prp_copy_func_t, H5P_prp_close_func_t), plist_id, name, size, value, prp_set, prp_get, prp_delete, prp_copy, prp_close)
         finally
             unlock(liblock)
         end
@@ -6046,14 +6046,14 @@ function h5p_insert(plist_id, name, size, value, prp_set, prp_get, prp_delete, p
 end
 
 """
-    h5p_insert(plist_id::hid_t, name::Ptr{Cchar}, size::Csize_t, value::Ptr{Cvoid}, set::H5P_prp_set_func_t, get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, copy::H5P_prp_copy_func_t, compare::H5P_prp_compare_func_t, close::H5P_prp_close_func_t)
+    h5p_insert(plist_id::hid_t, name::Cstring, size::Csize_t, value::Ptr{Cvoid}, set::H5P_prp_set_func_t, get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, copy::H5P_prp_copy_func_t, compare::H5P_prp_compare_func_t, close::H5P_prp_close_func_t)
 
 See `libhdf5` documentation for [`H5Pinsert2`](https://portal.hdfgroup.org/display/HDF5/H5P_INSERT2).
 """
 function h5p_insert(plist_id, name, size, value, set, get, prp_del, copy, compare, close)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pinsert2, libhdf5), herr_t, (hid_t, Ptr{Cchar}, Csize_t, Ptr{Cvoid}, H5P_prp_set_func_t, H5P_prp_get_func_t, H5P_prp_delete_func_t, H5P_prp_copy_func_t, H5P_prp_compare_func_t, H5P_prp_close_func_t), plist_id, name, size, value, set, get, prp_del, copy, compare, close)
+            ccall((:H5Pinsert2, libhdf5), herr_t, (hid_t, Cstring, Csize_t, Ptr{Cvoid}, H5P_prp_set_func_t, H5P_prp_get_func_t, H5P_prp_delete_func_t, H5P_prp_copy_func_t, H5P_prp_compare_func_t, H5P_prp_close_func_t), plist_id, name, size, value, set, get, prp_del, copy, compare, close)
         finally
             unlock(liblock)
         end
@@ -6110,14 +6110,14 @@ function h5p_modify_filter(plist_id, filter_id, flags, cd_nelmts, cd_values)
 end
 
 """
-    h5p_register(cls_id::hid_t, name::Ptr{Cchar}, size::Csize_t, def_value::Ptr{Cvoid}, prp_create::H5P_prp_create_func_t, prp_set::H5P_prp_set_func_t, prp_get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, prp_copy::H5P_prp_copy_func_t, prp_close::H5P_prp_close_func_t)
+    h5p_register(cls_id::hid_t, name::Cstring, size::Csize_t, def_value::Ptr{Cvoid}, prp_create::H5P_prp_create_func_t, prp_set::H5P_prp_set_func_t, prp_get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, prp_copy::H5P_prp_copy_func_t, prp_close::H5P_prp_close_func_t)
 
 See `libhdf5` documentation for [`H5Pregister1`](https://portal.hdfgroup.org/display/HDF5/H5P_REGISTER1).
 """
 function h5p_register(cls_id, name, size, def_value, prp_create, prp_set, prp_get, prp_del, prp_copy, prp_close)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pregister1, libhdf5), herr_t, (hid_t, Ptr{Cchar}, Csize_t, Ptr{Cvoid}, H5P_prp_create_func_t, H5P_prp_set_func_t, H5P_prp_get_func_t, H5P_prp_delete_func_t, H5P_prp_copy_func_t, H5P_prp_close_func_t), cls_id, name, size, def_value, prp_create, prp_set, prp_get, prp_del, prp_copy, prp_close)
+            ccall((:H5Pregister1, libhdf5), herr_t, (hid_t, Cstring, Csize_t, Ptr{Cvoid}, H5P_prp_create_func_t, H5P_prp_set_func_t, H5P_prp_get_func_t, H5P_prp_delete_func_t, H5P_prp_copy_func_t, H5P_prp_close_func_t), cls_id, name, size, def_value, prp_create, prp_set, prp_get, prp_del, prp_copy, prp_close)
         finally
             unlock(liblock)
         end
@@ -6126,14 +6126,14 @@ function h5p_register(cls_id, name, size, def_value, prp_create, prp_set, prp_ge
 end
 
 """
-    h5p_register(cls_id::hid_t, name::Ptr{Cchar}, size::Csize_t, def_value::Ptr{Cvoid}, create::H5P_prp_create_func_t, set::H5P_prp_set_func_t, get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, copy::H5P_prp_copy_func_t, compare::H5P_prp_compare_func_t, close::H5P_prp_close_func_t)
+    h5p_register(cls_id::hid_t, name::Cstring, size::Csize_t, def_value::Ptr{Cvoid}, create::H5P_prp_create_func_t, set::H5P_prp_set_func_t, get::H5P_prp_get_func_t, prp_del::H5P_prp_delete_func_t, copy::H5P_prp_copy_func_t, compare::H5P_prp_compare_func_t, close::H5P_prp_close_func_t)
 
 See `libhdf5` documentation for [`H5Pregister2`](https://portal.hdfgroup.org/display/HDF5/H5P_REGISTER2).
 """
 function h5p_register(cls_id, name, size, def_value, create, set, get, prp_del, copy, compare, close)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Pregister2, libhdf5), herr_t, (hid_t, Ptr{Cchar}, Csize_t, Ptr{Cvoid}, H5P_prp_create_func_t, H5P_prp_set_func_t, H5P_prp_get_func_t, H5P_prp_delete_func_t, H5P_prp_copy_func_t, H5P_prp_compare_func_t, H5P_prp_close_func_t), cls_id, name, size, def_value, create, set, get, prp_del, copy, compare, close)
+            ccall((:H5Pregister2, libhdf5), herr_t, (hid_t, Cstring, Csize_t, Ptr{Cvoid}, H5P_prp_create_func_t, H5P_prp_set_func_t, H5P_prp_get_func_t, H5P_prp_delete_func_t, H5P_prp_copy_func_t, H5P_prp_compare_func_t, H5P_prp_close_func_t), cls_id, name, size, def_value, create, set, get, prp_del, copy, compare, close)
         finally
             unlock(liblock)
         end
@@ -6142,14 +6142,14 @@ function h5p_register(cls_id, name, size, def_value, create, set, get, prp_del, 
 end
 
 """
-    h5p_remove(plist_id::hid_t, name::Ptr{Cchar})
+    h5p_remove(plist_id::hid_t, name::Cstring)
 
 See `libhdf5` documentation for [`H5Premove`](https://portal.hdfgroup.org/display/HDF5/H5P_REMOVE).
 """
 function h5p_remove(plist_id, name)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Premove, libhdf5), herr_t, (hid_t, Ptr{Cchar}), plist_id, name)
+            ccall((:H5Premove, libhdf5), herr_t, (hid_t, Cstring), plist_id, name)
         finally
             unlock(liblock)
         end
@@ -6174,14 +6174,14 @@ function h5p_remove_filter(plist_id, filter_id)
 end
 
 """
-    h5p_unregister(pclass_id::hid_t, name::Ptr{Cchar})
+    h5p_unregister(pclass_id::hid_t, name::Cstring)
 
 See `libhdf5` documentation for [`H5Punregister`](https://portal.hdfgroup.org/display/HDF5/H5P_UNREGISTER).
 """
 function h5p_unregister(pclass_id, name)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Punregister, libhdf5), herr_t, (hid_t, Ptr{Cchar}), pclass_id, name)
+            ccall((:H5Punregister, libhdf5), herr_t, (hid_t, Cstring), pclass_id, name)
         finally
             unlock(liblock)
         end
@@ -6222,14 +6222,14 @@ function h5pl_get_loading_state(plugin_control_mask)
 end
 
 """
-    h5pl_append(search_path::Ptr{Cchar})
+    h5pl_append(search_path::Cstring)
 
 See `libhdf5` documentation for [`H5PLappend`](https://portal.hdfgroup.org/display/HDF5/H5PL_APPEND).
 """
 function h5pl_append(search_path)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5PLappend, libhdf5), herr_t, (Ptr{Cchar},), search_path)
+            ccall((:H5PLappend, libhdf5), herr_t, (Cstring,), search_path)
         finally
             unlock(liblock)
         end
@@ -6238,14 +6238,14 @@ function h5pl_append(search_path)
 end
 
 """
-    h5pl_prepend(search_path::Ptr{Cchar})
+    h5pl_prepend(search_path::Cstring)
 
 See `libhdf5` documentation for [`H5PLprepend`](https://portal.hdfgroup.org/display/HDF5/H5PL_PREPEND).
 """
 function h5pl_prepend(search_path)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5PLprepend, libhdf5), herr_t, (Ptr{Cchar},), search_path)
+            ccall((:H5PLprepend, libhdf5), herr_t, (Cstring,), search_path)
         finally
             unlock(liblock)
         end
@@ -6254,14 +6254,14 @@ function h5pl_prepend(search_path)
 end
 
 """
-    h5pl_replace(search_path::Ptr{Cchar}, index::Cuint)
+    h5pl_replace(search_path::Cstring, index::Cuint)
 
 See `libhdf5` documentation for [`H5PLreplace`](https://portal.hdfgroup.org/display/HDF5/H5PL_REPLACE).
 """
 function h5pl_replace(search_path, index)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5PLreplace, libhdf5), herr_t, (Ptr{Cchar}, Cuint), search_path, index)
+            ccall((:H5PLreplace, libhdf5), herr_t, (Cstring, Cuint), search_path, index)
         finally
             unlock(liblock)
         end
@@ -6270,14 +6270,14 @@ function h5pl_replace(search_path, index)
 end
 
 """
-    h5pl_insert(search_path::Ptr{Cchar}, index::Cuint)
+    h5pl_insert(search_path::Cstring, index::Cuint)
 
 See `libhdf5` documentation for [`H5PLinsert`](https://portal.hdfgroup.org/display/HDF5/H5PL_INSERT).
 """
 function h5pl_insert(search_path, index)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5PLinsert, libhdf5), herr_t, (Ptr{Cchar}, Cuint), search_path, index)
+            ccall((:H5PLinsert, libhdf5), herr_t, (Cstring, Cuint), search_path, index)
         finally
             unlock(liblock)
         end
@@ -6334,14 +6334,14 @@ function h5pl_size(num_paths)
 end
 
 """
-    h5r_create(ref::Ptr{Cvoid}, loc_id::hid_t, pathname::Ptr{UInt8}, ref_type::Cint, space_id::hid_t)
+    h5r_create(ref::Ptr{Cvoid}, loc_id::hid_t, pathname::Cstring, ref_type::Cint, space_id::hid_t)
 
 See `libhdf5` documentation for [`H5Rcreate`](https://portal.hdfgroup.org/display/HDF5/H5R_CREATE).
 """
 function h5r_create(ref, loc_id, pathname, ref_type, space_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Rcreate, libhdf5), herr_t, (Ptr{Cvoid}, hid_t, Ptr{UInt8}, Cint, hid_t), ref, loc_id, pathname, ref_type, space_id)
+            ccall((:H5Rcreate, libhdf5), herr_t, (Ptr{Cvoid}, hid_t, Cstring, Cint, hid_t), ref, loc_id, pathname, ref_type, space_id)
         finally
             unlock(liblock)
         end
@@ -6720,14 +6720,14 @@ function h5t_committed(dtype_id)
 end
 
 """
-    h5t_commit(loc_id::hid_t, name::Ptr{UInt8}, dtype_id::hid_t, lcpl_id::hid_t, tcpl_id::hid_t, tapl_id::hid_t)
+    h5t_commit(loc_id::hid_t, name::Cstring, dtype_id::hid_t, lcpl_id::hid_t, tcpl_id::hid_t, tapl_id::hid_t)
 
 See `libhdf5` documentation for [`H5Tcommit2`](https://portal.hdfgroup.org/display/HDF5/H5T_COMMIT2).
 """
 function h5t_commit(loc_id, name, dtype_id, lcpl_id, tcpl_id, tapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Tcommit2, libhdf5), herr_t, (hid_t, Ptr{UInt8}, hid_t, hid_t, hid_t, hid_t), loc_id, name, dtype_id, lcpl_id, tcpl_id, tapl_id)
+            ccall((:H5Tcommit2, libhdf5), herr_t, (hid_t, Cstring, hid_t, hid_t, hid_t, hid_t), loc_id, name, dtype_id, lcpl_id, tcpl_id, tapl_id)
         finally
             unlock(liblock)
         end
@@ -6912,14 +6912,14 @@ function h5t_get_member_class(dtype_id, index)
 end
 
 """
-    h5t_get_member_index(dtype_id::hid_t, membername::Ptr{UInt8}) -> Int
+    h5t_get_member_index(dtype_id::hid_t, membername::Cstring) -> Int
 
 See `libhdf5` documentation for [`H5Tget_member_index`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_MEMBER_INDEX).
 """
 function h5t_get_member_index(dtype_id, membername)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Tget_member_index, libhdf5), Cint, (hid_t, Ptr{UInt8}), dtype_id, membername)
+            ccall((:H5Tget_member_index, libhdf5), Cint, (hid_t, Cstring), dtype_id, membername)
         finally
             unlock(liblock)
         end
@@ -7104,14 +7104,14 @@ function h5t_get_super(dtype_id)
 end
 
 """
-    h5t_insert(dtype_id::hid_t, fieldname::Ptr{UInt8}, offset::Csize_t, field_id::hid_t)
+    h5t_insert(dtype_id::hid_t, fieldname::Cstring, offset::Csize_t, field_id::hid_t)
 
 See `libhdf5` documentation for [`H5Tinsert`](https://portal.hdfgroup.org/display/HDF5/H5T_INSERT).
 """
 function h5t_insert(dtype_id, fieldname, offset, field_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Tinsert, libhdf5), herr_t, (hid_t, Ptr{UInt8}, Csize_t, hid_t), dtype_id, fieldname, offset, field_id)
+            ccall((:H5Tinsert, libhdf5), herr_t, (hid_t, Cstring, Csize_t, hid_t), dtype_id, fieldname, offset, field_id)
         finally
             unlock(liblock)
         end
@@ -7152,14 +7152,14 @@ function h5t_lock(type_id)
 end
 
 """
-    h5t_open(loc_id::hid_t, name::Ptr{UInt8}, tapl_id::hid_t) -> hid_t
+    h5t_open(loc_id::hid_t, name::Cstring, tapl_id::hid_t) -> hid_t
 
 See `libhdf5` documentation for [`H5Topen2`](https://portal.hdfgroup.org/display/HDF5/H5T_OPEN2).
 """
 function h5t_open(loc_id, name, tapl_id)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5Topen2, libhdf5), hid_t, (hid_t, Ptr{UInt8}, hid_t), loc_id, name, tapl_id)
+            ccall((:H5Topen2, libhdf5), hid_t, (hid_t, Cstring, hid_t), loc_id, name, tapl_id)
         finally
             unlock(liblock)
         end
@@ -7488,14 +7488,14 @@ function h5ds_set_label(did, idx, label)
 end
 
 """
-    h5ds_set_scale(dsid::hid_t, dimname::Ptr{UInt8})
+    h5ds_set_scale(dsid::hid_t, dimname::Cstring)
 
 See `libhdf5` documentation for [`H5DSset_scale`](https://portal.hdfgroup.org/display/HDF5/H5DS_SET_SCALE).
 """
 function h5ds_set_scale(dsid, dimname)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5DSset_scale, libhdf5_hl), herr_t, (hid_t, Ptr{UInt8}), dsid, dimname)
+            ccall((:H5DSset_scale, libhdf5_hl), herr_t, (hid_t, Cstring), dsid, dimname)
         finally
             unlock(liblock)
         end
@@ -7520,14 +7520,14 @@ function h5lt_dtype_to_text(datatype, str, lang_type, len)
 end
 
 """
-    h5tb_append_records(loc_id::hid_t, dset_name::Ptr{UInt8}, nrecords::hsize_t, type_size::Csize_t, field_offset::Ptr{Csize_t}, field_sizes::Ptr{Csize_t}, data::Ptr{Cvoid})
+    h5tb_append_records(loc_id::hid_t, dset_name::Cstring, nrecords::hsize_t, type_size::Csize_t, field_offset::Ptr{Csize_t}, field_sizes::Ptr{Csize_t}, data::Ptr{Cvoid})
 
 See `libhdf5` documentation for [`H5TBappend_records`](https://portal.hdfgroup.org/display/HDF5/H5TB_APPEND_RECORDS).
 """
 function h5tb_append_records(loc_id, dset_name, nrecords, type_size, field_offset, field_sizes, data)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5TBappend_records, libhdf5_hl), herr_t, (hid_t, Ptr{UInt8}, hsize_t, Csize_t, Ptr{Csize_t}, Ptr{Csize_t}, Ptr{Cvoid}), loc_id, dset_name, nrecords, type_size, field_offset, field_sizes, data)
+            ccall((:H5TBappend_records, libhdf5_hl), herr_t, (hid_t, Cstring, hsize_t, Csize_t, Ptr{Csize_t}, Ptr{Csize_t}, Ptr{Cvoid}), loc_id, dset_name, nrecords, type_size, field_offset, field_sizes, data)
         finally
             unlock(liblock)
         end
@@ -7536,14 +7536,14 @@ function h5tb_append_records(loc_id, dset_name, nrecords, type_size, field_offse
 end
 
 """
-    h5tb_get_field_info(loc_id::hid_t, table_name::Ptr{UInt8}, field_names::Ptr{Ptr{UInt8}}, field_sizes::Ptr{Csize_t}, field_offsets::Ptr{Csize_t}, type_size::Ptr{Csize_t})
+    h5tb_get_field_info(loc_id::hid_t, table_name::Cstring, field_names::Ptr{Ptr{UInt8}}, field_sizes::Ptr{Csize_t}, field_offsets::Ptr{Csize_t}, type_size::Ptr{Csize_t})
 
 See `libhdf5` documentation for [`H5TBget_field_info`](https://portal.hdfgroup.org/display/HDF5/H5TB_GET_FIELD_INFO).
 """
 function h5tb_get_field_info(loc_id, table_name, field_names, field_sizes, field_offsets, type_size)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5TBget_field_info, libhdf5_hl), herr_t, (hid_t, Ptr{UInt8}, Ptr{Ptr{UInt8}}, Ptr{Csize_t}, Ptr{Csize_t}, Ptr{Csize_t}), loc_id, table_name, field_names, field_sizes, field_offsets, type_size)
+            ccall((:H5TBget_field_info, libhdf5_hl), herr_t, (hid_t, Cstring, Ptr{Ptr{UInt8}}, Ptr{Csize_t}, Ptr{Csize_t}, Ptr{Csize_t}), loc_id, table_name, field_names, field_sizes, field_offsets, type_size)
         finally
             unlock(liblock)
         end
@@ -7552,14 +7552,14 @@ function h5tb_get_field_info(loc_id, table_name, field_names, field_sizes, field
 end
 
 """
-    h5tb_get_table_info(loc_id::hid_t, table_name::Ptr{UInt8}, nfields::Ptr{hsize_t}, nrecords::Ptr{hsize_t})
+    h5tb_get_table_info(loc_id::hid_t, table_name::Cstring, nfields::Ptr{hsize_t}, nrecords::Ptr{hsize_t})
 
 See `libhdf5` documentation for [`H5TBget_table_info`](https://portal.hdfgroup.org/display/HDF5/H5TB_GET_TABLE_INFO).
 """
 function h5tb_get_table_info(loc_id, table_name, nfields, nrecords)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5TBget_table_info, libhdf5_hl), herr_t, (hid_t, Ptr{UInt8}, Ptr{hsize_t}, Ptr{hsize_t}), loc_id, table_name, nfields, nrecords)
+            ccall((:H5TBget_table_info, libhdf5_hl), herr_t, (hid_t, Cstring, Ptr{hsize_t}, Ptr{hsize_t}), loc_id, table_name, nfields, nrecords)
         finally
             unlock(liblock)
         end
@@ -7568,14 +7568,14 @@ function h5tb_get_table_info(loc_id, table_name, nfields, nrecords)
 end
 
 """
-    h5tb_make_table(table_title::Ptr{UInt8}, loc_id::hid_t, dset_name::Ptr{UInt8}, nfields::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_names::Ptr{Ptr{UInt8}}, field_offset::Ptr{Csize_t}, field_types::Ptr{hid_t}, chunk_size::hsize_t, fill_data::Ptr{Cvoid}, compress::Cint, data::Ptr{Cvoid})
+    h5tb_make_table(table_title::Cstring, loc_id::hid_t, dset_name::Cstring, nfields::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_names::Ptr{Cstring}, field_offset::Ptr{Csize_t}, field_types::Ptr{hid_t}, chunk_size::hsize_t, fill_data::Ptr{Cvoid}, compress::Cint, data::Ptr{Cvoid})
 
 See `libhdf5` documentation for [`H5TBmake_table`](https://portal.hdfgroup.org/display/HDF5/H5TB_MAKE_TABLE).
 """
 function h5tb_make_table(table_title, loc_id, dset_name, nfields, nrecords, type_size, field_names, field_offset, field_types, chunk_size, fill_data, compress, data)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5TBmake_table, libhdf5_hl), herr_t, (Ptr{UInt8}, hid_t, Ptr{UInt8}, hsize_t, hsize_t, Csize_t, Ptr{Ptr{UInt8}}, Ptr{Csize_t}, Ptr{hid_t}, hsize_t, Ptr{Cvoid}, Cint, Ptr{Cvoid}), table_title, loc_id, dset_name, nfields, nrecords, type_size, field_names, field_offset, field_types, chunk_size, fill_data, compress, data)
+            ccall((:H5TBmake_table, libhdf5_hl), herr_t, (Cstring, hid_t, Cstring, hsize_t, hsize_t, Csize_t, Ptr{Cstring}, Ptr{Csize_t}, Ptr{hid_t}, hsize_t, Ptr{Cvoid}, Cint, Ptr{Cvoid}), table_title, loc_id, dset_name, nfields, nrecords, type_size, field_names, field_offset, field_types, chunk_size, fill_data, compress, data)
         finally
             unlock(liblock)
         end
@@ -7584,14 +7584,14 @@ function h5tb_make_table(table_title, loc_id, dset_name, nfields, nrecords, type
 end
 
 """
-    h5tb_read_records(loc_id::hid_t, table_name::Ptr{UInt8}, start::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_offsets::Ptr{Csize_t}, dst_sizes::Ptr{Csize_t}, data::Ptr{Cvoid})
+    h5tb_read_records(loc_id::hid_t, table_name::Cstring, start::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_offsets::Ptr{Csize_t}, dst_sizes::Ptr{Csize_t}, data::Ptr{Cvoid})
 
 See `libhdf5` documentation for [`H5TBread_records`](https://portal.hdfgroup.org/display/HDF5/H5TB_READ_RECORDS).
 """
 function h5tb_read_records(loc_id, table_name, start, nrecords, type_size, field_offsets, dst_sizes, data)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5TBread_records, libhdf5_hl), herr_t, (hid_t, Ptr{UInt8}, hsize_t, hsize_t, Csize_t, Ptr{Csize_t}, Ptr{Csize_t}, Ptr{Cvoid}), loc_id, table_name, start, nrecords, type_size, field_offsets, dst_sizes, data)
+            ccall((:H5TBread_records, libhdf5_hl), herr_t, (hid_t, Cstring, hsize_t, hsize_t, Csize_t, Ptr{Csize_t}, Ptr{Csize_t}, Ptr{Cvoid}), loc_id, table_name, start, nrecords, type_size, field_offsets, dst_sizes, data)
         finally
             unlock(liblock)
         end
@@ -7600,14 +7600,14 @@ function h5tb_read_records(loc_id, table_name, start, nrecords, type_size, field
 end
 
 """
-    h5tb_read_table(loc_id::hid_t, table_name::Ptr{UInt8}, dst_size::Csize_t, dst_offset::Ptr{Csize_t}, dst_sizes::Ptr{Csize_t}, dst_buf::Ptr{Cvoid})
+    h5tb_read_table(loc_id::hid_t, table_name::Cstring, dst_size::Csize_t, dst_offset::Ptr{Csize_t}, dst_sizes::Ptr{Csize_t}, dst_buf::Ptr{Cvoid})
 
 See `libhdf5` documentation for [`H5TBread_table`](https://portal.hdfgroup.org/display/HDF5/H5TB_READ_TABLE).
 """
 function h5tb_read_table(loc_id, table_name, dst_size, dst_offset, dst_sizes, dst_buf)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5TBread_table, libhdf5_hl), herr_t, (hid_t, Ptr{UInt8}, Csize_t, Ptr{Csize_t}, Ptr{Csize_t}, Ptr{Cvoid}), loc_id, table_name, dst_size, dst_offset, dst_sizes, dst_buf)
+            ccall((:H5TBread_table, libhdf5_hl), herr_t, (hid_t, Cstring, Csize_t, Ptr{Csize_t}, Ptr{Csize_t}, Ptr{Cvoid}), loc_id, table_name, dst_size, dst_offset, dst_sizes, dst_buf)
         finally
             unlock(liblock)
         end
@@ -7616,14 +7616,14 @@ function h5tb_read_table(loc_id, table_name, dst_size, dst_offset, dst_sizes, ds
 end
 
 """
-    h5tb_write_records(loc_id::hid_t, table_name::Ptr{UInt8}, start::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_offsets::Ptr{UInt8}, field_sizes::Ptr{UInt8}, data::Ptr{Cvoid})
+    h5tb_write_records(loc_id::hid_t, table_name::Cstring, start::hsize_t, nrecords::hsize_t, type_size::Csize_t, field_offsets::Ptr{Csize_t}, field_sizes::Ptr{Csize_t}, data::Ptr{Cvoid})
 
 See `libhdf5` documentation for [`H5TBwrite_records`](https://portal.hdfgroup.org/display/HDF5/H5TB_WRITE_RECORDS).
 """
 function h5tb_write_records(loc_id, table_name, start, nrecords, type_size, field_offsets, field_sizes, data)
     lock(liblock)
     var"#status#" = try
-            ccall((:H5TBwrite_records, libhdf5_hl), herr_t, (hid_t, Ptr{UInt8}, hsize_t, hsize_t, Csize_t, Ptr{UInt8}, Ptr{UInt8}, Ptr{Cvoid}), loc_id, table_name, start, nrecords, type_size, field_offsets, field_sizes, data)
+            ccall((:H5TBwrite_records, libhdf5_hl), herr_t, (hid_t, Cstring, hsize_t, hsize_t, Csize_t, Ptr{Csize_t}, Ptr{Csize_t}, Ptr{Cvoid}), loc_id, table_name, start, nrecords, type_size, field_offsets, field_sizes, data)
         finally
             unlock(liblock)
         end

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -1525,6 +1525,11 @@ end
     @test_throws HDF5.API.H5Error create_group(hfile, "/group1/group1a")
     @test_throws HDF5.API.H5Error create_group(g1, "group1a")
 
+    # issue #1055
+    create_group(hfile, SubString("abcdef", 1, 3))
+    @test haskey(hfile, "abc")
+    @test !haskey(hfile, "abcdef")
+
     create_dataset(hfile, "dset1", 1)
     create_dataset(hfile, "/group1/dset1", 1)
 


### PR DESCRIPTION
Fixes #1055 

I've changed all the cases where we pass an input string, but kept unchanged the cases where it is for an output buffer.