### PR TITLE
Fix H5F_LIBVER_LATEST, map lib 1.15 to H5F_LIBVER_V116

### DIFF
--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -3,7 +3,17 @@
 # For instance, many property getters return values through pointer output arguments,
 # so the methods here handle making the appropriate `Ref`s and return them (as tuples).
 
-const H5F_LIBVER_LATEST = _libhdf5_build_ver >= v"1.12" ? H5F_LIBVER_V112 : H5F_LIBVER_V110
+const H5F_LIBVER_LATEST = if _libhdf5_build_ver >= v"1.15"
+    H5F_LIBVER_V116
+elseif _libhdf5_build_ver >= v"1.14"
+    H5F_LIBVER_V114
+elseif _libhdf5_build_ver >= v"1.12"
+    H5F_LIBVER_V112
+elseif _libhdf5_build_ver >= v"1.10"
+    H5F_LIBVER_V110
+else
+    H5F_LIBVER_V108
+end
 
 ###
 ### HDF5 General library functions

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -702,7 +702,7 @@ end
 libver_bound_to_enum(val::Integer) = val
 libver_bound_to_enum(val::API.H5F_libver_t) = val
 function libver_bound_to_enum(val::VersionNumber)
-    val >= v"1.16"   ? API.H5F_LIBVER_V116 :
+    val >= v"1.15"   ? API.H5F_LIBVER_V116 :
     val >= v"1.14"   ? API.H5F_LIBVER_V114 :
     val >= v"1.12"   ? API.H5F_LIBVER_V112 :
     val >= v"1.10"   ? API.H5F_LIBVER_V110 :
@@ -711,7 +711,7 @@ function libver_bound_to_enum(val::VersionNumber)
 end
 function libver_bound_to_enum(val::Symbol)
     val == :earliest ? API.H5F_LIBVER_EARLIEST :
-    val == :latest   ? libver_bound_to_enum(libversion) :
+    val == :latest   ? API.H5F_LIBVER_LATEST :
     throw(ArgumentError("Invalid libver_bound $val."))
 end
 function libver_bound_from_enum(enum::API.H5F_libver_t)

--- a/test/properties.jl
+++ b/test/properties.jl
@@ -70,7 +70,7 @@ using Test
         @test fapl.driver == Drivers.POSIX()
         @test_throws HDF5.API.H5Error fapl.driver_info
         @test fapl.fclose_degree == :strong
-        @test fapl.libver_bounds == (:earliest, Base.thisminor(HDF5.libversion))
+        @test fapl.libver_bounds == (:earliest, HDF5.libver_bound_from_enum(HDF5.API.H5F_LIBVER_LATEST))
         @test fapl.meta_block_size == 1024
 
         @test gcpl.local_heap_size_hint == 0

--- a/test/properties.jl
+++ b/test/properties.jl
@@ -70,7 +70,8 @@ using Test
         @test fapl.driver == Drivers.POSIX()
         @test_throws HDF5.API.H5Error fapl.driver_info
         @test fapl.fclose_degree == :strong
-        @test fapl.libver_bounds == (:earliest, HDF5.libver_bound_from_enum(HDF5.API.H5F_LIBVER_LATEST))
+        @test fapl.libver_bounds ==
+            (:earliest, HDF5.libver_bound_from_enum(HDF5.API.H5F_LIBVER_LATEST))
         @test fapl.meta_block_size == 1024
 
         @test gcpl.local_heap_size_hint == 0


### PR DESCRIPTION
Update the mapping of libver_bound :latest such that HDF5 C library version 1.15 maps to `H5F_LIBVER_V116`.

Addresses issue https://github.com/HDFGroup/hdf5/pull/4123
Fix #1142
