### PR TITLE
Fix codecov-action options in CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@latest
       - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
 
   integration:
     name: ${{ matrix.package.repo }} - julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}


### PR DESCRIPTION
Newer version of codecov-action uses `files:` instead of `file:`