### PR TITLE
Functional API with Strings / variable-size strings

### DIFF
--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -351,7 +351,9 @@ function Base.setindex!(dset::Dataset, X::Array{T}, I::IndexType...) where {T}
     return X
 end
 
-function Base.setindex!(dset::Dataset, X::Array{S}, I::IndexType...) where {S <: AbstractString}
+function Base.setindex!(
+    dset::Dataset, X::Array{S}, I::IndexType...
+) where {S<:AbstractString}
     !isconcretetype(S) && error("type $S is not concrete")
     U = get_jl_type(dset)
 
@@ -372,7 +374,6 @@ function Base.setindex!(dset::Dataset, X::Array{S}, I::IndexType...) where {S <:
         error("number of elements in src and dest arrays must be equal")
     end
 
-
     p = Ref{Cstring}(X)
     try
         API.h5d_write(dset, memtype, memspace, dspace, dset.xfer, p)
@@ -383,7 +384,6 @@ function Base.setindex!(dset::Dataset, X::Array{S}, I::IndexType...) where {S <:
     end
 
     return X
-
 end
 
 function Base.setindex!(dset::Dataset, x::T, I::IndexType...) where {T<:Number}

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -351,7 +351,48 @@ function Base.setindex!(dset::Dataset, X::Array{T}, I::IndexType...) where {T}
     return X
 end
 
+function Base.setindex!(dset::Dataset, X::Array{S}, I::IndexType...) where {S <: AbstractString}
+    !isconcretetype(S) && error("type $S is not concrete")
+    U = get_jl_type(dset)
+
+    filetype = datatype(dset)
+    memtype = _memtype(filetype, eltype(X))
+    close(filetype)
+
+    dspace = dataspace(dset)
+    stype = API.h5s_get_simple_extent_type(dspace)
+    stype == API.H5S_NULL && error("attempting to write to null dataspace")
+
+    indices = Base.to_indices(dset, I)
+    dspace = hyperslab(dspace, indices...)
+
+    memspace = dataspace(X)
+
+    if API.h5s_get_select_npoints(dspace) != API.h5s_get_select_npoints(memspace)
+        error("number of elements in src and dest arrays must be equal")
+    end
+
+
+    p = Ref{Cstring}(X)
+    try
+        API.h5d_write(dset, memtype, memspace, dspace, dset.xfer, p)
+    finally
+        close(memtype)
+        close(memspace)
+        close(dspace)
+    end
+
+    return X
+
+end
+
 function Base.setindex!(dset::Dataset, x::T, I::IndexType...) where {T<:Number}
+    indices = Base.to_indices(dset, I)
+    X = fill(x, map(length, indices))
+    Base.setindex!(dset, X, indices...)
+end
+
+function Base.setindex!(dset::Dataset, x::T, I::IndexType...) where {T<:AbstractString}
     indices = Base.to_indices(dset, I)
     X = fill(x, map(length, indices))
     Base.setindex!(dset, X, indices...)

--- a/src/readwrite.jl
+++ b/src/readwrite.jl
@@ -300,7 +300,7 @@ if the size matches.
     return memtype
 end
 
-@inline function _memtype(filetype::Datatype, ::Type{S}) where S <: AbstractString
+@inline function _memtype(filetype::Datatype, ::Type{S}) where {S<:AbstractString}
     return datatype(S)
 end
 

--- a/src/readwrite.jl
+++ b/src/readwrite.jl
@@ -300,6 +300,10 @@ if the size matches.
     return memtype
 end
 
+@inline function _memtype(filetype::Datatype, ::Type{S}) where S <: AbstractString
+    return datatype(S)
+end
+
 #=
     _size_of_buffer(obj::DatasetOrAttribute, [I::Tuple, dspace::Dataspace])
 

--- a/src/typeconversions.jl
+++ b/src/typeconversions.jl
@@ -214,7 +214,7 @@ function datatype(str::AbstractString)
     API.h5t_set_cset(type_id, cset(typeof(str)))
     Datatype(type_id)
 end
-function datatype(::Type{S}) where S <: AbstractString
+function datatype(::Type{S}) where {S<:AbstractString}
     type_id = API.h5t_copy(hdf5_type_id(S))
     API.h5t_set_size(type_id, API.H5T_VARIABLE)
     API.h5t_set_cset(type_id, cset(S))

--- a/src/typeconversions.jl
+++ b/src/typeconversions.jl
@@ -214,6 +214,12 @@ function datatype(str::AbstractString)
     API.h5t_set_cset(type_id, cset(typeof(str)))
     Datatype(type_id)
 end
+function datatype(::Type{S}) where S <: AbstractString
+    type_id = API.h5t_copy(hdf5_type_id(S))
+    API.h5t_set_size(type_id, API.H5T_VARIABLE)
+    API.h5t_set_cset(type_id, cset(S))
+    Datatype(type_id)
+end
 function datatype(::Array{S}) where {S<:AbstractString}
     type_id = API.h5t_copy(hdf5_type_id(S))
     API.h5t_set_size(type_id, API.H5T_VARIABLE)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,8 @@ end
 @testset "HDF5.jl" begin
     @debug "plain"
     include("plain.jl")
+    @debug "strings"
+    include("strings.jl")
     @debug "api"
     include("api.jl")
     @debug "compound"

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -38,7 +38,7 @@ using HDF5
         ds = write_dataset(f, "string", GenericString("Hi"))
     end
     h5open(fn) do f
-        @test f["string"][]  == "Hi"
+        @test f["string"][] == "Hi"
     end
     rm(fn)
 end

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -1,0 +1,44 @@
+using Test
+using HDF5
+
+@testset "Strings" begin
+    # Check creation of variable length string by passing String
+    fn = tempname()
+    h5open(fn, "w") do f
+        ds = create_dataset(f, "strings", String, (4,))
+        ds[1] = "Hello"
+        ds[2] = "Hi"
+        ds[3] = "Bonjour"
+        ds[4] = GenericString("Hola")
+    end
+    h5open(fn, "r") do f
+        ds = f["strings"]
+        @test ds[1] == "Hello"
+        @test ds[2] == "Hi"
+        @test ds[3] == "Bonjour"
+        @test ds[4] == "Hola"
+    end
+    rm(fn)
+
+    # Check multiple assignment
+    h5open(fn, "w") do f
+        ds = create_dataset(f, "strings2", String, (3,))
+        ds[:] = "Guten tag"
+    end
+    h5open(fn, "r") do f
+        ds = f["strings2"]
+        @test ds[1] == "Guten tag"
+        @test ds[2] == "Guten tag"
+        @test ds[3] == "Guten tag"
+    end
+    rm(fn)
+
+    # Check assignment to a scalar dataset
+    h5open(fn, "w") do f
+        ds = write_dataset(f, "string", GenericString("Hi"))
+    end
+    h5open(fn) do f
+        @test f["string"][]  == "Hi"
+    end
+    rm(fn)
+end


### PR DESCRIPTION
This is a response to https://discourse.julialang.org/t/hdf5-jl-variable-length-string/98808 adding support for just passing `String` as a type to `create_dataset`.

This allow allows `Base.setindex!` with Strings.

Traditionally, we omitted this because variable length strings are probably not a great idea to store in HDF5. Preferably, one would use fixed-length strings.

Todo:
- [x] : Add basic tests
- [x] : Test with other `AbstractString`
- [ ] : Consider implications for use with [InlineStrings.jl](https://github.com/JuliaStrings/InlineStrings.jl)
- [ ] : Consider implications for use with [StaticStrings.jl](https://github.com/mkitti/StaticStrings.jl)