### PR TITLE
Fixes create_dataset for compound types

### DIFF
--- a/src/typeconversions.jl
+++ b/src/typeconversions.jl
@@ -64,7 +64,7 @@ end
 
 # These will use finalizers. Close them eagerly to avoid issues.
 datatype(::T) where {T} = Datatype(hdf5_type_id(T), true)
-datatype(::Type{T}) where T = Datatype(hdf5_type_id(T), isstructtype(T))
+datatype(::Type{T}) where {T} = Datatype(hdf5_type_id(T), isstructtype(T))
 datatype(x::AbstractArray{T}) where {T} = Datatype(hdf5_type_id(T), true)
 
 hdf5_type_id(::Type{T}) where {T} = hdf5_type_id(T, Val(isstructtype(T)))

--- a/src/typeconversions.jl
+++ b/src/typeconversions.jl
@@ -64,6 +64,7 @@ end
 
 # These will use finalizers. Close them eagerly to avoid issues.
 datatype(::T) where {T} = Datatype(hdf5_type_id(T), true)
+datatype(::Type{T}) where T = Datatype(hdf5_type_id(T), isstructtype(T))
 datatype(x::AbstractArray{T}) where {T} = Datatype(hdf5_type_id(T), true)
 
 hdf5_type_id(::Type{T}) where {T} = hdf5_type_id(T, Val(isstructtype(T)))


### PR DESCRIPTION
A small fix of `create_dataset` which choked when passing your own `structs`.

Closes #1068