### PR TITLE
Guard malloc in compression filters

### DIFF
--- a/filters/H5Zbitshuffle/src/H5Zbitshuffle.jl
+++ b/filters/H5Zbitshuffle/src/H5Zbitshuffle.jl
@@ -196,6 +196,7 @@ function H5Z_filter_bitshuffle(
         end
 
         size = nbytes_uncomp ÷ elem_size
+        buf_size_out <= 0 && error("bitshuffle_h5plugin: Non-positive buf_size_out for malloc: $buf_size_out")
         out_buf = Libc.malloc(buf_size_out)
         if out_buf == C_NULL
             error(

--- a/filters/H5Zblosc/src/H5Zblosc.jl
+++ b/filters/H5Zblosc/src/H5Zblosc.jl
@@ -96,6 +96,7 @@ function blosc_filter(
         # the result is larger, we simply return 0. The filter is flagged
         # as optional, so HDF5 marks the chunk as uncompressed and proceeds.
         outbuf_size = unsafe_load(buf_size)
+        outbuf_size <= 0 && return Csize_t(0)
         outbuf = Libc.malloc(outbuf_size)
         outbuf == C_NULL && return Csize_t(0)
 
@@ -121,6 +122,7 @@ function blosc_filter(
         # See https://github.com/JuliaLang/julia/issues/43402
         # Resolved in https://github.com/JuliaLang/julia/pull/43408
         outbuf_size, cbytes, blocksize = Blosc.cbuffer_sizes(in)
+        outbuf_size <= && return Csize_t(0)
         outbuf = Libc.malloc(outbuf_size)
         outbuf == C_NULL && return Csize_t(0)
         status = Blosc.blosc_decompress(in, outbuf, outbuf_size)

--- a/filters/H5Zblosc/src/H5Zblosc.jl
+++ b/filters/H5Zblosc/src/H5Zblosc.jl
@@ -122,7 +122,7 @@ function blosc_filter(
         # See https://github.com/JuliaLang/julia/issues/43402
         # Resolved in https://github.com/JuliaLang/julia/pull/43408
         outbuf_size, cbytes, blocksize = Blosc.cbuffer_sizes(in)
-        outbuf_size <= && return Csize_t(0)
+        outbuf_size <= 0 && return Csize_t(0)
         outbuf = Libc.malloc(outbuf_size)
         outbuf == C_NULL && return Csize_t(0)
         status = Blosc.blosc_decompress(in, outbuf, outbuf_size)

--- a/filters/H5Zbzip2/src/H5Zbzip2.jl
+++ b/filters/H5Zbzip2/src/H5Zbzip2.jl
@@ -40,6 +40,7 @@ function H5Z_filter_bzip2(
             # Decompress
 
             outbuflen = nbytes * 3 + 1
+            outbuflen <= 0 && error("H5Zbzip2: Non-positive outbuflen for malloc: $outbuflen.")
             outbuf = Libc.malloc(outbuflen)
             if outbuf == C_NULL
                 error("H5Zbzip2: memory allocation failed for bzip2 decompression.")
@@ -106,6 +107,7 @@ function H5Z_filter_bzip2(
 
             # Prepare the output buffer
             outbuflen = nbytes + nbytes ÷ 100 + 600 # worse case (bzip2 docs)
+            outbuflen <= 0 && error("H5Zbzip2: Non-positive outbuflen for malloc: $outbuflen.")
             outbuf = Libc.malloc(outbuflen)
             @debug "Allocated" outbuflen outbuf
             if outbuf == C_NULL


### PR DESCRIPTION
Providing a length of `0` bytes to malloc could result in a valid pointer being generated. This is probably an error.

This pull request detects this condition and errors if detected. Also improves error messaging for failed allocation.
