### PR TITLE
Fix `h5readattr` docstring

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -242,7 +242,7 @@ function h5writeattr(filename, name::AbstractString, data::Dict)
 end
 
 """
-    h5readattr(filename, name::AbstractString, data::Dict)
+    h5readattr(filename, name::AbstractString)
 
 Read the attributes of the object at `name` in the HDF5 file `filename`, returning a `Dict`.
 """


### PR DESCRIPTION
The function does not take a third argument.