### PR TITLE
In docs, suggest passing HDF5 module to set_preferences!() instead of UUID

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -63,6 +63,17 @@ set_preferences!(
     "libhdf5_hl" => "/usr/lib/x86_64-linux-gnu/hdf5/mpich/libhdf5_hl.so", force = true)
 ```
 
+If HDF5 cannot be loaded, it may be useful to use the UUID to change these settings:
+
+```julia
+using Preferences, UUIDs
+
+set_preferences!(
+    UUID("f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"), # UUID of HDF5.jl,
+    "libhdf5" => "/usr/lib/x86_64-linux-gnu/hdf5/mpich/libhdf5.so",
+    "libhdf5_hl" => "/usr/lib/x86_64-linux-gnu/hdf5/mpich/libhdf5_hl.so", force = true)
+```
+
 Also see the file `test/configure_packages.jl` for an example.
 
 Both, the MPI preferences and the preferences for HDF5.jl write to a file called LocalPreferences.toml in the project directory. After performing the described steps this file could look like the following:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -55,10 +55,10 @@ MPIPreferences.use_system_binary()
 to set the MPI preferences, see the [documentation of MPI.jl](https://juliaparallel.org/MPI.jl/stable/configuration/). You can set the path to the system library using [Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl) by:
 
 ```julia
-using Preferences, UUIDs
+using Preferences, HDF5
 
 set_preferences!(
-    UUID("f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"), # UUID of HDF5.jl
+    HDF5,
     "libhdf5" => "/usr/lib/x86_64-linux-gnu/hdf5/mpich/libhdf5.so",
     "libhdf5_hl" => "/usr/lib/x86_64-linux-gnu/hdf5/mpich/libhdf5_hl.so", force = true)
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -69,7 +69,7 @@ If HDF5 cannot be loaded, it may be useful to use the UUID to change these setti
 using Preferences, UUIDs
 
 set_preferences!(
-    UUID("f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"), # UUID of HDF5.jl,
+    UUID("f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"), # UUID of HDF5.jl
     "libhdf5" => "/usr/lib/x86_64-linux-gnu/hdf5/mpich/libhdf5.so",
     "libhdf5_hl" => "/usr/lib/x86_64-linux-gnu/hdf5/mpich/libhdf5_hl.so", force = true)
 ```


### PR DESCRIPTION
In the docs, to use custom or system-provided binaries, it is currently suggested to pass the UUID for HDF5.jl to `set_preferences!()`. It is simpler to load the module with `using HDF5`, and pass `HDF5` directly to `set_preferences!()`. Is there a reason this is a bad idea?

This PR upates the docs to suggest the method proposed above.