### PR TITLE
Pass comp_lvl to bitshuffle with zstd

### DIFF
--- a/ext/bitshuffle_jll_ext/bitshuffle_jll_ext.jl
+++ b/ext/bitshuffle_jll_ext/bitshuffle_jll_ext.jl
@@ -268,12 +268,13 @@ function H5Z_filter_bitshuffle(
                     err = ccall(
                         (:bshuf_compress_zstd, libbitshuffle),
                         Int64,
-                        (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t, Csize_t, Csize_t),
+                        (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t, Csize_t, Csize_t, Cint),
                         in_buf,
                         out_buf + 12,
                         size,
                         elem_size,
-                        block_size
+                        block_size,
+                        Cint(comp_lvl)
                     )
                 end
 


### PR DESCRIPTION
While adapting the implementation of BitshuffleFilter for JLD2,
I noticed that the `comp_level` field in `BitshuffleFilter` is not forwarded to the C library.
This still worked because it is an optional function argument.

This PR updates the relevant Ccall.