### PR TITLE
Revert "Disable h5a_iterate and h5l_iterate assertion tests (#1155)"

### DIFF
--- a/test/api.jl
+++ b/test/api.jl
@@ -38,7 +38,6 @@ using HDF5, Test
     @test names == ["a"]
 
     # Julia error
-    #=
     @test_throws AssertionError HDF5.API.h5a_iterate(
         f, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_INC
     ) do loc, name, info
@@ -51,7 +50,6 @@ using HDF5, Test
     ) do loc, name, info
         return -1
     end
-    =#
 end
 
 @testset "h5l_iterate" begin
@@ -91,7 +89,6 @@ end
     end == 1
     @test names == ["a"]
 
-    #=
     # HDF5 error
     @test_throws HDF5.API.H5Error HDF5.API.h5l_iterate(
         f, HDF5.API.H5_INDEX_NAME, HDF5.API.H5_ITER_INC
@@ -105,7 +102,6 @@ end
     ) do loc, name, info
         @assert false
     end
-    =#
 end
 
 @testset "h5dchunk_iter" begin


### PR DESCRIPTION
This reverts commit fb5290602b1564f9227275e775c8a9c958458bd7.

The purpose is to try to reproduce the iteration errors.
