### PR TITLE
Declare `public` methods

### DIFF
--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -51,6 +51,7 @@ export @read,
 
 @static if VERSION ≥ v"1.11.0"
     eval(Expr(
+        :public,
         :create_external,
         :create_external_dataset,
         :file,

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -47,17 +47,30 @@ export @read,
     Filters,
     Drivers
 
-### The following require module scoping ###
+### The following public methods require module scoping ###
 
-# file, filename, name,
-# get_chunk, get_datasets,
-# get_access_properties, get_create_properties,
-# root, readmmap,
-# iscontiguous, iscompact, ischunked,
-# ishdf5, ismmappable,
-# refresh
-# start_swmr_write
-# create_external, create_external_dataset
+@static if VERSION ≥ v"1.11.0"
+    eval(Expr(
+        :create_external,
+        :create_external_dataset,
+        :file,
+        :filename,
+        :get_access_properties,
+        :get_create_properties,
+        :get_chunk,
+        :get_datasets,
+        :iscompact,
+        :ischunked,
+        :iscontiguous,
+        :ishdf5,
+        :ismmappable,
+        :name,
+        :readmmap,
+        :refresh,
+        :root,
+        :set_dims!,
+        :start_swmr_write,
+    ))
 
 ### Types
 # H5DataStore, Attribute, File, Group, Dataset, Datatype, Opaque,

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -72,6 +72,7 @@ export @read,
         :set_dims!,
         :start_swmr_write,
     ))
+end
 
 ### Types
 # H5DataStore, Attribute, File, Group, Dataset, Datatype, Opaque,

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -50,28 +50,30 @@ export @read,
 ### The following public methods require module scoping ###
 
 @static if VERSION ≥ v"1.11.0"
-    eval(Expr(
-        :public,
-        :create_external,
-        :create_external_dataset,
-        :file,
-        :filename,
-        :get_access_properties,
-        :get_create_properties,
-        :get_chunk,
-        :get_datasets,
-        :iscompact,
-        :ischunked,
-        :iscontiguous,
-        :ishdf5,
-        :ismmappable,
-        :name,
-        :readmmap,
-        :refresh,
-        :root,
-        :set_dims!,
-        :start_swmr_write,
-    ))
+    eval(
+        Expr(
+            :public,
+            :create_external,
+            :create_external_dataset,
+            :file,
+            :filename,
+            :get_access_properties,
+            :get_create_properties,
+            :get_chunk,
+            :get_datasets,
+            :iscompact,
+            :ischunked,
+            :iscontiguous,
+            :ishdf5,
+            :ismmappable,
+            :name,
+            :readmmap,
+            :refresh,
+            :root,
+            :set_dims!,
+            :start_swmr_write,
+        )
+    )
 end
 
 ### Types


### PR DESCRIPTION
Addresses #1216 by declaring public methods as such (those that are not exported and thuse require module scoping).

I used the union of the list of methods in the history file:
https://github.com/JuliaIO/HDF5.jl/blob/master/HISTORY.md#v014
and the methods mentioned in `HDF5.jl`

Any maintainer (or I) can edit the list in this PR to remove any names that should not be public.

This works only in Jula v0.11.0 and beyond.  Currently, `eval Expr` is needed to avoid problems with code coverage in earlier versions.  Eventually, when the long-term release is >= 0.11, then this code can be simplified to avoid `eval Expr`

I learned this Eval trick over at https://github.com/JuliaMath/FFTW.jl/pull/329