### PR TITLE
Drop Requires.jl, bump to 0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HDF5"
 uuid = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
-version = "0.17.1"
+version = "0.18.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -11,8 +11,27 @@ Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[weakdeps]
+Blosc = "a74b3585-a348-5f62-a45c-50e91977d574"
+CodecBzip2 = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
+CodecLz4 = "5ba52731-8f18-5e0d-9241-30f10d1ec561"
+CodecZstd = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+bitshuffle_jll = "228fe19c-1b83-5282-a626-13744502a320"
+
+[extensions]
+BloscExt = "Blosc"
+CodecBzip2Ext = "CodecBzip2"
+CodecLz4Ext = "CodecLz4"
+CodecZstdExt = "CodecZstd"
+FileIOExt = "FileIO"
+MPIExt = "MPI"
+OrderedCollectionsFileIOExt = ["FileIO", "OrderedCollections"]
+bitshuffle_jll_ext = "bitshuffle_jll"
 
 [compat]
 Blosc = "0.7.3"
@@ -24,19 +43,8 @@ HDF5_jll = "~1.10.5, ~1.12.0, ~1.14.0"
 MPI = "0.20"
 MPIPreferences = "0.1.7"
 Preferences = "1.3"
-Requires = "1.0"
 bitshuffle_jll = "0.4.2, 0.5"
 julia = "1.9"
-
-[extensions]
-BloscExt = "Blosc"
-CodecBzip2Ext = "CodecBzip2"
-CodecLz4Ext = "CodecLz4"
-CodecZstdExt = "CodecZstd"
-FileIOExt = "FileIO"
-MPIExt = "MPI"
-OrderedCollectionsFileIOExt = ["FileIO", "OrderedCollections"]
-bitshuffle_jll_ext = "bitshuffle_jll"
 
 [extras]
 Blosc = "a74b3585-a348-5f62-a45c-50e91977d574"
@@ -59,13 +67,3 @@ bitshuffle_jll = "228fe19c-1b83-5282-a626-13744502a320"
 
 [targets]
 test = ["Test", "MPI", "Distributed", "LinearAlgebra", "OrderedCollections", "Pkg", "CRC32c", "FileIO"]
-
-[weakdeps]
-Blosc = "a74b3585-a348-5f62-a45c-50e91977d574"
-CodecBzip2 = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
-CodecLz4 = "5ba52731-8f18-5e0d-9241-30f10d1ec561"
-CodecZstd = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
-FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
-OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-bitshuffle_jll = "228fe19c-1b83-5282-a626-13744502a320"

--- a/filters/H5Zbitshuffle/Project.toml
+++ b/filters/H5Zbitshuffle/Project.toml
@@ -8,6 +8,6 @@ HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 bitshuffle_jll = "228fe19c-1b83-5282-a626-13744502a320"
 
 [compat]
-HDF5 = "0.17"
+HDF5 = "0.17, 0.18"
 bitshuffle_jll = "0.4.2, 0.5"
 julia = "1.9"

--- a/filters/H5Zblosc/Project.toml
+++ b/filters/H5Zblosc/Project.toml
@@ -7,6 +7,6 @@ Blosc = "a74b3585-a348-5f62-a45c-50e91977d574"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 
 [compat]
-HDF5 = "0.17"
+HDF5 = "0.17, 0.18"
 Blosc = "0.7.3"
 julia = "1.9"

--- a/filters/H5Zbzip2/Project.toml
+++ b/filters/H5Zbzip2/Project.toml
@@ -7,6 +7,6 @@ CodecBzip2 = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 
 [compat]
-HDF5 = "0.17"
+HDF5 = "0.17, 0.18"
 CodecBzip2 = "0.7, 0.8"
 julia = "1.9"

--- a/filters/H5Zlz4/Project.toml
+++ b/filters/H5Zlz4/Project.toml
@@ -7,6 +7,6 @@ CodecLz4 = "5ba52731-8f18-5e0d-9241-30f10d1ec561"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 
 [compat]
-HDF5 = "0.17"
+HDF5 = "0.17, 0.18"
 CodecLz4 = "0.4"
 julia = "1.9"

--- a/filters/H5Zzstd/Project.toml
+++ b/filters/H5Zzstd/Project.toml
@@ -7,6 +7,6 @@ CodecZstd = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 
 [compat]
-HDF5 = "0.17"
+HDF5 = "0.17, 0.18"
 CodecZstd = "0.7, 0.8"
 julia = "1.9"

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1,7 +1,6 @@
 module HDF5
 
 using Base: unsafe_convert
-using Requires: @require
 using Mmap: Mmap
 # needed for filter(f, tuple) in julia 1.3
 using Compat
@@ -122,12 +121,6 @@ function __init__()
     UTF8_LINK_PROPERTIES.create_intermediate_group = true
     ASCII_ATTRIBUTE_PROPERTIES.char_encoding = :ascii
     UTF8_ATTRIBUTE_PROPERTIES.char_encoding = :utf8
-
-    @static if !isdefined(Base, :get_extension)
-        @require FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549" include(
-            "../ext/FileIOExt.jl"
-        )
-    end
 
     return nothing
 end

--- a/src/drivers/drivers.jl
+++ b/src/drivers/drivers.jl
@@ -6,9 +6,6 @@ import ..API
 import ..HDF5: HDF5, Properties, h5doc
 
 using Libdl: dlopen, dlsym
-if !isdefined(Base, :get_extension)
-    using Requires: @require
-end
 
 function get_driver(p::Properties)
     driver_id = API.h5p_get_driver(p)
@@ -91,9 +88,6 @@ function __init__()
     HDF5.HAS_PARALLEL[] = API._has_symbol(:H5Pset_fapl_mpio)
     HDF5.HAS_ROS3[] = API._has_symbol(:H5Pset_fapl_ros3)
 
-    @static if !isdefined(Base, :get_extension)
-        @require MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195" include("../../ext/MPIExt.jl")
-    end
 end
 
 # The docstring for `MPIO` basically belongs to the struct `MPIO` in


### PR DESCRIPTION
This pull request is in prepration for a 0.18 release.

* Minimum Julia version is now Julia 1.9 for extension support
* Requires.jl support is dropped in favor of the extensions
* Filter packages are just helpers that trigger the extension mechanism
