### PR TITLE
Add HDF5.Filters.Registered module

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,8 @@ not_low_level_api(::typeof(HDF5.API.h5p_get_class_name)) = false
 not_low_level_api(::typeof(HDF5.API.h5t_get_member_name)) = false
 not_low_level_api(::typeof(HDF5.API.h5t_get_tag)) = false
 
+DocMeta.setdocmeta!(HDF5, :DocTestSetup, :(using HDF5); recursive=true)
+
 makedocs(;
     sitename="HDF5.jl",
     modules=[HDF5, H5Zblosc, H5Zbzip2, H5Zlz4, H5Zzstd],

--- a/docs/src/interface/filters.md
+++ b/docs/src/interface/filters.md
@@ -125,6 +125,12 @@ h5open(filename, "w") do h5f
 end
 ```
 
+### Registered Filter Helpers
+
+The HDF Group maintains a list of registered filters which have been assigned a filter ID number.
+The module [`Filters.Registered`](@ref) contains information about registered filters including functions
+to create an `ExternalFilter` for each registered filter.
+
 ### Creating a new Filter type
 
 Examining the [bitshuffle filter source code](https://github.com/kiyo-masui/bitshuffle/blob/0aee87e142c71407aa097c660727f2621c71c493/src/bshuf_h5filter.c#L47-L64) we see that three additional data components get prepended to the options. These are
@@ -190,6 +196,12 @@ set_local_cfunc
 filter_func
 filter_cfunc
 register_filter
+```
+
+## Registered Filters
+
+```@autodocs
+Modules = [Registered]
 ```
 
 ## External Links

--- a/src/filters/filters.jl
+++ b/src/filters/filters.jl
@@ -428,7 +428,7 @@ end
 function Base.convert(::Type{I}, ::Type{F}) where {I<:Integer,F<:Filter}
     Base.convert(I, filterid(F))
 end
-function Base.convert(::Type{I}, f::Filter) where {I <:Integer}
+function Base.convert(::Type{I}, f::Filter) where {I<:Integer}
     Base.convert(I, filterid(f))
 end
 

--- a/src/filters/filters.jl
+++ b/src/filters/filters.jl
@@ -428,7 +428,7 @@ end
 function Base.convert(::Type{I}, ::Type{F}) where {I<:Integer,F<:Filter}
     Base.convert(I, filterid(F))
 end
-function Base.convert(::Type{I}, f::Filter) where {I<:Integer}
+function Base.convert(::Type{I}, f::Filter) where {I <:Integer}
     Base.convert(I, filterid(f))
 end
 

--- a/src/filters/filters.jl
+++ b/src/filters/filters.jl
@@ -428,6 +428,9 @@ end
 function Base.convert(::Type{I}, ::Type{F}) where {I<:Integer,F<:Filter}
     Base.convert(I, filterid(F))
 end
+function Base.convert(::Type{I}, f::Filter) where {I <:Integer}
+    Base.convert(I, filterid(f))
+end
 
 """
     EXTERNAL_FILTER_JULIA_PACKAGES
@@ -479,5 +482,6 @@ end
 
 include("builtin.jl")
 include("filters_midlevel.jl")
+include("registered.jl")
 
 end # module

--- a/src/filters/registered.jl
+++ b/src/filters/registered.jl
@@ -86,52 +86,58 @@ const _REGISTERED_FILTERIDS_DICT = Dict{H5Z_filter_t,Symbol}(
     32027 => :FLAC
 )
 
-const REGISTERED_FILTERS = Dict{H5Z_filter_t, Function}()
+const REGISTERED_FILTERS = Dict{H5Z_filter_t,Function}()
 
 for (filter_id, filter_name) in _REGISTERED_FILTERIDS_DICT
     fn = Symbol(String(filter_name) * "Filter")
     filter_name_string = String(filter_name)
-    docstr = 
-    """
-        $fn(flags::Cuint, data::Vector{Cuint}, config::Cuint)
-        $fn(flags, data::Integer...)
-        $fn(data::AbstractVector{<:Integer} = Cuint[])
+    docstr = """
+                 $fn(flags::Cuint, data::Vector{Cuint}, config::Cuint)
+                 $fn(flags, data::Integer...)
+                 $fn(data::AbstractVector{<:Integer} = Cuint[])
 
-        Create an [`HDF5.Filter.ExternalFilter`](@ref) for $filter_name with filter id $filter_id.
-        Allows the quick creation of filters without subtyping `HDF5.Filters.Filter`.
-        $(haskey(EXTERNAL_FILTER_JULIA_PACKAGES, filter_id) ?
-            "Users are instead encouraged to use the Julia package $(EXTERNAL_FILTER_JULIA_PACKAGES[filter_id])." :
-            "Users are instead encouraged to define subtypes on `HDF5.Filters.Filter`."
-        )
+                 Create an [`HDF5.Filter.ExternalFilter`](@ref) for $filter_name with filter id $filter_id.
+                 Allows the quick creation of filters without subtyping `HDF5.Filters.Filter`.
+                 $(haskey(EXTERNAL_FILTER_JULIA_PACKAGES, filter_id) ?
+                     "Users are instead encouraged to use the Julia package $(EXTERNAL_FILTER_JULIA_PACKAGES[filter_id])." :
+                     "Users are instead encouraged to define subtypes on `HDF5.Filters.Filter`."
+                 )
 
-        # Fields / Arguments
-        * `flags` -     (optional) bit vector describing general properties of the filter. Defaults to `API.H5Z_FLAG_MANDATORY`
-        * `data` -      (optional) auxillary data for the filter. See [`cd_values`](@ref API.h5p_set_filter). Defaults to `Cuint[]`
-        * `config` -    (optional) bit vector representing information about the filter regarding whether it is able to encode data, decode data, neither, or both. Defaults to `0`.
+                 # Fields / Arguments
+                 * `flags` -     (optional) bit vector describing general properties of the filter. Defaults to `API.H5Z_FLAG_MANDATORY`
+                 * `data` -      (optional) auxillary data for the filter. See [`cd_values`](@ref API.h5p_set_filter). Defaults to `Cuint[]`
+                 * `config` -    (optional) bit vector representing information about the filter regarding whether it is able to encode data, decode data, neither, or both. Defaults to `0`.
 
-        # See also:
-        * [`API.h5p_set_filter`](@ref)
-        * [`H5Z_GET_FILTER_INFO`](https://portal.hdfgroup.org/display/HDF5/H5Z_GET_FILTER_INFO).
-        * [Registered Filter Plugins](https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins)
-        `flags` bits
-        * `API.H5Z_FLAG_OPTIONAL`
-        * `API.H5Z_FLAG_MANDATORY`
-        `config` bits 
-        * `API.H5Z_FILTER_CONFIG_ENCODE_ENABLED`
-        * `API.H5Z_FILTER_CONFIG_DECODE_ENABLED`
-    """
-    eval(quote
-        docstr = $docstr
-        export $fn
-        """
-        $docstr
-        """
-        $fn(flags, data::AbstractVector{<:Integer}) = ExternalFilter($filter_id, flags, Cuint.(data), $filter_name_string, 0)
-        $fn(flags, data::Integer...) = ExternalFilter($filter_id, flags, Cuint[data...], $filter_name_string, 0)
-        $fn(data::AbstractVector{<:Integer}=Cuint[]) = ExternalFilter($filter_id, H5Z_FLAG_MANDATORY, Cuint.(data), $filter_name_string, 0)
-        $fn(flags, data, config) = ExternalFilter($filter_id, flags, data, $filter_name_string, config)
-        REGISTERED_FILTERS[$filter_id] =  $fn
-    end)
+                 # See also:
+                 * [`API.h5p_set_filter`](@ref)
+                 * [`H5Z_GET_FILTER_INFO`](https://portal.hdfgroup.org/display/HDF5/H5Z_GET_FILTER_INFO).
+                 * [Registered Filter Plugins](https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins)
+                 `flags` bits
+                 * `API.H5Z_FLAG_OPTIONAL`
+                 * `API.H5Z_FLAG_MANDATORY`
+                 `config` bits 
+                 * `API.H5Z_FILTER_CONFIG_ENCODE_ENABLED`
+                 * `API.H5Z_FILTER_CONFIG_DECODE_ENABLED`
+             """
+    eval(
+        quote
+            docstr = $docstr
+            export $fn
+            """
+            $docstr
+            """
+            $fn(flags, data::AbstractVector{<:Integer}) =
+                ExternalFilter($filter_id, flags, Cuint.(data), $filter_name_string, 0)
+            $fn(flags, data::Integer...) =
+                ExternalFilter($filter_id, flags, Cuint[data...], $filter_name_string, 0)
+            $fn(data::AbstractVector{<:Integer}=Cuint[]) = ExternalFilter(
+                $filter_id, H5Z_FLAG_MANDATORY, Cuint.(data), $filter_name_string, 0
+            )
+            $fn(flags, data, config) =
+                ExternalFilter($filter_id, flags, data, $filter_name_string, config)
+            REGISTERED_FILTERS[$filter_id] = $fn
+        end
+    )
 end
 
 """
@@ -141,7 +147,7 @@ Return a `Dict{H5Z_filter_t, Function}` listing the available filter ids and
 their corresponding convenience function.
 """
 function available_registered_filters()
-    filter(p->isavailable(first(p)), REGISTERED_FILTERS)
+    filter(p -> isavailable(first(p)), REGISTERED_FILTERS)
 end
 
 end

--- a/src/filters/registered.jl
+++ b/src/filters/registered.jl
@@ -86,58 +86,52 @@ const _REGISTERED_FILTERIDS_DICT = Dict{H5Z_filter_t,Symbol}(
     32027 => :FLAC
 )
 
-const REGISTERED_FILTERS = Dict{H5Z_filter_t,Function}()
+const REGISTERED_FILTERS = Dict{H5Z_filter_t, Function}()
 
 for (filter_id, filter_name) in _REGISTERED_FILTERIDS_DICT
     fn = Symbol(String(filter_name) * "Filter")
     filter_name_string = String(filter_name)
-    docstr = """
-                 $fn(flags::Cuint, data::Vector{Cuint}, config::Cuint)
-                 $fn(flags, data::Integer...)
-                 $fn(data::AbstractVector{<:Integer} = Cuint[])
+    docstr = 
+    """
+        $fn(flags::Cuint, data::Vector{Cuint}, config::Cuint)
+        $fn(flags, data::Integer...)
+        $fn(data::AbstractVector{<:Integer} = Cuint[])
 
-                 Create an [`HDF5.Filter.ExternalFilter`](@ref) for $filter_name with filter id $filter_id.
-                 Allows the quick creation of filters without subtyping `HDF5.Filters.Filter`.
-                 $(haskey(EXTERNAL_FILTER_JULIA_PACKAGES, filter_id) ?
-                     "Users are instead encouraged to use the Julia package $(EXTERNAL_FILTER_JULIA_PACKAGES[filter_id])." :
-                     "Users are instead encouraged to define subtypes on `HDF5.Filters.Filter`."
-                 )
+        Create an [`HDF5.Filter.ExternalFilter`](@ref) for $filter_name with filter id $filter_id.
+        Allows the quick creation of filters without subtyping `HDF5.Filters.Filter`.
+        $(haskey(EXTERNAL_FILTER_JULIA_PACKAGES, filter_id) ?
+            "Users are instead encouraged to use the Julia package $(EXTERNAL_FILTER_JULIA_PACKAGES[filter_id])." :
+            "Users are instead encouraged to define subtypes on `HDF5.Filters.Filter`."
+        )
 
-                 # Fields / Arguments
-                 * `flags` -     (optional) bit vector describing general properties of the filter. Defaults to `API.H5Z_FLAG_MANDATORY`
-                 * `data` -      (optional) auxillary data for the filter. See [`cd_values`](@ref API.h5p_set_filter). Defaults to `Cuint[]`
-                 * `config` -    (optional) bit vector representing information about the filter regarding whether it is able to encode data, decode data, neither, or both. Defaults to `0`.
+        # Fields / Arguments
+        * `flags` -     (optional) bit vector describing general properties of the filter. Defaults to `API.H5Z_FLAG_MANDATORY`
+        * `data` -      (optional) auxillary data for the filter. See [`cd_values`](@ref API.h5p_set_filter). Defaults to `Cuint[]`
+        * `config` -    (optional) bit vector representing information about the filter regarding whether it is able to encode data, decode data, neither, or both. Defaults to `0`.
 
-                 # See also:
-                 * [`API.h5p_set_filter`](@ref)
-                 * [`H5Z_GET_FILTER_INFO`](https://portal.hdfgroup.org/display/HDF5/H5Z_GET_FILTER_INFO).
-                 * [Registered Filter Plugins](https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins)
-                 `flags` bits
-                 * `API.H5Z_FLAG_OPTIONAL`
-                 * `API.H5Z_FLAG_MANDATORY`
-                 `config` bits 
-                 * `API.H5Z_FILTER_CONFIG_ENCODE_ENABLED`
-                 * `API.H5Z_FILTER_CONFIG_DECODE_ENABLED`
-             """
-    eval(
-        quote
-            docstr = $docstr
-            export $fn
-            """
-            $docstr
-            """
-            $fn(flags, data::AbstractVector{<:Integer}) =
-                ExternalFilter($filter_id, flags, Cuint.(data), $filter_name_string, 0)
-            $fn(flags, data::Integer...) =
-                ExternalFilter($filter_id, flags, Cuint[data...], $filter_name_string, 0)
-            $fn(data::AbstractVector{<:Integer}=Cuint[]) = ExternalFilter(
-                $filter_id, H5Z_FLAG_MANDATORY, Cuint.(data), $filter_name_string, 0
-            )
-            $fn(flags, data, config) =
-                ExternalFilter($filter_id, flags, data, $filter_name_string, config)
-            REGISTERED_FILTERS[$filter_id] = $fn
-        end
-    )
+        # See also:
+        * [`API.h5p_set_filter`](@ref)
+        * [`H5Z_GET_FILTER_INFO`](https://portal.hdfgroup.org/display/HDF5/H5Z_GET_FILTER_INFO).
+        * [Registered Filter Plugins](https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins)
+        `flags` bits
+        * `API.H5Z_FLAG_OPTIONAL`
+        * `API.H5Z_FLAG_MANDATORY`
+        `config` bits 
+        * `API.H5Z_FILTER_CONFIG_ENCODE_ENABLED`
+        * `API.H5Z_FILTER_CONFIG_DECODE_ENABLED`
+    """
+    eval(quote
+        docstr = $docstr
+        export $fn
+        """
+        $docstr
+        """
+        $fn(flags, data::AbstractVector{<:Integer}) = ExternalFilter($filter_id, flags, Cuint.(data), $filter_name_string, 0)
+        $fn(flags, data::Integer...) = ExternalFilter($filter_id, flags, Cuint[data...], $filter_name_string, 0)
+        $fn(data::AbstractVector{<:Integer}=Cuint[]) = ExternalFilter($filter_id, H5Z_FLAG_MANDATORY, Cuint.(data), $filter_name_string, 0)
+        $fn(flags, data, config) = ExternalFilter($filter_id, flags, data, $filter_name_string, config)
+        REGISTERED_FILTERS[$filter_id] =  $fn
+    end)
 end
 
 """
@@ -147,7 +141,7 @@ Return a `Dict{H5Z_filter_t, Function}` listing the available filter ids and
 their corresponding convenience function.
 """
 function available_registered_filters()
-    filter(p -> isavailable(first(p)), REGISTERED_FILTERS)
+    filter(p->isavailable(first(p)), REGISTERED_FILTERS)
 end
 
 end

--- a/src/filters/registered.jl
+++ b/src/filters/registered.jl
@@ -1,0 +1,147 @@
+"""
+    HDF5.Filters.Registered
+
+Module containing convenience methods to create `ExternalFilter` instances
+of HDF5 registered filters as detailed at the following URL.
+
+https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins
+
+This module does not implement any filter.
+Rather the functions within this module allow already *loaded* registered filters to be
+conveniently used.
+
+Examine `REGISTERED_FILTERS`, a `Dict{H5Z_filter_t, Function}`, for a list of
+filter functions contained within this module, which are exported.
+
+```julia
+julia> println.(values(HDF5.Filters.Registered.REGISTERED_FILTERS));
+FCIDECOMPFilter
+LZOFilter
+BitGroomFilter
+SZ3Filter
+Delta_RiceFilter
+fpzipFilter
+LPC_RiceFilter
+LZFFilter
+FLACFilter
+VBZFilter
+FAPECFilter
+zfpFilter
+CBFFilter
+JPEG_XRFilter
+LZ4Filter
+BLOSC2Filter
+ZstandardFilter
+SZFilter
+Granular_BitRoundFilter
+JPEGFilter
+SnappyFilter
+B³DFilter
+APAXFilter
+BLOSCFilter
+SPDPFilter
+bitshuffleFilter
+MAFISCFilter
+BZIP2Filter
+CCSDS_123Filter
+JPEG_LSFilter
+```
+
+"""
+module Registered
+
+using HDF5.Filters: ExternalFilter, EXTERNAL_FILTER_JULIA_PACKAGES, isavailable
+using HDF5.API: H5Z_filter_t, H5Z_FLAG_MANDATORY
+
+const _REGISTERED_FILTERIDS_DICT = Dict{H5Z_filter_t,Symbol}(
+    305 => :LZO,
+    307 => :BZIP2,
+    32000 => :LZF,
+    32001 => :BLOSC,
+    32002 => :MAFISC,
+    32003 => :Snappy,
+    32004 => :LZ4,
+    32005 => :APAX,
+    32006 => :CBF,
+    32007 => :JPEG_XR,
+    32008 => :bitshuffle,
+    32009 => :SPDP,
+    32010 => :LPC_Rice,
+    32011 => :CCSDS_123,
+    32012 => :JPEG_LS,
+    32013 => :zfp,
+    32014 => :fpzip,
+    32015 => :Zstandard,
+    32016 => :B³D,
+    32017 => :SZ,
+    32018 => :FCIDECOMP,
+    32019 => :JPEG,
+    32020 => :VBZ,
+    32021 => :FAPEC,
+    32022 => :BitGroom,
+    32023 => :Granular_BitRound,
+    32024 => :SZ3,
+    32025 => :Delta_Rice,
+    32026 => :BLOSC2,
+    32027 => :FLAC
+)
+
+const REGISTERED_FILTERS = Dict{H5Z_filter_t, Function}()
+
+for (filter_id, filter_name) in _REGISTERED_FILTERIDS_DICT
+    fn = Symbol(String(filter_name) * "Filter")
+    filter_name_string = String(filter_name)
+    docstr = 
+    """
+        $fn(flags::Cuint, data::Vector{Cuint}, config::Cuint)
+        $fn(flags, data::Integer...)
+        $fn(data::AbstractVector{<:Integer} = Cuint[])
+
+        Create an [`HDF5.Filter.ExternalFilter`](@ref) for $filter_name with filter id $filter_id.
+        Allows the quick creation of filters without subtyping `HDF5.Filters.Filter`.
+        $(haskey(EXTERNAL_FILTER_JULIA_PACKAGES, filter_id) ?
+            "Users are instead encouraged to use the Julia package $(EXTERNAL_FILTER_JULIA_PACKAGES[filter_id])." :
+            "Users are instead encouraged to define subtypes on `HDF5.Filters.Filter`."
+        )
+
+        # Fields / Arguments
+        * `flags` -     (optional) bit vector describing general properties of the filter. Defaults to `API.H5Z_FLAG_MANDATORY`
+        * `data` -      (optional) auxillary data for the filter. See [`cd_values`](@ref API.h5p_set_filter). Defaults to `Cuint[]`
+        * `config` -    (optional) bit vector representing information about the filter regarding whether it is able to encode data, decode data, neither, or both. Defaults to `0`.
+
+        # See also:
+        * [`API.h5p_set_filter`](@ref)
+        * [`H5Z_GET_FILTER_INFO`](https://portal.hdfgroup.org/display/HDF5/H5Z_GET_FILTER_INFO).
+        * [Registered Filter Plugins](https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins)
+        `flags` bits
+        * `API.H5Z_FLAG_OPTIONAL`
+        * `API.H5Z_FLAG_MANDATORY`
+        `config` bits 
+        * `API.H5Z_FILTER_CONFIG_ENCODE_ENABLED`
+        * `API.H5Z_FILTER_CONFIG_DECODE_ENABLED`
+    """
+    eval(quote
+        docstr = $docstr
+        export $fn
+        """
+        $docstr
+        """
+        $fn(flags, data::AbstractVector{<:Integer}) = ExternalFilter($filter_id, flags, Cuint.(data), $filter_name_string, 0)
+        $fn(flags, data::Integer...) = ExternalFilter($filter_id, flags, Cuint[data...], $filter_name_string, 0)
+        $fn(data::AbstractVector{<:Integer}=Cuint[]) = ExternalFilter($filter_id, H5Z_FLAG_MANDATORY, Cuint.(data), $filter_name_string, 0)
+        $fn(flags, data, config) = ExternalFilter($filter_id, flags, data, $filter_name_string, config)
+        REGISTERED_FILTERS[$filter_id] =  $fn
+    end)
+end
+
+"""
+    available_registered_filters()::Dict{H5Z_filter_t, Function}
+
+Return a `Dict{H5Z_filter_t, Function}` listing the available filter ids and
+their corresponding convenience function.
+"""
+function available_registered_filters()
+    filter(p->isavailable(first(p)), REGISTERED_FILTERS)
+end
+
+end


### PR DESCRIPTION
I created a new module containing information about registered filters as well as convenience functions for creating `ExternalFilter`s from the data.

I put this in a new module `HDF5.Filters.Registered`. Alternatively, we could just integrate it into `HDF5.Filters` and make it a separate package.