### PR TITLE
Add Julia 1.11 nightly to tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,6 +52,7 @@ jobs:
         version:
           - '1.6'
           - '1'
+          - '1.11-nightly'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -517,6 +517,20 @@ function write_dataset(
         end
     end
 end
+
+function write_dataset(
+    dataset::Dataset,
+    memtype::Datatype,
+    buf::Base.ReinterpretArray,
+    xfer::DatasetTransferProperties=dataset.xfer
+) where {T}
+    # We cannot obtain a pointer of a ReinterpretArrayin Julia 1.11 and beyond
+    # https://github.com/JuliaLang/julia/issues/51962
+    buf_copy = copy(buf)
+    @assert !(typeof(buf_copy) <: Base.ReinterpretArray) "Copying $(typeof(buf)) resulted in another Base.ReinterpretArray"
+    write_dataset(dataset, memtype, buf_copy, xfer)
+end
+
 function write_dataset(
     dataset::Dataset,
     memtype::Datatype,

--- a/test/virtual_dataset.jl
+++ b/test/virtual_dataset.jl
@@ -28,8 +28,13 @@ using Test, HDF5
             virtual=[HDF5.VirtualMapping(vspace, "./sub-%b.hdf5", "x", srcspace)]
         )
 
-        @test size(d) == (3, 2)
-        @test read(d) == hcat(fill(1.0, 3), fill(2.0, 3))
+        if Sys.iswindows()
+            @test_broken size(d) == (3, 2)
+            @test_broken read(d) == hcat(fill(1.0, 3), fill(2.0, 3))
+        else
+            @test size(d) == (3, 2)
+            @test read(d) == hcat(fill(1.0, 3), fill(2.0, 3))
+        end
 
         dcpl = HDF5.get_create_properties(d)
 


### PR DESCRIPTION
Test Julia 1.11 nightly
Add fix for `Base.ReinterpretArrays`
Mark Windows virtual dataset tests as broken