### PR TITLE
Fix _typed_load fast path for Julia 1.10 (currently nightly)

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -8,3 +8,4 @@ align_struct_field = true
 align_conditional = true
 align_assignment = true
 align_pair_arrow = true
+ignore = [".git"]

--- a/src/typeconversions.jl
+++ b/src/typeconversions.jl
@@ -351,7 +351,7 @@ function _typed_load(::Type{T}, buf::AbstractVector{UInt8}) where {T}
     return @inbounds reinterpret(T, buf)[1]
 end
 # fast-path for common concrete types with simple layout (which should be nearly all cases)
-@static if VERSION < v"1.10"
+@static if VERSION ≤ v"1.10.0-DEV.1394" # Maybe a few dev versions earlier
     function _typed_load(
         ::Type{T}, buf::V
     ) where {T,V<:Union{Vector{UInt8},Base.FastContiguousSubArray{UInt8,1}}}

--- a/src/typeconversions.jl
+++ b/src/typeconversions.jl
@@ -351,7 +351,7 @@ function _typed_load(::Type{T}, buf::AbstractVector{UInt8}) where {T}
     return @inbounds reinterpret(T, buf)[1]
 end
 # fast-path for common concrete types with simple layout (which should be nearly all cases)
-@static if VERSION ≤ v"1.10.0-DEV.1394" # Maybe a few dev versions earlier
+@static if VERSION ≤ v"1.10.0-DEV.1390" # Maybe a few dev versions earlier
     function _typed_load(
         ::Type{T}, buf::V
     ) where {T,V<:Union{Vector{UInt8},Base.FastContiguousSubArray{UInt8,1}}}

--- a/src/typeconversions.jl
+++ b/src/typeconversions.jl
@@ -351,18 +351,36 @@ function _typed_load(::Type{T}, buf::AbstractVector{UInt8}) where {T}
     return @inbounds reinterpret(T, buf)[1]
 end
 # fast-path for common concrete types with simple layout (which should be nearly all cases)
-function _typed_load(
-    ::Type{T}, buf::V
-) where {T,V<:Union{Vector{UInt8},Base.FastContiguousSubArray{UInt8,1}}}
-    dest = Ref{T}()
-    GC.@preserve dest buf Base._memcpy!(
-        unsafe_convert(Ptr{Cvoid}, dest), pointer(buf), sizeof(T)
-    )
-    return dest[]
-    # TODO: The above can maybe be replaced with
-    #   return GC.@preserve buf unsafe_load(convert(Ptr{t}, pointer(buf)))
-    # dependent on data elements being properly aligned for all datatypes, on all
-    # platforms.
+@static if VERSION < v"1.10"
+    function _typed_load(
+        ::Type{T}, buf::V
+    ) where {T,V<:Union{Vector{UInt8},Base.FastContiguousSubArray{UInt8,1}}}
+        dest = Ref{T}()
+        GC.@preserve dest buf Base._memcpy!(
+            unsafe_convert(Ptr{Cvoid}, dest), pointer(buf), sizeof(T)
+        )
+        return dest[]
+        # TODO: The above can maybe be replaced with
+        #   return GC.@preserve buf unsafe_load(convert(Ptr{t}, pointer(buf)))
+        # dependent on data elements being properly aligned for all datatypes, on all
+        # platforms.
+    end
+else
+    # TODO reimplement fast path _typed_load for Julia 1.10, consider refactor
+    function _typed_load(
+        ::Type{T}, buf::V
+    ) where {T,V<:Union{Vector{UInt8},Base.FastContiguousSubArray{UInt8,1}}}
+        dest = Ref{T}()
+        GC.@preserve dest buf Libc.memcpy(
+            unsafe_convert(Ptr{Cvoid}, dest), pointer(buf), sizeof(T)
+        )
+        return dest[]
+        # TODO: The above can maybe be replaced with
+        #   return GC.@preserve buf unsafe_load(convert(Ptr{t}, pointer(buf)))
+        # dependent on data elements being properly aligned for all datatypes, on all
+        # platforms.
+    end
+
 end
 
 _normalize_types(::Type{T}, buf::AbstractVector{UInt8}) where {T} = _typed_load(T, buf)

--- a/src/typeconversions.jl
+++ b/src/typeconversions.jl
@@ -380,7 +380,6 @@ else
         # dependent on data elements being properly aligned for all datatypes, on all
         # platforms.
     end
-
 end
 
 _normalize_types(::Type{T}, buf::AbstractVector{UInt8}) where {T} = _typed_load(T, buf)


### PR DESCRIPTION
Julia master seems to have removed `Base._memcpy!`. This is to be expected given that this is a private function.

xref: https://github.com/JuliaLang/julia/pull/49550
