### PR TITLE
use API lock in helper function ccalls

### DIFF
--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -628,12 +628,10 @@ See `libhdf5` documentation for [`H5Oget_info1`](https://portal.hdfgroup.org/dis
 function h5o_get_info1(object_id, buf)
     lock(liblock)
     var"#status#" = try
-            ccall(
-                (:H5Oget_info1, libhdf5), herr_t, (hid_t, Ptr{H5O_info_t}), object_id, buf
-            )
-        finally
-            unlock(liblock)
-        end
+        ccall((:H5Oget_info1, libhdf5), herr_t, (hid_t, Ptr{H5O_info_t}), object_id, buf)
+    finally
+        unlock(liblock)
+    end
     var"#status#" < 0 && @h5error("Error getting object info")
     return nothing
 end
@@ -883,10 +881,10 @@ See `libhdf5` documentation for [`H5P_GET_CLASS_NAME`](https://portal.hdfgroup.o
 function h5p_get_class_name(pcid)
     lock(liblock)
     pc = try
-            ccall((:H5Pget_class_name, libhdf5), Ptr{UInt8}, (hid_t,), pcid)
-        finally
-            unlock(liblock)
-        end
+        ccall((:H5Pget_class_name, libhdf5), Ptr{UInt8}, (hid_t,), pcid)
+    finally
+        unlock(liblock)
+    end
     if pc == C_NULL
         @h5error("Error getting class name")
     end
@@ -999,10 +997,10 @@ See `libhdf5` documentation for [`H5Oopen`](https://portal.hdfgroup.org/display/
 function h5t_get_member_name(type_id, index)
     lock(liblock)
     pn = try
-            ccall((:H5Tget_member_name, libhdf5), Ptr{UInt8}, (hid_t, Cuint), type_id, index)
-        finally
-            unlock(liblock)
-        end
+        ccall((:H5Tget_member_name, libhdf5), Ptr{UInt8}, (hid_t, Cuint), type_id, index)
+    finally
+        unlock(liblock)
+    end
     if pn == C_NULL
         @h5error("Error getting name of compound datatype member #$index")
     end
@@ -1019,10 +1017,10 @@ See `libhdf5` documentation for [`H5Oopen`](https://portal.hdfgroup.org/display/
 function h5t_get_tag(type_id)
     lock(liblock)
     pc = try
-            ccall((:H5Tget_tag, libhdf5), Ptr{UInt8}, (hid_t,), type_id)
-        finally
-            unlock(liblock)
-        end
+        ccall((:H5Tget_tag, libhdf5), Ptr{UInt8}, (hid_t,), type_id)
+    finally
+        unlock(liblock)
+    end
     if pc == C_NULL
         @h5error("Error getting opaque tag")
     end

--- a/src/api/helpers.jl
+++ b/src/api/helpers.jl
@@ -626,9 +626,14 @@ Deprecated HDF5 function. Use [`h5o_get_info`](@ref) or [`h5o_get_native_info`](
 See `libhdf5` documentation for [`H5Oget_info1`](https://portal.hdfgroup.org/display/HDF5/H5O_GET_INFO1).
 """
 function h5o_get_info1(object_id, buf)
-    var"#status#" = ccall(
-        (:H5Oget_info1, libhdf5), herr_t, (hid_t, Ptr{H5O_info_t}), object_id, buf
-    )
+    lock(liblock)
+    var"#status#" = try
+            ccall(
+                (:H5Oget_info1, libhdf5), herr_t, (hid_t, Ptr{H5O_info_t}), object_id, buf
+            )
+        finally
+            unlock(liblock)
+        end
     var"#status#" < 0 && @h5error("Error getting object info")
     return nothing
 end
@@ -876,7 +881,12 @@ end
 See `libhdf5` documentation for [`H5P_GET_CLASS_NAME`](https://portal.hdfgroup.org/display/HDF5/H5P_GET_CLASS_NAME).
 """
 function h5p_get_class_name(pcid)
-    pc = ccall((:H5Pget_class_name, libhdf5), Ptr{UInt8}, (hid_t,), pcid)
+    lock(liblock)
+    pc = try
+            ccall((:H5Pget_class_name, libhdf5), Ptr{UInt8}, (hid_t,), pcid)
+        finally
+            unlock(liblock)
+        end
     if pc == C_NULL
         @h5error("Error getting class name")
     end
@@ -987,7 +997,12 @@ end
 See `libhdf5` documentation for [`H5Oopen`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_MEMBER_NAME).
 """
 function h5t_get_member_name(type_id, index)
-    pn = ccall((:H5Tget_member_name, libhdf5), Ptr{UInt8}, (hid_t, Cuint), type_id, index)
+    lock(liblock)
+    pn = try
+            ccall((:H5Tget_member_name, libhdf5), Ptr{UInt8}, (hid_t, Cuint), type_id, index)
+        finally
+            unlock(liblock)
+        end
     if pn == C_NULL
         @h5error("Error getting name of compound datatype member #$index")
     end
@@ -1002,7 +1017,12 @@ end
 See `libhdf5` documentation for [`H5Oopen`](https://portal.hdfgroup.org/display/HDF5/H5T_GET_TAG).
 """
 function h5t_get_tag(type_id)
-    pc = ccall((:H5Tget_tag, libhdf5), Ptr{UInt8}, (hid_t,), type_id)
+    lock(liblock)
+    pc = try
+            ccall((:H5Tget_tag, libhdf5), Ptr{UInt8}, (hid_t,), type_id)
+        finally
+            unlock(liblock)
+        end
     if pc == C_NULL
         @h5error("Error getting opaque tag")
     end

--- a/test/apilock.jl
+++ b/test/apilock.jl
@@ -1,7 +1,9 @@
 using Pkg, Test
 @testset "issue1179" begin
     @test try
-        run(`$(Base.julia_cmd()) --project=$(dirname(Pkg.project().path)) -t 6 $(joinpath(@__DIR__, "issue1179.jl"))`)
+        run(
+            `$(Base.julia_cmd()) --project=$(dirname(Pkg.project().path)) -t 6 $(joinpath(@__DIR__, "issue1179.jl"))`
+        )
         true
     catch err
         @info err

--- a/test/apilock.jl
+++ b/test/apilock.jl
@@ -1,0 +1,10 @@
+using Pkg, Test
+@testset "issue1179" begin
+    @test try
+        run(`$(Base.julia_cmd()) --project=$(dirname(Pkg.project().path)) -t 6 $(joinpath(@__DIR__, "issue1179.jl"))`)
+        true
+    catch err
+        @info err
+        false
+    end
+end

--- a/test/issue1179.jl
+++ b/test/issue1179.jl
@@ -1,0 +1,13 @@
+using HDF5
+
+T = ComplexF64
+# T = Float64 # OK
+sizes = (100, 100, 100)
+Threads.@threads for i in 1:Threads.nthreads()
+    h5open("file$i.hdf5", "w") do h5
+        d = create_dataset(h5, "rand", T, sizes)
+        for n in 1:sizes[3]
+            d[:,:,n] = rand(T, sizes[1:2])
+        end
+    end
+end

--- a/test/issue1179.jl
+++ b/test/issue1179.jl
@@ -7,7 +7,7 @@ Threads.@threads for i in 1:Threads.nthreads()
     h5open("file$i.hdf5", "w") do h5
         d = create_dataset(h5, "rand", T, sizes)
         for n in 1:sizes[3]
-            d[:,:,n] = rand(T, sizes[1:2])
+            d[:, :, n] = rand(T, sizes[1:2])
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,6 +92,8 @@ end
         @debug "virtual datasets"
         include("virtual_dataset.jl")
     end
+    @debug "api lock"
+    include("apilock.jl")
 
     # basic MPI tests, for actual parallel tests we need to run in MPI mode
     include("mpio.jl")


### PR DESCRIPTION
Hi,

This pr wraps `ccall`s in `src/api/helpers.jl` with the library API lock. I believe the handling of strings is still thread-safe, but it would help for someone to check. Also, if this pr should be implemented at the level of the generator I may need some assistance with where to start.

Fixes #1179