### PR TITLE
Fix H5Oexist test result after HDF5 bugfix

### DIFF
--- a/test/objects.jl
+++ b/test/objects.jl
@@ -16,7 +16,13 @@ using HDF5.API
     h5open(fn, "r") do h5f
         @test API.h5o_exists_by_name(h5f, "data")
         @test API.h5o_exists_by_name(h5f, "lore")
-        @test_throws API.H5Error API.h5o_exists_by_name(h5f, "noonian")
+        @static if HDF5.API.h5_get_libversion() <= v"1.14.5"
+            # Buggy behavior in earlier versions of HDF5 returns FAIL (-1)
+            @test_throws API.H5Error API.h5o_exists_by_name(h5f, "noonian")
+        else
+            # The correct behavior is to return false (0)
+            @test API.h5o_exists_by_name(h5f, "noonian") == 0
+        end
 
         loc_id = API.h5o_open(h5f, "data", API.H5P_DEFAULT)
         try


### PR DESCRIPTION
A bugfix in the HDF5 library changed the return value of the H5Oexists(_by_name) API call. In earlier versions of the library, when the ID was a file ID and the object didn't exist, the call would return FAIL (-1). The correct behavior is to return false (0). This change will appear in the next released version of HDF5, which is planned to be 2.0.0.

This change updates the object test to expect FAIL for 1.14.5 and earlier and false for later versions.