### PR TITLE
Fix H5Zzstd error reporting and decompressed size behavior

### DIFF
--- a/filters/H5Zzstd/src/H5Zzstd.jl
+++ b/filters/H5Zzstd/src/H5Zzstd.jl
@@ -88,7 +88,8 @@ function H5Z_filter_zstd(
     catch e
         #  "In the case of failure, the return value is 0 (zero) and all pointer arguments are left unchanged."
         ret_value = Csize_t(0)
-        @error "H5Zzstd Non-Fatal ERROR: " exception=(e, catch_backtrace())
+        # Output Julia error via async so we do not task switch during callback
+        @async @error "H5Zzstd Non-Fatal ERROR: " exception=(e, catch_backtrace())
     finally
         if outbuf != C_NULL
             Libc.free(outbuf)

--- a/filters/H5Zzstd/src/H5Zzstd.jl
+++ b/filters/H5Zzstd/src/H5Zzstd.jl
@@ -89,7 +89,6 @@ function H5Z_filter_zstd(
         #  "In the case of failure, the return value is 0 (zero) and all pointer arguments are left unchanged."
         ret_value = Csize_t(0)
         @error "H5Zzstd Non-Fatal ERROR: " exception=(e, catch_backtrace())
-        #display(stacktrace(catch_backtrace()))
     finally
         if outbuf != C_NULL
             Libc.free(outbuf)

--- a/filters/H5Zzstd/src/H5Zzstd.jl
+++ b/filters/H5Zzstd/src/H5Zzstd.jl
@@ -38,6 +38,11 @@ function H5Z_filter_zstd(
             #decompresssion
 
             decompSize = LibZstd.ZSTD_getDecompressedSize(inbuf, origSize)
+            if decompSize == 0
+                error(
+                    "zstd_h5plugin: Cannot retrieve decompressed chunk size"
+                )
+            end
             outbuf = Libc.malloc(decompSize)
             if outbuf == C_NULL
                 error(
@@ -83,11 +88,11 @@ function H5Z_filter_zstd(
     catch e
         #  "In the case of failure, the return value is 0 (zero) and all pointer arguments are left unchanged."
         ret_value = Csize_t(0)
-        @error "H5Zzstd Non-Fatal ERROR: " err
-        display(stacktrace(catch_backtrace()))
+        @error "H5Zzstd Non-Fatal ERROR: " exception=(e, catch_backtrace())
+        #display(stacktrace(catch_backtrace()))
     finally
         if outbuf != C_NULL
-            free(outbuf)
+            Libc.free(outbuf)
         end
     end # try catch finally
     return Csize_t(ret_value)

--- a/filters/H5Zzstd/src/H5Zzstd.jl
+++ b/filters/H5Zzstd/src/H5Zzstd.jl
@@ -39,9 +39,7 @@ function H5Z_filter_zstd(
 
             decompSize = LibZstd.ZSTD_getDecompressedSize(inbuf, origSize)
             if decompSize == 0
-                error(
-                    "zstd_h5plugin: Cannot retrieve decompressed chunk size"
-                )
+                error("zstd_h5plugin: Cannot retrieve decompressed chunk size")
             end
             outbuf = Libc.malloc(decompSize)
             if outbuf == C_NULL
@@ -89,7 +87,7 @@ function H5Z_filter_zstd(
         #  "In the case of failure, the return value is 0 (zero) and all pointer arguments are left unchanged."
         ret_value = Csize_t(0)
         # Output Julia error via async so we do not task switch during callback
-        @async @error "H5Zzstd Non-Fatal ERROR: " exception=(e, catch_backtrace())
+        @async @error "H5Zzstd Non-Fatal ERROR: " exception = (e, catch_backtrace())
     finally
         if outbuf != C_NULL
             Libc.free(outbuf)


### PR DESCRIPTION
https://github.com/JuliaIO/JLD2.jl/pull/560 revealed that error reporting was not occuring when there were errors present.

1. `ZSTD_getDecompressedSize` can result in an error, resulting in a return value of 0.
2. `Libc.malloc(0)` may not return a null pointer.

Therefore we need to check the return value of `ZSTD_getDecompressedSize` directly before
trying to malloc.

Also improve error handing overall.
