### PR TITLE
Add fallback for missing H5Pget_dxpl_mpio

### DIFF
--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -674,8 +674,12 @@ end
 
 function h5p_get_dxpl_mpio(dxpl_id)
     xfer_mode = Ref{Cint}()
-    h5p_get_dxpl_mpio(dxpl_id, xfer_mode)
-    return xfer_mode[]
+    try
+        h5p_get_dxpl_mpio(dxpl_id, xfer_mode)
+        return xfer_mode[]
+    catch err
+        return Cint(0)
+    end
 end
 
 function h5p_get_efile_prefix(plist)


### PR DESCRIPTION
When trying to iterate through properties, one finds the `xfer` property of a `HDF5.Dataset`. This in turn discovers the property `dxpl_mpio` which may fail if `H5Pget_dxpl_mpio` does not exist.

The commit is a temporary fix, but may need be reworked perhaps at a higher level in properties.jl.

cc: @simonbyrne 

```
julia> h5ds.xfer.dxpl_mpio
ERROR: could not load symbol "H5Pget_dxpl_mpio":
The specified procedure could not be found.
Stacktrace:
 [1] h5p_get_dxpl_mpio(dxpl_id::HDF5.DatasetTransferProperties, xfer_mode::Base.RefValue{Int32})
   @ HDF5.API C:\Users\kittisopikulm\.julia\packages\HDF5\ttJRb\src\api\functions.jl:3130
 [2] h5p_get_dxpl_mpio(dxpl_id::HDF5.DatasetTransferProperties)
   @ HDF5.API C:\Users\kittisopikulm\.julia\packages\HDF5\ttJRb\src\api\helpers.jl:677
 [3] get_dxpl_mpio(p::HDF5.DatasetTransferProperties)
   @ HDF5 C:\Users\kittisopikulm\.julia\packages\HDF5\ttJRb\src\properties.jl:192
 [4] class_getproperty(#unused#::Type{HDF5.DatasetTransferProperties}, p::HDF5.DatasetTransferProperties, name::Symbol)
   @ HDF5 C:\Users\kittisopikulm\.julia\packages\HDF5\ttJRb\src\properties.jl:882
 [5] getproperty(p::HDF5.DatasetTransferProperties, name::Symbol)
   @ HDF5 C:\Users\kittisopikulm\.julia\packages\HDF5\ttJRb\src\properties.jl:51
 [6] top-level scope
   @ REPL[175]:1
```