### PR TITLE
Check for invalidations on Julia 1.10

### DIFF
--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: julia-actions/setup-julia@v1
       with:
-        version: '1'
+        version: '1.10'
     - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1


### PR DESCRIPTION
The julia-invalidations actions uses SnoopCompile v2 which only works with Julia 1.10 at the moment
