### PR TITLE
Fix Base.parent by splitting on / only, fix #1161

### DIFF
--- a/src/groups.jl
+++ b/src/groups.jl
@@ -101,7 +101,7 @@ function Base.parent(obj::Union{File,Group,Dataset})
     # Only split on / not \
     # See "HDF5 Path Names and Navigation" under "The HDF5 Data Model and File Structure"
     path_parts = split(path, "/")
-    parentname = join(path_parts[1:end-1], "/")
+    parentname = join(path_parts[1:(end - 1)], "/")
     if !isempty(parentname)
         return open_object(f, parentname)
     else

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -98,9 +98,12 @@ function Base.parent(obj::Union{File,Group,Dataset})
     if length(path) == 1
         return f
     end
-    parentname = dirname(path)
+    # Only split on / not \
+    # See "HDF5 Path Names and Navigation" under "The HDF5 Data Model and File Structure"
+    path_parts = split(path, "/")
+    parentname = join(path_parts[1:end-1], "/")
     if !isempty(parentname)
-        return open_object(f, dirname(path))
+        return open_object(f, parentname)
     else
         return root(f)
     end


### PR DESCRIPTION
Fix `Base.parent`, fix #1161, by splitting only on `/` and not `\`.